### PR TITLE
NEX-17099 Cinder volume revert to snapshot: NexentaException: Waited for 120s, but pool pool1 service is still not running

### DIFF
--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -252,6 +252,13 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         except exception.NexentaException:
             return
 
+    def snapshot_revert_use_temp_snapshot(self):
+        # Considering that NexentaStor based drivers use COW images
+        # for storing snapshots, having chains of such images,
+        # creating a backup snapshot when reverting one is not
+        # actually helpful.
+        return False
+
     def revert_to_snapshot(self, context, volume, snapshot):
         """Revert volume to snapshot."""
         volume_path = self._get_volume_path(volume)

--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -428,6 +428,13 @@ class NexentaNfsDriver(nfs.NfsDriver):
         except exception.NexentaException:
             return
 
+    def snapshot_revert_use_temp_snapshot(self):
+        # Considering that NexentaStor based drivers use COW images
+        # for storing snapshots, having chains of such images,
+        # creating a backup snapshot when reverting one is not
+        # actually helpful.
+        return False
+
     def revert_to_snapshot(self, context, volume, snapshot):
         """Revert volume to snapshot."""
         pool, fs = self._get_share_datasets(self.share)


### PR DESCRIPTION
*NEX-17099 Cinder volume revert to snapshot: NexentaException: Waited for 120s, but pool pool1 service is still not running*

Changes:
- Implement driver function snapshot_revert_use_temp_snapshot:

Considering that NexentaStor based drivers use COW images
for storing snapshots, having chains of such images,
creating a backup snapshot when reverting one is not
actually helpful.
