### PR TITLE
Fixed latest Master, use ex2err to convert a Cinder Exception to a NexentaStor error

### DIFF
--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -13,7 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import ast
 import ipaddress
 import math
 import random
@@ -123,7 +122,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         try:
             self.nef.post(url, data)
         except exception.NexentaException as ex:
-            err = ast.literal_eval(ex.msg)
+            err = utils.ex2err(ex)
             if err['code'] == 'EEXIST':
                 LOG.debug('Volume group %(group)s already exists',
                           {'group': self.volume_group})
@@ -191,7 +190,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             url = 'storage/volumes/%s?snapshots=true' % path
             self.nef.delete(url)
         except exception.NexentaException as ex:
-            err = ast.literal_eval(ex.msg)
+            err = utils.ex2err(ex)
             if 'Failed to destroy snap' in err['message']:
                 url = 'storage/snapshots?parent=%s' % path
                 snap_map = {}

--- a/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
@@ -13,7 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import ast
 import json
 import requests
 import six
@@ -24,6 +23,7 @@ from oslo_log import log as logging
 from cinder import exception
 from cinder.i18n import _
 from cinder.utils import retry
+from cinder.volume.drivers.nexenta import utils
 from oslo_serialization import jsonutils
 from requests.cookies import extract_cookies_to_jar
 from requests.packages.urllib3 import exceptions
@@ -107,7 +107,7 @@ class RESTCaller(object):
         try:
             check_error(response)
         except exception.NexentaException as ex:
-            err = ast.literal_eval(ex.msg)
+            err = utils.ex2err(ex)
             if err['code'] == 'ENOENT':
                 LOG.warning('Exception on call to %(appliance)s: '
                             '%(url)s %(method)s data: %(data)s '
@@ -142,7 +142,7 @@ class RESTCaller(object):
                 try:
                     check_error(response)
                 except exception.NexentaException as ex:
-                    err = ast.literal_eval(ex.msg)
+                    err = utils.ex2err(ex)
                     if err['code'] == 'ENOENT':
                         LOG.debug('Exception on call to %(appliance)s: '
                                   '%(url)s %(method)s data: %(data)s '

--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -13,7 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import ast
 import hashlib
 import os
 import six
@@ -167,7 +166,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         try:
             self.nef.post(url, data)
         except exception.NexentaException as ex:
-            err = ast.literal_eval(ex.msg)
+            err = utils.ex2err(ex)
             if err['code'] == 'EEXIST':
                 LOG.debug('Filesystem %(filesystem)s already exists, '
                           'reuse existing filesystem',
@@ -346,7 +345,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         try:
             self.nef.post(url, data)
         except exception.NexentaException as ex:
-            err = ast.literal_eval(ex.msg)
+            err = utils.ex2err(ex)
             if err['code'] == 'ENOENT' and len(nef_ips) > 1:
                 data['remoteNode']['host'] = nef_ips[1]
                 self.nef.post(url, data)
@@ -431,7 +430,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         try:
             self.nef.delete(url)
         except exception.NexentaException as ex:
-            err = ast.literal_eval(ex.msg)
+            err = utils.ex2err(ex)
             if 'Failed to destroy snap' in err['message']:
                 url = 'storage/snapshots?parent=%s' % '%2F'.join(
                     [pool, fs, volume['name']])
@@ -529,7 +528,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         try:
             self.nef.delete(url)
         except exception.NexentaException as ex:
-            err = ast.literal_eval(ex.msg)
+            err = utils.ex2err(ex)
             if (err['code'] == 'EBUSY' and
                 'Dependent datasets' in err['message']):
                 LOG.debug('Snapshot %(snapshot)s has dependent '

--- a/cinder/volume/drivers/nexenta/utils.py
+++ b/cinder/volume/drivers/nexenta/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Nexenta Systems, Inc.
+# Copyright 2018 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import ast
 import re
 import six
 
@@ -163,3 +164,7 @@ def parse_nef_url(url):
 def get_migrate_snapshot_name(volume):
     """Return name for snapshot that will be used to migrate the volume."""
     return 'cinder-migrate-snapshot-%(id)s' % volume
+
+def ex2err(ex):
+    """Convert a Cinder Exception to a Nexenta Error."""
+    return ast.literal_eval(ex.msg)


### PR DESCRIPTION
**Fixed latest Master, use ex2err to convert a Cinder Exception to a NexentaStor error**

*iSCSI*
```
======
Totals
======
Ran: 258 tests in 2566.9528 sec.
 - Passed: 249
 - Skipped: 9
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2566.9528 sec.
```

*NFS*
```
======
Totals
======
Ran: 258 tests in 3004.0000 sec.
 - Passed: 248
 - Skipped: 10
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2325.3062 sec.
```