### PR TITLE
Implementing the use of _L’x’/i18n markers

### DIFF
--- a/cinder/volume/drivers/nexenta/nexentaedge/iscsi_ne.py
+++ b/cinder/volume/drivers/nexenta/nexentaedge/iscsi_ne.py
@@ -19,7 +19,7 @@
 .. moduleauthor:: Zohar Mamedov <zohar.mamedov@nexenta.com>
 """
 
-from cinder.i18n import _
+from cinder.i18n import _, _LE
 from cinder.image import image_utils
 from cinder.openstack.common import log as logging
 from cinder.volume import driver
@@ -116,7 +116,7 @@ class NexentaEdgeISCSIDriver(driver.ISCSIDriver):  # pylint: disable=R0921
 
     def _verify_name_in_map(self, name):
         if not (name in self.name_map):
-            LOG.error(_('Bucket metadata map missing volume name'))
+            LOG.error(_LE('Bucket metadata map missing volume name'))
             raise nexenta.NexentaException('Bucket metadata ' +
                                            'map missing volume: ' +
                                            name)
@@ -137,7 +137,7 @@ class NexentaEdgeISCSIDriver(driver.ISCSIDriver):  # pylint: disable=R0921
                 lunNumber = i
                 break
         if lunNumber is None:
-            LOG.error(_('Failed to allocate LUN number: '
+            LOG.error(_LE('Failed to allocate LUN number: '
                         'All 255 lun numbers used, WOW!'))
             raise nexenta.NexentaException('All 255 lun numbers used')
         return lunNumber
@@ -158,7 +158,7 @@ class NexentaEdgeISCSIDriver(driver.ISCSIDriver):  # pylint: disable=R0921
             self._set_bucket_name_map()
 
         except nexenta.NexentaException as e:
-            LOG.error(_('Error while creating volume: %s'), unicode(e))
+            LOG.error(_LE('Error while creating volume: %s'), unicode(e))
             raise
 
         return {'provider_location': self._get_provider_location(volume)}
@@ -174,7 +174,7 @@ class NexentaEdgeISCSIDriver(driver.ISCSIDriver):  # pylint: disable=R0921
             self._set_bucket_name_map()
 
         except nexenta.NexentaException as e:
-            LOG.error(_('Error while deleting: %s'), unicode(e))
+            LOG.error(_LE('Error while deleting: %s'), unicode(e))
             raise
 
     def extend_volume(self, volume, new_size):
@@ -210,7 +210,7 @@ class NexentaEdgeISCSIDriver(driver.ISCSIDriver):  # pylint: disable=R0921
             self._set_bucket_name_map()
 
         except nexenta.NexentaException as e:
-            LOG.error(_('Error while creating volume: %s'), unicode(e))
+            LOG.error(_LE('Error while creating volume: %s'), unicode(e))
             raise
 
     def create_snapshot(self, snapshot):
@@ -255,7 +255,7 @@ class NexentaEdgeISCSIDriver(driver.ISCSIDriver):  # pylint: disable=R0921
             self._set_bucket_name_map()
 
         except nexenta.NexentaException as e:
-            LOG.error(_('Error creating cloned volume: %s'), unicode(e))
+            LOG.error(_LE('Error creating cloned volume: %s'), unicode(e))
             raise
 
     def copy_image_to_volume(self, context, volume, image_service, image_id):
@@ -279,7 +279,7 @@ class NexentaEdgeISCSIDriver(driver.ISCSIDriver):  # pylint: disable=R0921
                 try:
                     self.restapi.post(url, payload)
                 except nexenta.NexentaException as e:
-                    LOG.error(_('Error copying Image to Volume: %s'),
+                    LOG.error(_LE('Error copying Image to Volume: %s'),
                               unicode(e))
                     pass
 


### PR DESCRIPTION
Placing the _Lx markers back into the code.  No other cleaner solution has has been implemented. 
Partial-Bug: #1384312
Link: https://bugs.launchpad.net/cinder/+bug/1384312