### PR TITLE
NEX-17729 Sync NexentaStor5 Cinder driver: Kilo NFS/iSCSI with Master

### DIFF
--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Nexenta Systems, Inc.
+# Copyright 2018 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -13,11 +13,16 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import ipaddress
+import math
+import random
+import six
 import uuid
 
 from eventlet import greenthread
 from oslo_log import log as logging
 from oslo_utils import units
+from six.moves import urllib
 
 from cinder import context
 from cinder import db
@@ -28,7 +33,7 @@ from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 from cinder.volume.drivers.nexenta import options
 from cinder.volume.drivers.nexenta import utils
 
-VERSION = '1.3.0'
+VERSION = '1.3.6'
 LOG = logging.getLogger(__name__)
 
 
@@ -44,6 +49,11 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         1.2.1 - Configurable luns per parget, target prefix.
         1.3.0 - Removed target/TG caching, added support for target portals
                 and host groups.
+        1.3.1 - Refactored _do_export to query exact lunMapping.
+        1.3.3 - Refactored LUN creation, use host group for LUN mappings.
+        1.3.4 - Adapted NexentaException for the latest Cinder.
+        1.3.5 - Added deferred deletion for snapshots.
+        1.3.6 - Fixed race between volume/clone deletion.
     """
 
     VERSION = VERSION
@@ -65,12 +75,17 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 options.NEXENTA_RRMGR_OPTS)
         self.verify_ssl = self.configuration.driver_ssl_cert_verify
         self.target_prefix = self.configuration.nexenta_target_prefix
+        self.target_group_prefix = (
+            self.configuration.nexenta_target_group_prefix)
+        self.host_group_prefix = self.configuration.nexenta_host_group_prefix
+        self.luns_per_target = self.configuration.nexenta_luns_per_target
+        self.lu_writebackcache_disabled = (
+            self.configuration.nexenta_lu_writebackcache_disabled)
         self.use_https = self.configuration.nexenta_use_https
         self.nef_host = self.configuration.nexenta_rest_address
         self.iscsi_host = self.configuration.nexenta_host
         self.nef_port = self.configuration.nexenta_rest_port
         self.nef_user = self.configuration.nexenta_user
-        self.host_group = self.configuration.nexenta_iscsi_target_host_group
         self.nef_password = self.configuration.nexenta_password
         self.storage_pool = self.configuration.nexenta_volume
         self.volume_group = self.configuration.nexenta_volume_group
@@ -96,8 +111,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
     def do_setup(self, context):
         host = self.nef_host or self.iscsi_host
         self.nef = jsonrpc.NexentaJSONProxy(
-            host, self.nef_port, self.nef_user,
-            self.nef_password, self.use_https, self.verify_ssl)
+            host, self.nef_port, self.nef_user, self.nef_password,
+            self.use_https, self.storage_pool, self.verify_ssl)
         url = 'storage/volumeGroups'
         data = {
             'path': '/'.join([self.storage_pool, self.volume_group]),
@@ -106,17 +121,16 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         }
         try:
             self.nef.post(url, data)
-        except exception.NexentaException as e:
-            if 'EEXIST' in e.args[0]:
-                LOG.debug('volumeGroup already exists, skipping')
+        except exception.NexentaException as ex:
+            err = utils.ex2err(ex)
+            if err['code'] == 'EEXIST':
+                LOG.debug('Volume group %(group)s already exists',
+                          {'group': self.volume_group})
             else:
-                raise
+                raise ex
 
     def check_for_setup_error(self):
-        """Verify that the zfs pool, vg and iscsi service exists.
-
-        :raise: :py:exc:`LookupError`
-        """
+        """Verify that the zfs pool, vg and iscsi service exists."""
         url = 'storage/pools/%s' % self.storage_pool
         self.nef.get(url)
         url = 'storage/volumeGroups/%s' % '%2F'.join([
@@ -124,23 +138,25 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         try:
             self.nef.get(url)
         except exception.NexentaException:
-            raise LookupError(_(
-                "Dataset group %s not found at Nexenta SA"), '/'.join(
-                [self.storage_pool, self.volume_group]))
+            msg = (_('Volume group %(group)s not found')
+                   % {'group': self.volume_group})
+            raise exception.NexentaException(msg)
         services = self.nef.get('services')
         for service in services['data']:
             if service['name'] == 'iscsit':
                 if service['state'] != 'online':
-                    raise exception.NexentaException(
-                        'iSCSI service is not running on NS appliance')
+                    msg = _('iSCSI target service is not running')
+                    raise exception.NexentaException(msg)
                 break
 
     def create_volume(self, volume):
         """Create a zfs volume on appliance.
 
         :param volume: volume reference
-        :return: model update dict for volume reference
+        :returns: model update dict for volume reference
         """
+        LOG.debug('Create volume %(volume)s',
+                  {'volume': volume['name']})
         url = 'storage/volumes'
         path = '/'.join([self.storage_pool, self.volume_group, volume['name']])
         data = {
@@ -153,39 +169,53 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         self.nef.post(url, data)
 
     def delete_volume(self, volume):
-        """Destroy a zfs volume on appliance.
+        """Deletes a logical volume.
 
         :param volume: volume reference
         """
-        path = '%2F'.join([
-            self.storage_pool, self.volume_group, volume['name']])
-        url = 'storage/volumes/%s' % path
-        origin = self.nef.get(url).get('originalSnapshot')
+        LOG.debug('Delete volume %(volume)s',
+                  {'volume': volume['name']})
+        path = self._get_volume_path(volume)
+        params = {'path': path}
+        url = 'storage/volumes?%s' % (
+            urllib.parse.urlencode(params))
+        data = self.nef.get(url).get('data')
+        if not data:
+            return
+        params = {'snapshots': 'true'}
+        url = 'storage/volumes/%s?%s' % (
+            urllib.parse.quote_plus(path),
+            urllib.parse.urlencode(params))
         try:
-            url = 'storage/volumes/%s?snapshots=true' % path
             self.nef.delete(url)
-        except exception.NexentaException as exc:
-            if 'Failed to destroy snap' in exc.kwargs['message']['message']:
-                url = 'storage/snapshots?parent=%s' % path
+        except exception.NexentaException as ex:
+            err = utils.ex2err(ex)
+            if err['code'] == 'EEXIST':
+                params = {'parent': path}
+                url = 'storage/snapshots?%s' % (
+                    urllib.parse.urlencode(params))
                 snap_map = {}
                 for snap in self.nef.get(url)['data']:
                     url = 'storage/snapshots/%s' % (
-                        snap['path'].replace('/', '%2F'))
+                        urllib.parse.quote_plus(snap['path']))
                     data = self.nef.get(url)
-                    if data['clones']:
+                    if data and data.get('clones'):
                         snap_map[data['creationTxg']] = snap['path']
-                snap = snap_map[max(snap_map)]
-                url = 'storage/snapshots/%s' % snap.replace('/', '%2F')
-                clone = self.nef.get(url)['clones'][0]
-                url = 'storage/volumes/%s/promote' % clone.replace('/', '%2F')
-                self.nef.post(url)
-                url = 'storage/volumes/%s?snapshots=true' % path
+                if snap_map:
+                    snap = snap_map[max(snap_map)]
+                    url = 'storage/snapshots/%s' % urllib.parse.quote_plus(
+                        snap)
+                    clone = self.nef.get(url)['clones'][0]
+                    url = 'storage/volumes/%s/promote' % (
+                        urllib.parse.quote_plus(clone))
+                    self.nef.post(url)
+                params = {'snapshots': 'true'}
+                url = 'storage/volumes/%s?%s' % (
+                    urllib.parse.quote_plus(path),
+                    urllib.parse.urlencode(params))
                 self.nef.delete(url)
             else:
-                raise
-        if origin and 'clone' in origin:
-            url = 'storage/snapshots/%s' % origin.replace('/', '%2F')
-            self.nef.delete(url)
+                raise ex
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -193,8 +223,9 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: volume reference
         :param new_size: volume new size in GB
         """
-        LOG.info('Extending volume: %(id)s New size: %(size)s GB',
-                 {'id': volume['id'], 'size': new_size})
+        LOG.debug('Extend volume %(volume)s, new size: %(size)sGB',
+                  {'volume': volume['name'],
+                   'size': new_size})
         path = '%2F'.join([
             self.storage_pool, self.volume_group, volume['name']])
         url = 'storage/volumes/%s' % path
@@ -207,30 +238,34 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param snapshot: snapshot reference
         """
         snapshot_vol = self._get_snapshot_volume(snapshot)
-        LOG.info('Creating snapshot %(snap)s of volume %(vol)s', {
-            'snap': snapshot['name'],
-            'vol': snapshot_vol['name']
-        })
+        LOG.info('Create snapshot %(snapshot)s for volume %(volume)s',
+                 {'snapshot': snapshot['name'],
+                  'volume': snapshot_vol['name']})
         volume_path = self._get_volume_path(snapshot_vol)
         url = 'storage/snapshots'
         data = {'path': '%s@%s' % (volume_path, snapshot['name'])}
         self.nef.post(url, data)
 
     def delete_snapshot(self, snapshot):
-        """Delete volume's snapshot on appliance.
+        """Deletes a snapshot.
 
         :param snapshot: snapshot reference
         """
-        LOG.info('Deleting snapshot: %s', snapshot['name'])
-        snapshot_vol = self._get_snapshot_volume(snapshot)
-        volume_path = self._get_volume_path(snapshot_vol)
-        pool, group, volume = volume_path.split('/')
-        path = '%2F'.join([self.storage_pool, self.volume_group, volume])
-        url = 'storage/snapshots/%s@%s' % (path, snapshot['name'])
-        try:
-            self.nef.delete(url)
-        except exception.NexentaException:
+        LOG.debug('Delete snapshot: %(snapshot)s',
+                  {'snapshot': snapshot['name']})
+        volume = self._get_snapshot_volume(snapshot)
+        path = '%s@%s' % (self._get_volume_path(volume),
+                          snapshot['name'])
+        params = {'path': path}
+        url = 'storage/snapshots?%s' % urllib.parse.urlencode(params)
+        snap_data = self.nef.get(url).get('data')
+        if not snap_data:
             return
+        params = {'defer': 'true'}
+        url = 'storage/snapshots/%s?%s' % (
+            urllib.parse.quote_plus(path),
+            urllib.parse.urlencode(params))
+        self.nef.delete(url)
 
     def create_volume_from_snapshot(self, volume, snapshot):
         """Create new volume from other's snapshot on appliance.
@@ -238,7 +273,9 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: reference of volume to be created
         :param snapshot: reference of source snapshot
         """
-        LOG.info('Creating volume from snapshot: %s', snapshot['name'])
+        LOG.debug('Create volume %(volume)s from snapshot: %(snapshot)s',
+                 {'volume': volume['name'],
+                  'snapshot': snapshot['name']})
         snapshot_vol = self._get_snapshot_volume(snapshot)
         path = '%2F'.join([
             self.storage_pool, self.volume_group, snapshot_vol['name']])
@@ -258,61 +295,90 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                     'volume_id': src_vref['id'],
                     'volume_size': src_vref['size'],
                     'name': self._get_clone_snapshot_name(volume)}
-        LOG.debug('Creating temp snapshot of the original volume: '
-                  '%s@%s', snapshot['volume_name'], snapshot['name'])
+        LOG.debug('Create temporary snapshot %(snapshot)s '
+                  'for the original volume %(volume)s',
+                  {'snapshot': snapshot['name'],
+                   'volume': snapshot['volume_name']})
         self.create_snapshot(snapshot)
+        LOG.debug('Create clone %(clone)s from '
+                  'temporary snapshot %(snapshot)s',
+                  {'clone': volume['name'],
+                   'snapshot': snapshot['name']})
         try:
             self.create_volume_from_snapshot(volume, snapshot)
-        except exception.NexentaException:
-            LOG.error('Volume creation failed, deleting created snapshot '
-                      '%s', '@'.join([snapshot['volume_name'],
-                                     snapshot['name']]))
+        except exception.NexentaException as ex:
+            LOG.debug('Volume creation failed, deleting temporary '
+                      'snapshot %(volume)s@%(snapshot)s',
+                      {'volume': snapshot['volume_name'],
+                       'snapshot': snapshot['name']})
             try:
                 self.delete_snapshot(snapshot)
             except (exception.NexentaException, exception.SnapshotIsBusy):
-                LOG.warning('Failed to delete zfs snapshot '
-                            '%s', '@'.join([snapshot['volume_name'],
-                                           snapshot['name']]))
-            raise
+                LOG.debug('Failed to delete temporary snapshot '
+                          '%(volume)s@%(snapshot)s',
+                          {'volume': snapshot['volume_name'],
+                           'snapshot': snapshot['name']})
+            raise ex
 
     def create_export(self, _ctx, volume):
-        """Create new export for zfs volume.
-
-        :param volume: reference of volume to be exported
-        :return: iscsiadm-formatted provider location string
-        """
-        model_update = self._do_export(_ctx, volume)
-        return model_update
+        """Export a volume."""
+        pass
 
     def ensure_export(self, _ctx, volume):
-        """Recreate parts of export if necessary.
-
-        :param volume: reference of volume to be exported
-        """
-        self._do_export(_ctx, volume)
+        """Synchronously recreate an export for a volume."""
+        pass
 
     def remove_export(self, _ctx, volume):
-        """Destroy all resources created to export zfs volume.
+        """Remove an export for a volume."""
+        pass
 
+    def terminate_connection(self, volume, connector, **kwargs):
+        """Terminate a connection to a volume.
 
-        :param volume: reference of volume to be unexported
+        :param volume: a volume object
+        :param connector: a connector object
+        :returns: dictionary of connection information
         """
+        info = {'driver_volume_type': 'iscsi', 'data': {}}
+        host_iqn = None
+        host_groups = []
         volume_path = self._get_volume_path(volume)
+        if isinstance(connector, dict) and 'initiator' in connector:
+            host_iqn = connector.get('initiator')
+            host_groups.append(options.DEFAULT_HOST_GROUP)
+            host_group = self._get_host_group(host_iqn)
+            if host_group is not None:
+                host_groups.append(host_group)
+            LOG.debug('Terminate connection for volume %(volume)s '
+                      'and initiator %(initiator)s',
+                      {'volume': volume_path, 'initiator': host_iqn})
+        else:
+            LOG.debug('Terminate all connections for volume %(volume)s',
+                      {'volume': volume_path})
 
-        # Get ID of a LUN mapping if the volume is exported
-        url = 'san/lunMappings?volume={}&fields=id'.format(
-            volume_path.replace('/', '%2F')
-        )
-        data = self.nef.get(url)['data']
-        if data:
-            url = 'san/lunMappings/%s' % data[0]['id']
-            try:
-                self.nef.delete(url)
-            except exception.NexentaException as e:
-                if 'No such lun mapping' in e.args[0]:
-                    LOG.debug('LU already deleted from appliance')
-                else:
-                    raise
+        params = {'volume': volume_path}
+        url = 'san/lunMappings?%s' % urllib.parse.urlencode(params)
+        mappings = self.nef.get(url).get('data')
+        if len(mappings) == 0:
+            LOG.debug('There are no LUN mappings found for volume %(volume)s',
+                      {'volume': volume_path})
+            return info
+        for mapping in mappings:
+            mapping_id = mapping.get('id')
+            mapping_tg = mapping.get('targetGroup')
+            mapping_hg = mapping.get('hostGroup')
+            if host_iqn is None or mapping_hg in host_groups:
+                LOG.debug('Delete LUN mapping %(id)s for volume %(volume)s, '
+                          'target group %(tg)s and host group %(hg)s',
+                          {'id': mapping_id, 'volume': volume_path,
+                           'tg': mapping_tg, 'hg': mapping_hg})
+                self._delete_lun_mapping(mapping_id)
+            else:
+                LOG.debug('Skip LUN mapping %(id)s for volume %(volume)s, '
+                          'target group %(tg)s and host group %(hg)s',
+                          {'id': mapping_id, 'volume': volume_path,
+                           'tg': mapping_tg, 'hg': mapping_hg})
+        return info
 
     def get_volume_stats(self, refresh=False):
         """Get volume stats.
@@ -376,127 +442,422 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             self.configuration.nexenta_target_group_prefix
         )
 
-    def _check_target_and_portals(self, tg):
-        target_name = tg.replace(
+    def _get_target_name(self, target_group_name):
+        """Return Nexenta iSCSI target name for volume."""
+        return target_group_name.replace(
             self.configuration.nexenta_target_group_prefix,
-            self.configuration.nexenta_target_prefix)
-        target = self.nef.get('san/iscsi/targets/%s' % target_name)
-        for portal in target['portals']:
-            if portal['address'] == self.iscsi_host:
-                return target_name
-        return ''
+            self.configuration.nexenta_target_prefix
+        )
 
-    def _do_export(self, _ctx, volume):
+    def _get_host_addresses(self):
+        """Return Nexenta IP addresses list."""
+        host_addresses = []
+        url = 'network/addresses'
+        data = self.nef.get(url).get('data')
+        for item in data:
+            ip_cidr = six.text_type(item['address'])
+            ip_addr, ip_mask = ip_cidr.split('/')
+            ip_obj = ipaddress.ip_address(ip_addr)
+            if not ip_obj.is_loopback:
+                host_addresses.append(ip_obj.exploded)
+        LOG.debug('Configured IP addresses: %(addresses)s',
+                  {'addresses': host_addresses})
+        return host_addresses
+
+    def _get_host_portals(self):
+        """Return configured iSCSI portals list."""
+        host_portals = []
+        host_addresses = self._get_host_addresses()
+        portal_host = self.iscsi_host
+        if portal_host:
+            if portal_host in host_addresses:
+                if self.portal_port:
+                    portal_port = int(self.portal_port)
+                else:
+                    portal_port = options.DEFAULT_ISCSI_PORT
+                host_portal = '%s:%s' % (portal_host, portal_port)
+                host_portals.append(host_portal)
+            else:
+                LOG.debug('Skip not a local portal IP address %(portal)s',
+                          {'portal': portal_host})
+        else:
+            LOG.debug('Configuration parameter nexenta_host is not defined')
+        for portal in self.portals.split(','):
+            if not portal:
+                continue
+            host_port = portal.split(':')
+            portal_host = host_port[0]
+            if portal_host in host_addresses:
+                if len(host_port) == 2:
+                    portal_port = int(host_port[1])
+                else:
+                    portal_port = options.DEFAULT_ISCSI_PORT
+                host_portal = '%s:%s' % (portal_host, portal_port)
+                if host_portal not in host_portals:
+                    host_portals.append(host_portal)
+            else:
+                LOG.debug('Skip not a local portal IP address %(portal)s',
+                          {'portal': portal_host})
+        LOG.debug('Configured iSCSI portals: %(portals)s',
+                  {'portals': host_portals})
+        return host_portals
+
+    def _target_group_props(self, group_name, host_portals):
+        """Check and update an existing targets/portals for given target group.
+
+        :param group_name: target group name
+        :param host_portals: configured host portals list
+        :returns: dictionary of portals per target
+        """
+        if not group_name.startswith(self.target_group_prefix):
+            LOG.debug('Skip not a cinder target group %(group)s',
+                      {'group': group_name})
+            return {}
+        group_props = {}
+        params = {'name': group_name}
+        url = 'san/targetgroups?%s' % urllib.parse.urlencode(params)
+        data = self.nef.get(url).get('data')
+        if not data:
+            LOG.debug('Skip target group %(group)s: group not found',
+                      {'group': group_name})
+            return {}
+        target_names = data[0]['members']
+        if len(target_names) == 0:
+            target_name = self._get_target_name(group_name)
+            self._create_target(target_name, host_portals)
+            self._update_target_group(group_name, [target_name])
+            group_props[target_name] = host_portals
+            return group_props
+        for target_name in target_names:
+            group_props[target_name] = []
+            params = {'name': target_name}
+            url = 'san/iscsi/targets?%s' % urllib.parse.urlencode(params)
+            data = self.nef.get(url).get('data')
+            if not data:
+                LOG.debug('Skip target group %(group)s: '
+                          'group member %(target)s not found',
+                          {'group': group_name, 'target': target_name})
+                return {}
+            target_portals = data[0]['portals']
+            if not target_portals:
+                LOG.debug('Skip target group %(group)s: '
+                          'group member %(target)s has no portals',
+                          {'group': group_name, 'target': target_name})
+                return {}
+            for item in target_portals:
+                target_portal = '%s:%s' % (item['address'], item['port'])
+                if target_portal not in host_portals:
+                    LOG.debug('Skip target group %(group)s: '
+                              'group member %(target)s bind to a '
+                              'non local portal address %(portal)s',
+                              {'group': group_name,
+                               'target': target_name,
+                               'portal': target_portal})
+                    return {}
+                group_props[target_name].append(target_portal)
+        return group_props
+
+    def initialize_connection(self, volume, connector):
         """Do all steps to get zfs volume exported at separate target.
 
-        :param volume: reference of volume to be exported
+        :param volume: volume reference
+        :param connector: connector reference
+        :returns: dictionary of connection information
         """
         volume_path = self._get_volume_path(volume)
-        lpt = self.configuration.nexenta_luns_per_target
-        tg = ''
-        target_name = ''
-        map_dict = {}
-        target_name = ''
-        # Check whether the volume is exported
-        url = 'san/lunMappings'
+        host_iqn = connector.get('initiator')
+        LOG.debug('Initialize connection for volume: %(volume)s '
+                  'and initiator: %(initiator)s',
+                  {'volume': volume_path, 'initiator': host_iqn})
+
+        host_groups = [options.DEFAULT_HOST_GROUP]
+        host_group = self._get_host_group(host_iqn)
+        if host_group:
+            host_groups.append(host_group)
+
+        host_portals = self._get_host_portals()
+        props_portals = []
+        props_iqns = []
+        props_luns = []
+        params = {'volume': volume_path}
+        url = 'san/lunMappings?%s' % urllib.parse.urlencode(params)
+        mappings = self.nef.get(url).get('data')
+        for mapping in mappings:
+            mapping_id = mapping['id']
+            mapping_lu = mapping['lun']
+            mapping_hg = mapping['hostGroup']
+            mapping_tg = mapping['targetGroup']
+            if mapping_hg not in host_groups:
+                LOG.debug('Skip LUN mapping %(id)s for host group %(hg)s',
+                          {'id': mapping_id, 'hg': mapping_hg})
+                continue
+            if mapping_tg == options.DEFAULT_TARGET_GROUP:
+                LOG.debug('Delete LUN mapping %(id)s for target group %(tg)s',
+                          {'id': mapping_id, 'tg': mapping_tg})
+                self.self._delete_lun_mapping(mapping_id)
+                continue
+            group_props = self._target_group_props(mapping_tg, host_portals)
+            if not group_props:
+                LOG.debug('Skip LUN mapping %(id)s for target group %(tg)s',
+                          {'id': mapping_id, 'tg': mapping_tg})
+                continue
+            for target_iqn in group_props:
+                target_portals = group_props[target_iqn]
+                props_portals += target_portals
+                props_iqns += [target_iqn] * len(target_portals)
+                props_luns += [mapping_lu] * len(target_portals)
+
+        props = {}
+        props['target_discovered'] = False
+        props['encrypted'] = False
+        props['qos_specs'] = None
+        props['volume_id'] = volume['id']
+        props['access_mode'] = 'rw'
+        multipath = connector.get('multipath', False)
+
+        if props_luns:
+            if multipath:
+                props['target_portals'] = props_portals
+                props['target_iqns'] = props_iqns
+                props['target_luns'] = props_luns
+            else:
+                index = random.randrange(0, len(props_luns))
+                props['target_portal'] = props_portals[index]
+                props['target_iqn'] = props_iqns[index]
+                props['target_lun'] = props_luns[index]
+            LOG.debug('Use existing LUN mapping(s) %(props)s',
+                      {'props': props})
+            return {'driver_volume_type': 'iscsi', 'data': props}
+
+        if host_group is None:
+            host_group = '%s-%s' % (self.host_group_prefix, uuid.uuid4().hex)
+            self._create_host_group(host_group, host_iqn)
+
+        mappings_spread = {}
+        targets_spread = {}
+        url = 'san/targetgroups'
         data = self.nef.get(url).get('data')
-        if data:
-            for mapping in data:
-                if mapping['volume'] == volume_path:
-                    # Found the right mapping
-                    tg = mapping['targetGroup']
-                    tg_data = self.nef.get('san/targetgroups?name=%s' % tg)
-                    target_name = tg_data['data'][0]['members'][0]
-                    provider_location = (
-                        '%(host)s:%(port)s,1 %(name)s %(lun)s') % {
-                        'host': self.iscsi_host,
-                        'port': self.portal_port,
-                        'name': target_name,
-                        'lun': mapping['lun'],
-                    }
-                    return {'provider_location': provider_location}
-            # Find correct TG with lowest LUNs
-            for m in data:
-                map_dict.setdefault(m['targetGroup'], []).append(m)
-            while not target_name and map_dict:
-                tg = min({k: v for k, v in map_dict.items() if k.startswith(
-                    self.configuration.nexenta_target_group_prefix)} or '')
-                if tg and len(map_dict.get(tg)) <= lpt:
-                    target_name = self._check_target_and_portals(tg)
-                    del map_dict[tg]
-                else:
-                    map_dict = {}
+        for item in data:
+            target_group = item['name']
+            group_props = self._target_group_props(target_group, host_portals)
+            members = len(group_props)
+            if members == 0:
+                LOG.debug('Skip unsuitable target group %(tg)s',
+                          {'tg': target_group})
+                continue
+            params = {'targetGroup': target_group}
+            url = 'san/lunMappings?%s' % urllib.parse.urlencode(params)
+            data = self.nef.get(url).get('data')
+            mappings = len(data)
+            if not mappings < self.luns_per_target:
+                LOG.debug('Skip target group %(tg)s: '
+                          'group members limit reached: %(limit)s',
+                          {'tg': target_group, 'limit': mappings})
+                continue
+            targets_spread[target_group] = group_props
+            mappings_spread[target_group] = mappings
+            LOG.debug('Found target group %(tg)s with %(members)s '
+                      'members and %(mappings)s LUNs',
+                      {'tg': target_group, 'members': members,
+                       'mappings': mappings})
 
-        if not target_name:
-            # Create new target and TG
-            target_name = self.target_prefix + '-' + uuid.uuid4().hex
-            url = 'san/iscsi/targets'
-            portals = []
-            if self.portals:
-                for portal in self.portals.split(','):
-                    address, port = portal.split(':')
-                    port = int(port) if port else 3260
-                    portals.append({
-                        'address': address,
-                        'port': port
-                    })
-            if not portals:
-                portals = [{"address": self.iscsi_host}]
-            data = {
-                "portals": portals,
-                'name': target_name
-            }
-            try:
-                self.nef.post(url, data)
-            except exception.NexentaException as e:
-                if 'EEXIST' not in e.args[0]:
-                    raise
-            tg = self._get_target_group_name(target_name)
-            self._create_target_group(tg, target_name)
+        if len(mappings_spread) == 0:
+            target = '%s-%s' % (self.target_prefix, uuid.uuid4().hex)
+            target_group = self._get_target_group_name(target)
+            self._create_target(target, host_portals)
+            self._create_target_group(target_group, [target])
+            props_portals += host_portals
+            props_iqns += [target] * len(host_portals)
+        else:
+            target_group = min(mappings_spread, key=mappings_spread.get)
+            targets = targets_spread[target_group]
+            members = targets.keys()
+            mappings = mappings_spread[target_group]
+            LOG.debug('Using existing target group %(tg)s '
+                      'with members %(members)s and %(mappings)s LUNs',
+                      {'tg': target_group, 'members': members,
+                       'mappings': mappings})
+            for target in targets:
+                    portals = targets[target]
+                    props_portals += portals
+                    props_iqns += [target] * len(portals)
 
-        # Export the volume
         url = 'san/lunMappings'
         data = {
-            "hostGroup": self.host_group,
-            "targetGroup": tg,
-            'volume': volume_path
+            'volume': volume_path,
+            'targetGroup': target_group,
+            'hostGroup': host_group
         }
-        try:
-            self.nef.post(url, data)
-        except exception.NexentaException as e:
-            if 'No such target group' in e.args[0]:
-                self._create_target_group(tg, target_name)
-                self.nef.post(url, data)
-            else:
-                raise
+        LOG.debug('Create LUN mapping %(data)s',
+                  {'data': data})
+        self.nef.post(url, data)
 
-        # Get LUN of just created volume
-        vol_map_url = 'san/lunMappings?volume={}&fields=lun'.format(
-            volume_path.replace('/', '%2F'))
-        data = self.nef.get(vol_map_url).get('data')
-        counter = 0
-        while not data and counter < lpt:
-            greenthread.sleep(1)
-            counter += 1
-            data = self.nef.get(vol_map_url).get('data')
+        params = {
+            'fields': 'lun',
+            'volume': volume_path,
+            'targetGroup': target_group,
+            'hostGroup': host_group
+        }
+        LOG.debug('Get LUN number of LUN mapping for %(params)s',
+                  {'params': params})
+        url = 'san/lunMappings?%s' % urllib.parse.urlencode(params)
+        data = self._poll_result(url)
         lun = data[0]['lun']
+        props_luns = [lun] * len(props_iqns)
 
-        provider_location = '%(host)s:%(port)s,1 %(name)s %(lun)s' % {
-            'host': self.iscsi_host,
-            'port': self.configuration.nexenta_iscsi_target_portal_port,
-            'name': target_name,
-            'lun': lun,
-        }
-        return {'provider_location': provider_location}
+        if multipath:
+            props['target_portals'] = props_portals
+            props['target_iqns'] = props_iqns
+            props['target_luns'] = props_luns
+        else:
+            index = random.randrange(0, len(props_luns))
+            props['target_portal'] = props_portals[index]
+            props['target_iqn'] = props_iqns[index]
+            props['target_lun'] = props_luns[index]
 
-    def _create_target_group(self, tg_name, target_name):
-        # Create new target group
+        if not self.lu_writebackcache_disabled:
+            LOG.debug('Get LUN guid for volume %(volume)s',
+                      {'volume': volume_path})
+            params = {'fields': 'guid', 'volume': volume_path}
+            url = 'san/logicalUnits?%s' % urllib.parse.urlencode(params)
+            data = self.nef.get(url).get('data')
+            guid = data[0]['guid']
+            LOG.debug('Enable Write Back Cache for LUN %(guid)s',
+                      {'guid': guid})
+            url = 'san/logicalUnits/%s' % urllib.parse.quote_plus(guid)
+            data = {'writebackCacheDisabled': False}
+            self.nef.put(url, data)
+
+        LOG.debug('Created new LUN mapping(s): %(props)s',
+                  {'props': props})
+        return {'driver_volume_type': 'iscsi', 'data': props}
+
+    def _create_target_group(self, name, members):
+        """Create a new target group with members.
+
+        :param name: group name
+        :param members: group members list
+        """
         url = 'san/targetgroups'
         data = {
-            'name': tg_name,
-            'members': [target_name]
+            'name': name,
+            'members': members
         }
+        LOG.debug('Create new target group %(name)s '
+                  'with members %(members)s',
+                  {'name': name, 'members': members})
         self.nef.post(url, data)
+
+    def _update_target_group(self, name, members):
+        """Update a existing target group with new members.
+
+        :param name: group name
+        :param members: group members list
+        """
+        url = 'san/targetgroups/%s' % urllib.parse.quote_plus(name)
+        data = {
+            'members': members
+        }
+        LOG.debug('Update existing target group %(name)s '
+                  'with new members %(members)s',
+                  {'name': name, 'members': members})
+        self.nef.put(url, data)
+
+    def _delete_lun_mapping(self, mapping):
+        """Delete an existing LUN mapping.
+
+        :param mapping: LUN mapping ID
+        """
+        url = 'san/lunMappings/%s' % mapping
+        LOG.debug('Delete LUN mapping %(mapping)s',
+                  {'mapping': mapping})
+        self.nef.delete(url)
+
+    def _create_target(self, name, portals):
+        """Create a new target with portals.
+
+        :param name: target name
+        :param portals: target portals list
+        """
+        url = 'san/iscsi/targets'
+        data = {
+            'name': name,
+            'portals': self._s2d(portals)
+        }
+        LOG.debug('Create new target %(name)s with portals %(portals)s',
+                  {'name': name, 'portals': portals})
+        self.nef.post(url, data)
+
+    def _get_host_group(self, member):
+        """Find existing host group by group member.
+
+        :param member: host group member
+        :returns: host group name
+        """
+        url = 'san/hostgroups'
+        host_groups = self.nef.get(url).get('data')
+        for host_group in host_groups:
+            members = host_group['members']
+            if member in members:
+                name = host_group['name']
+                LOG.debug('Found host group %(name)s for member %(member)s',
+                          {'name': name, 'member': member})
+                return name
+        return None
+
+    def _create_host_group(self, name, member):
+        """Create a new host group.
+
+        :param name: host group name
+        :param member: host group member
+        """
+        url = 'san/hostgroups'
+        data = {
+            'name': name,
+            'members': [member]
+        }
+        LOG.debug('Create new host group %(name)s with member %(member)s',
+                  {'name': name, 'member': member})
+        self.nef.post(url, data)
+
+    def _poll_result(self, url):
+        """Poll non-empty response data for NEF get method.
+
+        :param url: NEF URL
+        :returns: response data list
+        """
+        for retry in range(0, options.POLL_RETRIES):
+            data = self.nef.get(url).get('data')
+            if data:
+                return data
+            delay = int(math.exp(retry))
+            LOG.debug('Retry after %(delay)s seconds delay',
+                      {'delay': delay})
+            greenthread.sleep(delay)
+        return []
+
+    def _s2d(self, css):
+        """Parse list of colon-separated address and port to dictionary.
+
+        :param css: list of colon-separated address and port
+        :returns: dictionary
+        """
+        result = []
+        for key_val in css:
+            key, val = key_val.split(':')
+            result.append({'address': key, 'port': int(val)})
+        return result
+
+    def _d2s(self, kvp):
+        """Parse dictionary to list of colon-separated address and port.
+
+        :param kvp: dictionary
+        :returns: list of colon-separated address and port
+        """
+        result = []
+        for key_val in kvp:
+            result.append('%s:%s' % (key_val['address'], key_val['port']))
+        return result
 
     def _get_snapshot_volume(self, snapshot):
         ctxt = context.get_admin_context()

--- a/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Nexenta Systems, Inc.
+# Copyright 2018 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -15,21 +15,25 @@
 
 import json
 import requests
+import six
 import time
-import urllib3
 
 from oslo_log import log as logging
 
 from cinder import exception
 from cinder.i18n import _
 from cinder.utils import retry
+from cinder.volume.drivers.nexenta import utils
 from oslo_serialization import jsonutils
 from requests.cookies import extract_cookies_to_jar
+from requests.packages.urllib3 import exceptions
 
 LOG = logging.getLogger(__name__)
 TIMEOUT = 60
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+APPLIANCE ='NexentaStor Appliance'
 
+requests.packages.urllib3.disable_warnings(exceptions.InsecureRequestWarning)
+requests.packages.urllib3.disable_warnings(exceptions.InsecurePlatformWarning)
 
 def check_error(response):
     code = response.status_code
@@ -39,23 +43,28 @@ def check_error(response):
         try:
             content = jsonutils.loads(body) if body else None
         except ValueError:
-            raise exception.VolumeBackendAPIException(
-                data=_(
-                    'Could not parse response: %(code)s %(reason)s '
-                    '%(content)s') % {
-                        'code': code, 'reason': reason, 'content': body})
+            msg = (_('Could not parse response from %(appliance)s: '
+                     '%(code)s %(reason)s %(body)s')
+                   % {'appliance': APPLIANCE,
+                      'code': code,
+                      'reason': reason,
+                      'body': body})
+            raise exception.NexentaException(msg)
         if content and 'code' in content:
             raise exception.NexentaException(content)
-        raise exception.VolumeBackendAPIException(
-            data=_(
-                'Got bad response: %(code)s %(reason)s %(content)s') % {
-                    'code': code, 'reason': reason, 'content': content})
-
+        msg = (_('Got bad response from %(appliance)s: '
+                 '%(code)s %(reason)s %(content)s')
+               % {'appliance': APPLIANCE,
+                  'code': code,
+                  'reason': reason,
+                  'content': content})
+        raise exception.NexentaException(msg)
 
 class RESTCaller(object):
 
     retry_exc_tuple = (
         requests.exceptions.ConnectionError,
+        requests.exceptions.ConnectTimeout
     )
 
     def __init__(self, proxy, method):
@@ -69,29 +78,48 @@ class RESTCaller(object):
     def __call__(self, *args):
         url = self.get_full_url(args[0])
         kwargs = {'timeout': TIMEOUT, 'verify': self.__proxy.verify}
+        data = None
         if len(args) > 1:
-            kwargs['data'] = json.dumps(args[1])
+            kwargs['json'] = args[1]
+            data = args[1]
 
-        LOG.debug('Issuing call to NS: %s %s, data: %s',
-                  url, self.__method, kwargs['data'])
+        LOG.debug('Issuing call to %(appliance)s: '
+                  '%(url)s %(method)s data: %(data)s',
+                  {'appliance': APPLIANCE,
+                   'url': url,
+                   'method': self.__method,
+                   'data': data})
 
         try:
             response = getattr(
                 self.__proxy.session, self.__method)(url, **kwargs)
         except requests.exceptions.ConnectionError:
-            LOG.debug('ConnectionError on call to NS: %s %s, data: %s',
-                      self.__proxy.url, self.__method, kwargs['data'])
+            LOG.warning('Connection error on call to %(appliance)s: '
+                        '%(url)s %(method)s data: %(data)s',
+                        {'appliance': APPLIANCE,
+                         'url': self.__proxy.url,
+                         'method': self.__method,
+                         'data': data})
             self.handle_failover()
             url = self.get_full_url(args[0])
             response = getattr(
                 self.__proxy.session, self.__method)(url, **kwargs)
         try:
             check_error(response)
-        except exception.NexentaException as exc:
-            if exc.kwargs['message']['code'] == 'ENOENT':
-                LOG.warning('NexentaException on call to NS: %s %s, data: %s ,'
-                            'returned message: %s',
-                            url, self.__method, kwargs['data'], exc.kwargs['message'])
+        except exception.NexentaException as ex:
+            err = utils.ex2err(ex)
+            if err['code'] == 'ENOENT':
+                LOG.warning('Exception on call to %(appliance)s: '
+                            '%(url)s %(method)s data: %(data)s '
+                            'returned message: %(message)s',
+                            {'appliance': APPLIANCE,
+                             'url': url,
+                             'method': self.__method,
+                             'data': data,
+                             'message': six.text_type(err)})
+                if (err['source'] == 'hpr' and
+                        'Destination pool' in err['message']):
+                    return content
                 self.handle_failover()
                 url = self.get_full_url(args[0])
                 response = getattr(
@@ -100,10 +128,12 @@ class RESTCaller(object):
                 raise
         check_error(response)
         content = json.loads(response.content) if response.content else None
-        LOG.debug("Got response: %(code)s %(reason)s %(content)s", {
-            'code': response.status_code,
-            'reason': response.reason,
-            'content': content})
+        LOG.debug('Got response from %(appliance)s: '
+                  '%(code)s %(reason)s %(content)s',
+                  {'appliance': APPLIANCE,
+                   'code': response.status_code,
+                   'reason': response.reason,
+                   'content': content})
 
         if response.status_code == 202 and content:
             url = self.get_full_url(content['links'][0]['href'])
@@ -114,34 +144,85 @@ class RESTCaller(object):
                     url, verify=self.__proxy.verify)
                 try:
                     check_error(response)
-                except exception.NexentaException as exc:
-                    if exc.kwargs['message']['code'] == 'ENOENT':
-                        LOG.warning(
-                            'NexentaException on call to NS: %s %s, data: %s ,'
-                            'returned message: %s',
-                            url, self.__method, kwargs['data'], exc.kwargs['message'])
+                except exception.NexentaException as ex:
+                    err = utils.ex2err(ex)
+                    if err['code'] == 'ENOENT':
+                        LOG.debug('Exception on call to %(appliance)s: '
+                                  '%(url)s %(method)s data: %(data)s '
+                                  'returned message: %(message)s',
+                                  {'appliance': APPLIANCE,
+                                   'url': url,
+                                   'method': self.__method,
+                                   'data': data,
+                                   'message': six.text_type(err)})
+                        if (err['source'] == 'hpr' and
+                                'Destination pool' in err['message']):
+                            return content
                         self.handle_failover()
                         url = self.get_full_url(args[0])
                         response = getattr(
                             self.__proxy.session, self.__method)(url, **kwargs)
                     else:
                         raise
-                LOG.debug("Got response: %(code)s %(reason)s", {
-                    'code': response.status_code,
-                    'reason': response.reason})
+                LOG.debug('Got response from %(appliance)s: '
+                          '%(code)s %(reason)s',
+                          {'appliance': APPLIANCE,
+                           'code': response.status_code,
+                           'reason': response.reason})
                 content = response.json() if response.content else None
                 keep_going = response.status_code == 202
         return content
 
     def handle_failover(self):
         if self.__proxy.backup:
-            LOG.info('Server %s is unavailable, failing over to %s',
-                     self.__proxy.host, self.__proxy.backup)
+            LOG.info('Primary %(appliance)s %(host)s is unavailable, '
+                     'failing over to secondary %(backup)s',
+                     {'appliance': APPLIANCE,
+                      'host': self.__proxy.host,
+                      'backup': self.__proxy.backup})
             host = '%s,%s' % (self.__proxy.backup, self.__proxy.host)
             self.__proxy.__init__(
                 host, self.__proxy.port, self.__proxy.user,
                 self.__proxy.password, self.__proxy.use_https,
-                self.__proxy.verify)
+                self.__proxy.pool, self.__proxy.verify)
+            url = self.get_full_url('rsf/clusters')
+            response = self.__proxy.session.get(
+                url, verify=self.__proxy.verify)
+            content = response.json() if response.content else None
+            if not content:
+                raise exception.NexentaException(response)
+            cluster_name = content['data'][0]['clusterName']
+            for node in content['data'][0]['nodes']:
+                if node['ipAddress'] == self.__proxy.host:
+                    node_name = node['machineName']
+            counter = 0
+            interval = 5
+            url = self.get_full_url(
+                'rsf/clusters/%s/services' % cluster_name)
+            while counter < 24:
+                counter += 1
+                response = self.__proxy.session.get(
+                    url, verify=self.__proxy.verify)
+                content = response.json() if response.content else None
+                if content:
+                    for service in content['data']:
+                        if service['serviceName'] == self.__proxy.pool:
+                            if len(service['vips']) == 0:
+                                continue
+                            for mapping in service['vips'][0]['nodeMapping']:
+                                if (mapping['node'] == node_name and
+                                        mapping['status'] == 'up'):
+                                    return
+                LOG.debug('Pool %(pool)s service is not ready, '
+                          'sleeping for %(interval)ss',
+                          {'pool': self.__proxy.pool,
+                           'interval': interval})
+                time.sleep(interval)
+            msg = (_('Waited for %(period)ss, but pool %(pool)s '
+                     'service is still not running')
+                   % {'period': counter * interval,
+                      'pool': self.__proxy.pool})
+            raise exception.NexentaException(msg)
         else:
             raise
 
@@ -168,7 +249,9 @@ class HTTPSAuth(requests.auth.AuthBase):
 
     def handle_401(self, r, **kwargs):
         if r.status_code == 401:
-            LOG.debug('Got [401]. Trying to reauth...')
+            LOG.debug('Got [401] response from %(appliance)s: '
+                      'trying to reauthenticate ...',
+                      {'appliance': APPLIANCE})
             self.token = self.https_auth()
             # Consume content and release the original connection
             # to allow our new request to reuse the same one.
@@ -194,35 +277,40 @@ class HTTPSAuth(requests.auth.AuthBase):
         return r
 
     def https_auth(self):
-        LOG.debug('Sending auth request to %s.', self.url)
+        LOG.debug('Sending auth request to %(appliance)s: %(url)s',
+                  {'appliance': APPLIANCE,
+                   'url': self.url})
         url = '/'.join((self.url, 'auth/login'))
         headers = {'Content-Type': 'application/json'}
         data = {'username': self.username, 'password': self.password}
-        response = requests.post(
-            url, data=json.dumps(data), verify=self.verify,
-            headers=headers, timeout=TIMEOUT)
+        response = requests.post(url, json=data, verify=self.verify,
+                                 headers=headers, timeout=TIMEOUT)
         content = json.loads(response.content) if response.content else None
-        LOG.debug("NS auth response: %(code)s %(reason)s %(content)s", {
-            'code': response.status_code,
-            'reason': response.reason,
-            'content': content})
+        LOG.debug('Auth response from %(appliance)s: '
+                  '%(code)s %(reason)s %(content)s',
+                  {'appliance': APPLIANCE,
+                   'code': response.status_code,
+                   'reason': response.reason,
+                   'content': content})
         check_error(response)
         response.close()
         if response.content:
             token = content['token']
             del content['token']
             return token
-        raise exception.VolumeBackendAPIException(
-            data=_(
-                'Got bad response: %(code)s %(reason)s') % {
-                    'code': response.status_code, 'reason': response.reason})
-
+        msg = (_('Got bad response from %(appliance)s: '
+                 '%(code)s %(reason)s')
+               % {'appliance': APPLIANCE,
+                  'code': response.status_code,
+                  'reason': response.reason})
+        raise exception.NexentaException(msg)
 
 class NexentaJSONProxy(object):
 
-    def __init__(self, host, port, user, password, use_https, verify):
+    def __init__(self, host, port, user, password, use_https, pool, verify):
         self.session = requests.Session()
         self.session.headers.update({'Content-Type': 'application/json'})
+        self.pool = pool
         self.user = user
         self.verify = verify
         self.password = password

--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Nexenta Systems, Inc.
+# Copyright 2018 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -20,6 +20,7 @@ import six
 from eventlet import greenthread
 from oslo_log import log as logging
 from oslo_utils import units
+from six.moves import urllib
 
 from cinder import context
 from cinder import db
@@ -30,8 +31,9 @@ from cinder.volume.drivers.nexenta import options
 from cinder.volume.drivers.nexenta import utils
 from cinder.volume.drivers import nfs
 
-VERSION = '1.4.0'
+VERSION = '1.6.9'
 LOG = logging.getLogger(__name__)
+BLOCK_SIZE_MB = 1
 
 
 class NexentaNfsDriver(nfs.NfsDriver):
@@ -45,6 +47,18 @@ class NexentaNfsDriver(nfs.NfsDriver):
                 Added abandoned volumes and snapshots cleanup.
         1.3.0 - Failover support.
         1.4.0 - Migrate volume support and new NEF API calls.
+        1.6.0 - Get mountPoint from API to support old style mount points.
+                Mount and umount shares on each operation to avoid mass
+                mounts on controller. Clean up mount folders on delete.
+        1.6.1 - Fixed volume from image creation.
+        1.6.2 - Removed redundant share mount from initialize_connection.
+        1.6.3 - Adapted NexentaException for the latest Cinder.
+        1.6.4 - Fixed volume mount/unmount.
+        1.6.5 - Added driver_ssl_cert_verify for HA failover.
+        1.6.6 - Destroy unused snapshots after deletion of it's last clone.
+        1.6.7 - Fixed volume migration for HA environment.
+        1.6.8 - Added deferred deletion for snapshots.
+        1.6.9 - Fixed race between volume/clone deletion.
     """
 
     driver_prefix = 'nexenta'
@@ -91,15 +105,13 @@ class NexentaNfsDriver(nfs.NfsDriver):
 
     def do_setup(self, context):
         host = self.nef_host or self.nas_host
+        pool_name, fs = self._get_share_datasets(self.share)
         self.nef = jsonrpc.NexentaJSONProxy(
             host, self.nef_port, self.nef_user,
-            self.nef_password, self.use_https, self.verify_ssl)
+            self.nef_password, self.use_https, pool_name, self.verify_ssl)
 
     def check_for_setup_error(self):
-        """Verify that the volume for our folder exists.
-
-        :raise: :py:exc:`LookupError`
-        """
+        """Verify that nas_share_path is shared over NFS."""
         pool_name, fs = self._get_share_datasets(self.share)
         url = 'storage/pools/%s' % (pool_name)
         self.nef.get(url)
@@ -107,8 +119,9 @@ class NexentaNfsDriver(nfs.NfsDriver):
         url = 'nas/nfs?filesystem=%s' % urllib.parse.quote_plus(self.share)
         data = self.nef.get(url).get('data')
         if not (data and data[0].get('shareState') == 'online'):
-            raise exception.NexentaException(
-                _('NFS share %s is not accessible') % self.share)
+            msg = (_('NFS share %(share)s is not accessible')
+                   % {'share': self.share})
+            raise exception.NexentaException(msg)
 
     def create_volume(self, volume):
         """Creates a volume.
@@ -116,13 +129,34 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: volume reference
         :returns: provider_location update dict for database
         """
+        LOG.debug('Create volume %(volume)s',
+                  {'volume': volume['name']})
         self._do_create_volume(volume)
         return {'provider_location': volume['provider_location']}
+
+    def copy_image_to_volume(self, context, volume, image_service, image_id):
+        LOG.debug('Copy image %(image)s to volume %(volume)s',
+                  {'image': image_id,
+                   'volume': volume['name']})
+        self._mount_volume(volume)
+        super(NexentaNfsDriver, self).copy_image_to_volume(
+            context, volume, image_service, image_id)
+        self._unmount_volume(volume)
+
+    def copy_volume_to_image(self, context, volume, image_service, image_meta):
+        LOG.debug('Copy volume %(volume)s to image %(image)s',
+                  {'volume': volume['name'],
+                   'image': image_meta['id']})
+        self._mount_volume(volume)
+        super(NexentaNfsDriver, self).copy_volume_to_image(
+            context, volume, image_service, image_meta)
+        self._unmount_volume(volume)
 
     def _do_create_volume(self, volume):
         pool, fs = self._get_share_datasets(self.share)
         filesystem = '%s/%s/%s' % (pool, fs, volume['name'])
-        LOG.debug('Creating filesystem on NexentaStor %s', filesystem)
+        LOG.debug('Create filesystem %(filesystem)s',
+                  {'filesystem': filesystem})
         url = 'storage/filesystems'
         data = {
             'path': '/'.join([pool, fs, volume['name']]),
@@ -130,18 +164,19 @@ class NexentaNfsDriver(nfs.NfsDriver):
         }
         try:
             self.nef.post(url, data)
-        except exception.NexentaException as e:
-            if 'EEXIST' in e.args[0]:
-                LOG.info('Filesystem %s already exists, using it.', filesystem)
+        except exception.NexentaException as ex:
+            err = utils.ex2err(ex)
+            if err['code'] == 'EEXIST':
+                LOG.debug('Filesystem %(filesystem)s already exists, '
+                          'reuse existing filesystem',
+                          {'filesystem': filesystem})
             else:
-                raise
+                raise ex
         volume['provider_location'] = '%s:/%s/%s' % (
             self.nas_host, self.share, volume['name'])
         try:
             self._share_folder(fs, volume['name'])
-            self._ensure_share_mounted('%s:/%s/%s' % (
-                self.nas_host, self.share, volume['name']))
-
+            self._mount_volume(volume)
             volume_size = volume['size']
             if getattr(self.configuration,
                        self.driver_prefix + '_sparsed_volumes'):
@@ -162,20 +197,21 @@ class NexentaNfsDriver(nfs.NfsDriver):
                         # Backup default compression value if it was changed.
                         self.nef.put(url, {'compressionMode': compression})
 
-        except exception.NexentaException:
+        except exception.NexentaException as ex:
             try:
                 url = 'storage/filesystems/%s' % (
                     '%2F'.join([pool, fs, volume['name']]))
                 self.nef.delete(url)
             except exception.NexentaException:
-                LOG.warning("Cannot destroy created folder: "
-                            "%(vol)s/%(folder)s",
-                            {'vol': pool, 'folder': '/'.join(
-                                [fs, volume['name']])})
-            raise
+                LOG.debug('Cannot destroy created filesystem '
+                          '%(pool)s/%(filesystem)s/%(volume)s: %(error)s',
+                          {'pool': pool,
+                           'filesystem': fs,
+                           'volume': volume['name'],
+                           'error': six.text_type(ex)})
+            raise ex
         finally:
-            self._ensure_share_unmounted('%s:/%s/%s' % (
-                self.nas_host, self.share, volume['name']))
+            self._unmount_volume(volume)
 
     def _ensure_share_unmounted(self, nfs_share, mount_path=None):
         """Ensure that NFS share is unmounted on the host.
@@ -190,34 +226,76 @@ class NexentaNfsDriver(nfs.NfsDriver):
             mount_path = self._get_mount_point_for_share(nfs_share)
 
         if mount_path not in self._remotefsclient._read_mounts():
-            LOG.info('NFS share %(share)s already unmounted from %(path)s.', {
-                     'share': nfs_share,
-                     'path': mount_path})
+            LOG.debug('NFS share %(share)s is not mounted at %(path)s',
+                      {'share': nfs_share,
+                       'path': mount_path})
             return
 
         for attempt in range(num_attempts):
             try:
                 self._execute('umount', mount_path, run_as_root=True)
-                LOG.debug('NFS share %(share)s was successfully unmounted '
-                          'from %(path)s.', {
-                              'share': nfs_share,
-                              'path': mount_path})
-                return
-            except Exception as e:
-                msg = six.text_type(e)
+                LOG.debug('NFS share %(share)s has been unmounted at %(path)s',
+                          {'share': nfs_share,
+                           'path': mount_path})
+                break
+            except Exception as ex:
+                msg = six.text_type(ex)
                 if attempt == (num_attempts - 1):
                     LOG.error('Unmount failure for %(share)s after '
-                              '%(count)d attempts.', {
-                                  'share': nfs_share,
-                                  'count': num_attempts})
+                              '%(count)d attempts',
+                              {'share': nfs_share,
+                               'count': num_attempts})
                     raise exception.NfsException(msg)
-                LOG.warning('Unmount attempt %(attempt)d failed: %(msg)s. '
-                            'Retrying unmount %(share)s from %(path)s.', {
-                                'attempt': attempt,
-                                'msg': msg,
-                                'share': nfs_share,
-                                'path': mount_path})
+                LOG.warning('Unmount attempt %(attempt)d failed: %(msg)s, '
+                            'retrying unmount %(share)s from %(path)s',
+                            {'attempt': attempt,
+                             'msg': msg,
+                             'share': nfs_share,
+                             'path': mount_path})
                 greenthread.sleep(1)
+
+        self._delete(mount_path)
+
+    def _mount_volume(self, volume):
+        """Ensure that volume is activated and mounted on the host."""
+        dataset_name = self._get_dataset_name(volume)
+        dataset_url = 'storage/filesystems/%s' % (
+            urllib.parse.quote_plus(dataset_name))
+        dataset = self.nef.get(dataset_url)
+        dataset_mount_point = dataset.get('mountPoint')
+        dataset_ready = dataset.get('isMounted')
+        if dataset_mount_point == 'none':
+            hpr_url = 'hpr/activate'
+            data = {'datasetName': dataset_name}
+            self.nef.post(hpr_url, data)
+            dataset = self.nef.get(dataset_url)
+            dataset_mount_point = dataset.get('mountPoint')
+        elif not dataset_ready:
+            dataset_url = 'storage/filesystems/%s/mount' % (
+                urllib.parse.quote_plus(dataset_name))
+            self.nef.post(dataset_url)
+        nfs_share = '%s:%s' % (self.nas_host, dataset_mount_point)
+        self._ensure_share_mounted(nfs_share)
+
+    def _unmount_volume(self, volume):
+        """Ensure that volume is unmounted on the host."""
+        dataset_name = self._get_dataset_name(volume)
+        params = {'path': dataset_name}
+        url = 'storage/filesystems?%s' % urllib.parse.urlencode(params)
+        data = self.nef.get(url).get('data')
+        if not data:
+            return
+        dataset = data[0]
+        dataset_mount_point = dataset.get('mountPoint')
+        nfs_share = '%s:%s' % (self.nas_host, dataset_mount_point)
+        self._ensure_share_unmounted(nfs_share)
+
+    def _create_sparsed_file(self, path, size):
+        """Creates file with 0 disk usage."""
+        if self.configuration.nexenta_qcow2_volumes:
+            self._create_qcow2_file(path, size)
+        else:
+            super(NexentaNfsDriver, self)._create_sparsed_file(path, size)
 
     def migrate_volume(self, ctxt, volume, host):
         """Migrate if volume and host are managed by Nexenta appliance.
@@ -226,65 +304,111 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: a dictionary describing the volume to migrate
         :param host: a dictionary describing the host to migrate to
         """
-        LOG.debug('Enter: migrate_volume: id=%(id)s, host=%(host)s',
-                  {'id': volume['id'], 'host': host})
+        LOG.debug('Migrate volume %(volume)s to host %(host)s',
+                  {'volume': volume['name'],
+                   'host': host})
 
         false_ret = (False, None)
 
         if volume['status'] not in ('available', 'retyping'):
-            LOG.warning("Volume status must be 'available' or 'retyping'."
-                        " Current volume status: %s", volume['status'])
+            LOG.error('Volume %(volume)s status must be available or '
+                      'retyping, current volume status is %(status)s',
+                      {'volume': volume['name'],
+                       'status': volume['status']})
             return false_ret
 
         if 'capabilities' not in host:
-            LOG.warning("Unsupported host. No capabilities found")
+            LOG.error('Unsupported host %(host)s: '
+                      'no capabilities found',
+                      {'host': host})
             return false_ret
 
         capabilities = host['capabilities']
+
+        if not ('location_info' in capabilities and
+                'vendor_name' in capabilities and
+                'free_capacity_gb' in capabilities):
+            LOG.error('Unsupported host %(host)s: required NFS '
+                      'and vendor capabilities are not found',
+                      {'host': host})
+            return false_ret
+
         dst_driver_name = capabilities['location_info'].split(':')[0]
         dst_fs = capabilities['location_info'].split(':/')[1]
 
-        if (capabilities.get('vendor_name') != 'Nexenta' or
-                dst_driver_name != self.__class__.__name__ or
-                capabilities['free_capacity_gb'] < volume['size']):
+        if not (capabilities['vendor_name'] == 'Nexenta' and
+                dst_driver_name == self.__class__.__name__):
+            LOG.error('Unsupported host %(host)s: incompatible '
+                      'vendor %(vendor)s or driver %(driver)s',
+                      {'host': host,
+                       'vendor': capabilities['vendor_name'],
+                       'driver': dst_driver_name})
             return false_ret
 
+        if capabilities['free_capacity_gb'] < volume['size']:
+            LOG.error('There is not enough space available on the '
+                      'host %(host)s to migrate volume %(volume), '
+                      'free space: %(free)d, required: %(size)d',
+                      {'host': host,
+                       'volume': volume['name'],
+                       'free': capabilities['free_capacity_gb'],
+                       'size': volume['size']})
+            return false_ret
+
+        nef_ips = capabilities['nef_url'].split(',')
+        nef_ips.append(None)
         pool, fs = self._get_share_datasets(self.share)
         url = 'hpr/services'
-        svc_name = 'cinder-migrate-%s' % volume['name']
+        svc = 'cinder-migrate-%s' % volume['name']
         data = {
-            'name': svc_name,
+            'name': svc,
             'sourceDataset': '/'.join([pool, fs, volume['name']]),
             'destinationDataset': '/'.join([dst_fs, volume['name']]),
             'type': 'scheduled',
-            'sendShareNfs': True,
+            'sendShareNfs': True
         }
-        nef_ips = capabilities['nef_url'].split(',')
-        if capabilities['nef_url'] != self.nef_host:
-            data['isSource'] = True
-            data['remoteNode'] = {
-                'host': nef_ips[0],
-                'port': capabilities['nef_port']
-            }
-        try:
-            self.nef.post(url, data)
-        except exception.NexentaException as exc:
-            if 'ENOENT' in exc.args[0] and len(nef_ips) > 1:
-                data['remoteNode']['host'] = nef_ips[1]
-                self.nef.post(url, data)
-            else:
-                raise
+        for nef_ip in nef_ips:
+            hpr = data
+            if nef_ip is not None:
+                hpr['isSource'] = True
+                hpr['remoteNode'] = {
+                    'host': nef_ip,
+                    'port': capabilities['nef_port']
+                }
+            try:
+                self.nef.post(url, hpr)
+                break
+            except exception.NexentaException as ex:
+                err = utils.ex2err(ex)
+                if nef_ip is None or err['code'] not in ('EINVAL', 'ENOENT'):
+                    LOG.error('Failed to create replication '
+                              'service %(data)s: %(error)s',
+                              {'data': data,
+                               'error': six.text_type(err)})
+                    return false_ret
 
-        url = 'hpr/services/%s/start' % svc_name
-        self.nef.post(url)
+        url = 'hpr/services/%s/start' % svc
+        try:
+            self.nef.post(url)
+        except exception.NexentaException as ex:
+            err = utils.ex2err(ex)
+            LOG.error('Failed to start replication '
+                      'service %(svc)s: %(error)s',
+                      {'svc': svc,
+                       'error': six.text_type(err)})
+            return false_ret
+
         provider_location = '/'.join([
-            capabilities['location_info'].strip(dst_driver_name).strip(':'),
+            capabilities['location_info'].lstrip('%s:' % dst_driver_name),
             volume['name']])
 
-        params = (
-            '?destroySourceSnapshots=true&destroyDestinationSnapshots=true')
+        data = {
+            'destroySourceSnapshots': 'true',
+            'destroyDestinationSnapshots': 'true'
+        }
+        params = urllib.parse.urlencode(data)
         in_progress = True
-        url = 'hpr/services/%s' % svc_name
+        url = 'hpr/services/%s' % svc
         timeout = 1
         while in_progress:
             state = self.nef.get(url)['state']
@@ -294,27 +418,34 @@ class NexentaNfsDriver(nfs.NfsDriver):
                 greenthread.sleep(timeout)
                 timeout = timeout * 2
             else:
-                url = 'hpr/services/%s%s' % (svc_name, params)
+                url = 'hpr/services/%s?%s' % (svc, params)
                 self.nef.delete(url)
                 return false_ret
 
-        url = 'hpr/services/%s%s' % (svc_name, params)
+        url = 'hpr/services/%s?%s' % (svc, params)
         self.nef.delete(url)
 
         try:
             self.delete_volume(volume)
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot delete source volume %(volume)s on "
-                        "NexentaStor Appliance: %(exc)s",
-                        {'volume': volume['name'], 'exc': exc})
+        except exception.NexentaException as ex:
+            LOG.warning('Cannot delete source volume %(volume)s: %(error)s',
+                        {'volume': volume['name'],
+                         'error': six.text_type(ex)})
 
         return True, {'provider_location': provider_location}
 
+    def terminate_connection(self, volume, connector, **kwargs):
+        LOG.debug('Terminate volume connection for %(volume)s',
+                  {'volume': volume['name']})
+        self._unmount_volume(volume)
+
     def initialize_connection(self, volume, connector):
-        LOG.debug('Initialize volume connection for %s', volume['name'])
+        LOG.debug('Initialize volume connection for %(volume)s',
+                  {'volume': volume['name']})
         url = 'hpr/activate'
-        data = {'datasetName': volume['provider_location'].split(':/')[1]}
+        data = {'datasetName': '/'.join([self.share, volume['name']])}
         self.nef.post(url, data)
+        self._mount_volume(volume)
         data = {'export': volume['provider_location'], 'name': 'volume'}
         return {
             'driver_volume_type': self.driver_volume_type,
@@ -327,41 +458,65 @@ class NexentaNfsDriver(nfs.NfsDriver):
 
         :param volume: volume reference
         """
-        pool, fs = self._get_share_datasets(self.share)
-        url = 'storage/filesystems/%s' % '%2F'.join(
-            [pool, fs, volume['name']])
-
-        field = 'originalSnapshot'
-        origin = self.nef.get(url).get(field)
-        url = 'storage/filesystems/%s?snapshots=true' % '%2F'.join(
-            [pool, fs, volume['name']])
+        LOG.debug('Delete volume %(volume)s',
+                  {'volume': volume['name']})
+        path = self._get_dataset_name(volume)
+        params = {'path': path}
+        url = 'storage/filesystems?%s' % (
+            urllib.parse.urlencode(params))
+        fs_data = self.nef.get(url).get('data')
+        if not fs_data:
+            return
+        self._unmount_volume(volume)
+        params = {
+            'force': 'true',
+            'snapshots': 'true'
+        }
+        url = 'storage/filesystems/%s?%s' % (
+            urllib.parse.quote_plus(path),
+            urllib.parse.urlencode(params))
         try:
             self.nef.delete(url)
-        except exception.NexentaException as exc:
-            if 'Failed to destroy snap' in exc.kwargs['message']['message']:
-                url = 'storage/snapshots?parent=%s' % '%2F'.join(
-                    [pool, fs, volume['name']])
+        except exception.NexentaException as ex:
+            err = utils.ex2err(ex)
+            if err['code'] == 'EEXIST':
+                params = {'parent': path}
+                url = 'storage/snapshots?%s' % (
+                    urllib.parse.urlencode(params))
                 snap_map = {}
                 for snap in self.nef.get(url)['data']:
                     url = 'storage/snapshots/%s' % (
-                        snap['path'].replace('/', '%2F'))
+                        urllib.parse.quote_plus(snap['path']))
                     data = self.nef.get(url)
-                    if data['clones']:
+                    if data and data.get('clones'):
                         snap_map[data['creationTxg']] = snap['path']
-                snap = snap_map[max(snap_map)]
-                url = 'storage/snapshots/%s' % snap.replace('/', '%2F')
-                clone = self.nef.get(url)['clones'][0]
-                url = 'storage/filesystems/%s/promote' % clone.replace(
-                    '/', '%2F')
-                self.nef.post(url)
-                url = 'storage/filesystems/%s?snapshots=true' % '%2F'.join(
-                    [pool, fs, volume['name']])
+                if snap_map:
+                    snap = snap_map[max(snap_map)]
+                    url = 'storage/snapshots/%s' % urllib.parse.quote_plus(
+                        snap)
+                    clone = self.nef.get(url)['clones'][0]
+                    url = 'storage/filesystems/%s/promote' % (
+                        urllib.parse.quote_plus(clone))
+                    self.nef.post(url)
+                params = {
+                    'force': 'true',
+                    'snapshots': 'true'
+                }
+                url = 'storage/filesystems/%s?%s' % (
+                    urllib.parse.quote_plus(path),
+                    urllib.parse.urlencode(params))
                 self.nef.delete(url)
             else:
-                raise
-        if origin and 'clone' in origin:
-            url = 'storage/snapshots/%s' % origin.replace('/', '%2F')
-            self.nef.delete(url)
+                raise ex
+
+    def _delete(self, path):
+        try:
+            os.rmdir(path)
+            LOG.debug('The mountpoint %(path)s has been successfully removed',
+                      {'path': path})
+        except OSError as ex:
+            LOG.debug('Unable to remove mountpoint %(path)s: %(error)s',
+                      {'path': path, 'error': ex.strerror})
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -369,27 +524,27 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: volume reference
         :param new_size: volume new size in GB
         """
-        LOG.info('Extending volume: %(id)s New size: %(size)s GB',
-                 {'id': volume.id, 'size': new_size})
-        self._ensure_share_mounted('%s:/%s/%s' % (
-            self.nas_host, self.share, volume['name']))
+        LOG.info('Extending volume: %(volume)s, new size: %(size)sGB',
+                 {'volume': volume['name'],
+                  'size': new_size})
+        self._mount_volume(volume)
         if self.sparsed_volumes:
             self._execute('truncate', '-s', '%sG' % new_size,
                           self.local_path(volume),
-                          run_as_root=self._execute_as_root)
+                          run_as_root=True)
         else:
-            block_size_mb = 1
-            block_count = ((new_size - volume['size']) * units.Gi //
-                           (block_size_mb * units.Mi))
+            seek = (volume['size'] * units.Gi //
+                    (BLOCK_SIZE_MB * units.Mi))
+            count = ((new_size - volume['size']) * units.Gi //
+                     (BLOCK_SIZE_MB * units.Mi))
             self._execute(
                 'dd', 'if=/dev/zero',
-                'seek=%d' % (volume['size'] * units.Gi / block_size_mb),
+                'seek=%d' % seek,
                 'of=%s' % self.local_path(volume),
-                'bs=%dM' % block_size_mb,
-                'count=%d' % block_count,
+                'bs=%dM' % BLOCK_SIZE_MB,
+                'count=%d' % count,
                 run_as_root=True)
-        self._ensure_share_unmounted('%s:/%s/%s' % (
-            self.nas_host, self.share, volume['name']))
+        self._unmount_volume(volume)
 
     def create_snapshot(self, snapshot):
         """Creates a snapshot.
@@ -397,6 +552,9 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param snapshot: snapshot reference
         """
         volume = self._get_snapshot_volume(snapshot)
+        LOG.debug('Create snapshot %(snapshot)s for volume %(volume)s',
+                  {'snapshot': snapshot['name'],
+                   'volume': volume['name']})
         pool, fs = self._get_share_datasets(self.share)
         url = 'storage/snapshots'
 
@@ -409,14 +567,21 @@ class NexentaNfsDriver(nfs.NfsDriver):
 
         :param snapshot: snapshot reference
         """
+        LOG.debug('Delete snapshot %(snapshot)s',
+                  {'snapshot': snapshot['name']})
         volume = self._get_snapshot_volume(snapshot)
-        pool, fs = self._get_share_datasets(self.share)
-        url = 'storage/snapshots/%s@%s' % ('%2F'.join(
-            [pool, fs, volume['name']]), snapshot['name'])
-        try:
-            self.nef.delete(url)
-        except exception.NexentaException:
+        path = '%s@%s' % (self._get_dataset_name(volume),
+                          snapshot['name'])
+        params = {'path': path}
+        url = 'storage/snapshots?%s' % urllib.parse.urlencode(params)
+        snap_data = self.nef.get(url).get('data')
+        if not snap_data:
             return
+        params = {'defer': 'true'}
+        url = 'storage/snapshots/%s?%s' % (
+            urllib.parse.quote_plus(path),
+            urllib.parse.urlencode(params))
+        self.nef.delete(url)
 
     def create_volume_from_snapshot(self, volume, snapshot):
         """Create new volume from other's snapshot on appliance.
@@ -424,11 +589,13 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: reference of volume to be created
         :param snapshot: reference of source snapshot
         """
+        LOG.debug('Create volume %(volume)s from snapshot %(snapshot)s',
+                  {'volume': volume['name'],
+                   'snapshot': snapshot['name']})
         snapshot_vol = self._get_snapshot_volume(snapshot)
-        volume['provider_location'] = snapshot_vol['provider_location']
-
+        volume['provider_location'] = '%s:/%s/%s' % (
+            self.nas_host, self.share, volume['name'])
         pool, fs = self._get_share_datasets(self.share)
-        dataset_path = '%s/%s' % (pool, fs)
         fs_path = '%2F'.join([pool, fs, snapshot_vol['name']])
         url = ('storage/snapshots/%s/clone') % (
             '@'.join([fs_path, snapshot['name']]))
@@ -436,19 +603,25 @@ class NexentaNfsDriver(nfs.NfsDriver):
         data = {'targetPath': path}
         self.nef.post(url, data)
 
+        self.nef.post(
+            'storage/filesystems/%s/unmount' % urllib.parse.quote_plus(path))
+        self.nef.post(
+            'storage/filesystems/%s/mount' % urllib.parse.quote_plus(path))
+        dataset_path = '%s/%s' % (pool, fs)
         try:
             self._share_folder(fs, volume['name'])
-        except exception.NexentaException:
+
+        except exception.NexentaException as ex:
             try:
                 url = ('storage/filesystems/') % (
                     '%2F'.join([pool, fs, volume['name']]))
                 self.nef.delete(url)
             except exception.NexentaException:
-                LOG.warning("Cannot destroy cloned filesystem: "
-                            "%(vol)s/%(filesystem)s",
-                            {'vol': dataset_path,
+                LOG.warning('Cannot destroy cloned filesystem: '
+                            '%(volume)s/%(filesystem)s',
+                            {'volume': dataset_path,
                              'filesystem': volume['name']})
-            raise
+            raise ex
         if volume['size'] > snapshot['volume_size']:
             new_size = volume['size']
             volume['size'] = snapshot['volume_size']
@@ -462,32 +635,45 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: new volume reference
         :param src_vref: source volume reference
         """
-        LOG.info('Creating clone of volume: %s', src_vref['id'])
         snapshot = {'volume_name': src_vref['name'],
                     'volume_id': src_vref['id'],
                     'volume_size': src_vref['size'],
                     'name': self._get_clone_snapshot_name(volume)}
+        LOG.debug('Create temporary snapshot %(snapshot)s '
+                  'for the original volume %(volume)s',
+                  {'snapshot': snapshot['name'],
+                   'volume': snapshot['volume_name']})
         self.create_snapshot(snapshot)
         try:
             pl = self.create_volume_from_snapshot(volume, snapshot)
             return pl
-        except exception.NexentaException:
-            LOG.error('Volume creation failed, deleting created snapshot '
-                      '%(volume_name)s@%(name)s', snapshot)
+        except exception.NexentaException as ex:
+            LOG.debug('Volume creation failed, deleting temporary '
+                      'snapshot %(volume)s@%(snapshot)s',
+                      {'volume': snapshot['volume_name'],
+                       'snapshot': snapshot['name']})
             try:
                 self.delete_snapshot(snapshot)
             except (exception.NexentaException, exception.SnapshotIsBusy):
-                LOG.warning('Failed to delete zfs snapshot '
-                            '%(volume_name)s@%(name)s', snapshot)
-            raise
+                LOG.debug('Failed to delete temporary snapshot '
+                          '%(volume)s@%(snapshot)s',
+                          {'volume': snapshot['volume_name'],
+                           'snapshot': snapshot['name']})
+            raise ex
+
+    def _get_share_path(self, nas_host, share, volume_name):
+        url = 'storage/filesystems/%s' % urllib.parse.quote_plus(
+            '%s/%s' % (share, volume_name))
+        return '%s:%s' % (nas_host, self.nef.get(url)['mountPoint'])
 
     def local_path(self, volume):
         """Get volume path (mounted locally fs path) for given volume.
 
         :param volume: volume reference
         """
-        nfs_share = volume['provider_location']
-        return os.path.join(self._get_mount_point_for_share(nfs_share),
+        share_path = self._get_share_path(
+            self.nas_host, self.share, volume['name'])
+        return os.path.join(self._get_mount_point_for_share(share_path),
                             'volume')
 
     def _get_mount_point_for_share(self, nfs_share):
@@ -506,10 +692,10 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param filesystem: filesystem that needs to be shared
         """
         pool = self.share.split('/')[0]
-        LOG.debug(
-            'Creating ACL for filesystem %s on Nexenta Store', filesystem)
+        LOG.debug('Creating ACL for filesystem %(filesystem)s',
+                  {'filesystem': filesystem})
         url = 'storage/filesystems/%s/acl' % (
-            '%2F'.join([pool, path.replace('/', '%2F'), filesystem]))
+            '%2F'.join([pool, urllib.parse.quote_plus(path), filesystem]))
         data = {
             "type": "allow",
             "principal": "everyone@",
@@ -538,10 +724,9 @@ class NexentaNfsDriver(nfs.NfsDriver):
             ]
         }
         self.nef.post(url, data)
-
-        LOG.debug(
-            'Successfully shared filesystem %s', '/'.join(
-                [path, filesystem]))
+        LOG.debug('Successfully shared filesystem %(path)s/%(filesystem)s',
+                  {'path': path,
+                   'filesystem': filesystem})
 
     def _get_capacity_info(self, path):
         """Calculate available space on the NFS share.
@@ -562,7 +747,11 @@ class NexentaNfsDriver(nfs.NfsDriver):
 
     def _get_share_datasets(self, nfs_share):
         pool_name, fs = nfs_share.split('/', 1)
-        return pool_name, fs.replace('/', '%2F')
+        return pool_name, urllib.parse.quote_plus(fs)
+
+    def _get_dataset_name(self, volume):
+        """Returns ZFS dataset name for a volume."""
+        return '%s/%s' % (self.share, volume['name'])
 
     def _get_clone_snapshot_name(self, volume):
         """Return name for snapshot that will be used to clone the volume."""
@@ -598,13 +787,8 @@ class NexentaNfsDriver(nfs.NfsDriver):
             'free_capacity_gb': free_space,
             'reserved_percentage': self.configuration.reserved_percentage,
             'QoS_support': False,
+            'multiattach': True,
             'location_info': location_info,
             'volume_backend_name': self.backend_name,
             'nfs_mount_point_base': self.nfs_mount_point_base
         }
-
-    def get_original_snapshot_url(self, zfs_object):
-        return 'storage/snapshots/%s' % zfs_object.replace('/', '%2F')
-
-    def get_delete_volume_url(self, zfs_object):
-        return self.get_original_snapshot_url(zfs_object) + '?force=true'

--- a/cinder/volume/drivers/nexenta/options.py
+++ b/cinder/volume/drivers/nexenta/options.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Nexenta Systems, Inc.
+# Copyright 2018 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -15,6 +15,10 @@
 
 from oslo_config import cfg
 
+POLL_RETRIES = 5
+DEFAULT_ISCSI_PORT = 3260
+DEFAULT_HOST_GROUP = 'all'
+DEFAULT_TARGET_GROUP = 'all'
 
 NEXENTA_EDGE_OPTS = [
     cfg.StrOpt('nexenta_nbd_symlinks_dir',
@@ -23,10 +27,10 @@ NEXENTA_EDGE_OPTS = [
                     'links to NBDs'),
     cfg.StrOpt('nexenta_rest_user',
                default='admin',
-               help='User name to connect to NexentaEdge'),
+               help='User name to connect to NexentaEdge.'),
     cfg.StrOpt('nexenta_rest_password',
                default='nexenta',
-               help='Password to connect to NexentaEdge',
+               help='Password to connect to NexentaEdge.',
                secret=True),
     cfg.StrOpt('nexenta_lun_container',
                default='',
@@ -38,9 +42,19 @@ NEXENTA_EDGE_OPTS = [
                default='',
                help='NexentaEdge iSCSI Gateway client '
                'address for non-VIP service'),
+    cfg.IntOpt('nexenta_iops_limit',
+               default=0,
+               help='NexentaEdge iSCSI LUN object IOPS limit'),
     cfg.IntOpt('nexenta_chunksize',
                default=32768,
-               help='NexentaEdge iSCSI LUN object chunk size')
+               help='NexentaEdge iSCSI LUN object chunk size'),
+    cfg.IntOpt('nexenta_replication_count',
+               default=3,
+               help='NexentaEdge iSCSI LUN object replication count.'),
+    cfg.BoolOpt('nexenta_encryption',
+                default=False,
+                help='Defines whether NexentaEdge iSCSI LUN object '
+                     'has encryption enabled.')
 ]
 
 NEXENTA_CONNECTION_OPTS = [
@@ -66,6 +80,9 @@ NEXENTA_CONNECTION_OPTS = [
                 default=False,
                 help='If set to True the http client will validate the SSL '
                      'certificate of the backend endpoint.'),
+    cfg.BoolOpt('nexenta_lu_writebackcache_disabled',
+                default=False,
+                help='Postponed write to backing store or not'),
     cfg.StrOpt('nexenta_user',
                default='admin',
                help='User name to connect to Nexenta SA'),
@@ -102,6 +119,9 @@ NEXENTA_ISCSI_OPTS = [
     cfg.StrOpt('nexenta_target_group_prefix',
                default='cinder',
                help='Prefix for iSCSI target groups on SA'),
+    cfg.StrOpt('nexenta_host_group_prefix',
+               default='cinder',
+               help='Prefix for iSCSI host groups on SA'),
     cfg.StrOpt('nexenta_volume_group',
                default='iscsi',
                help='Volume group for NexentaStor5 iSCSI'),
@@ -111,6 +131,10 @@ NEXENTA_NFS_OPTS = [
     cfg.StrOpt('nexenta_shares_config',
                default='/etc/cinder/nfs_shares',
                help='File with the list of available nfs shares'),
+    cfg.StrOpt('nas_host',
+               deprecated_name='nas_ip',
+               default='',
+               help='VIP, IP address or Hostname of NexentaStor Appliance.'),
     cfg.StrOpt('nexenta_mount_point_base',
                default='$state_path/mnt',
                help='Base directory that contains NFS share mount points'),
@@ -120,6 +144,9 @@ NEXENTA_NFS_OPTS = [
                      'sparsed files that take no space. If disabled '
                      '(False), volume is created as a regular file, '
                      'which takes a long time.'),
+    cfg.BoolOpt('nexenta_qcow2_volumes',
+                default=False,
+                help='Create volumes as QCOW2 files rather than raw files'),
     cfg.BoolOpt('nexenta_nms_cache_volroot',
                 default=True,
                 help=('If set True cache NexentaStor appliance volroot option '

--- a/cinder/volume/drivers/nexenta/utils.py
+++ b/cinder/volume/drivers/nexenta/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Nexenta Systems, Inc.
+# Copyright 2018 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -38,7 +38,8 @@ def str2size(s, scale=1024):
 
     match = re.match(r'^([\.\d]+)\s*([BbKkMmGgTtPpEeZzYy]?)', s)
     if match is None:
-        raise ValueError(_('Invalid value: "%s"') % s)
+        raise ValueError(_('Invalid value: %(value)s')
+                         % {'value': s})
 
     groups = match.groups()
     value = float(groups[0])
@@ -61,7 +62,7 @@ def get_rrmgr_cmd(src, dst, compression=None, tcp_buf_size=None,
     """Returns rrmgr command for source and destination."""
     cmd = ['rrmgr', '-s', 'zfs']
     if compression:
-        cmd.extend(['-c', '%s' % compression])
+        cmd.extend(['-c', six.text_type(compression)])
     cmd.append('-q')
     cmd.append('-e')
     if tcp_buf_size:
@@ -116,50 +117,11 @@ def parse_nms_url(url):
     return auto, scheme, user, password, host, port, '/rest/nms/'
 
 
-def parse_nef_url(url):
-    """Parse NMS url into normalized parts like scheme, user, host and others.
-
-    Example NMS URL:
-        auto://admin:nexenta@192.168.1.1:8080/
-
-    NMS URL parts:
-
-    .. code-block:: none
-
-        auto                True if url starts with auto://, protocol
-                            will be automatically switched to https
-                            if http not supported;
-        scheme (auto)       connection protocol (http or https);
-        user (admin)        NMS user;
-        password (nexenta)  NMS password;
-        host (192.168.1.1)  NMS host;
-        port (8080)         NMS port.
-
-    :param url: url string
-    :return: tuple (auto, scheme, user, password, host, port)
-    """
-    pr = urlparse.urlparse(url)
-    scheme = pr.scheme
-    auto = scheme == 'auto'
-    if auto:
-        scheme = 'http'
-    user = 'admin'
-    password = 'nexenta'
-    if '@' not in pr.netloc:
-        host_and_port = pr.netloc
-    else:
-        user_and_password, host_and_port = pr.netloc.split('@', 1)
-        if ':' in user_and_password:
-            user, password = user_and_password.split(':')
-        else:
-            user = user_and_password
-    if ':' in host_and_port:
-        host, port = host_and_port.split(':', 1)
-    else:
-        host, port = host_and_port, '8080'
-    return auto, scheme, user, password, host, port
-
-
 def get_migrate_snapshot_name(volume):
     """Return name for snapshot that will be used to migrate the volume."""
     return 'cinder-migrate-snapshot-%(id)s' % volume
+
+
+def ex2err(ex):
+    """Convert a Cinder Exception to a Nexenta Error."""
+    return ex.msg


### PR DESCRIPTION
NEX-17729 Sync NexentaStor5 Cinder driver: Kilo NFS/iSCSI with Master

*Pep8 syntax/lint results*:
```
+ tox -e pep8
pep8 develop-inst-noop: /opt/stack/cinder
pep8 installed: aioeventlet==0.5.1,alembic==0.7.6,amqp==1.4.6,anyjson==0.3.3,appdirs==1.4.0,Babel==1.3,cffi==1.1.2,-e git://git.openstack.org/openstack/cinder.git@15ecdf5814f3b5c2963e46ed9e499608b35e9166#egg=cinder,cliff==1.10.1,cmd2==0.6.8,coverage==3.7.1,cryptography==0.9.1,decorator==3.4.2,discover==0.4.0,docutils==0.12,ecdsa==0.13,enum34==1.0.4,eventlet==0.17.4,extras==0.0.3,fixtures==1.2.0,flake8==2.2.4,functools32==3.2.3.post1,futures==3.0.3,greenlet==0.4.7,hacking==0.10.3,httplib2==0.9.1,idna==2.0,ipaddress==1.0.7,iso8601==0.1.10,Jinja2==2.7.3,jsonpatch==1.11,jsonpointer==1.9,jsonschema==2.5.1,keystonemiddleware==1.5.2,kombu==3.0.26,linecache2==1.0.0,lxml==3.4.4,Mako==1.0.1,MarkupSafe==0.23,mccabe==0.2.1,mock==1.0.1,mox==0.5.3,mox3==0.8.0,msgpack-python==0.4.6,MySQL-python==1.2.5,netaddr==0.7.15,netifaces==0.10.4,networkx==1.9.1,ordereddict==1.1,os-client-config==1.4.0,oslo.concurrency==1.8.2,oslo.config==1.9.3,oslo.context==0.2.0,oslo.db==1.7.5,oslo.i18n==1.5.0,oslo.log==1.0.0,oslo.messaging==1.8.3,oslo.middleware==1.0.0,oslo.rootwrap==1.6.0,oslo.serialization==1.4.0,oslo.utils==1.4.2,oslo.vmware==0.11.2,oslosphinx==3.0.0,oslotest==1.8.0,osprofiler==0.3.0,paramiko==1.15.2,Paste==1.7.5.1,PasteDeploy==1.5.2,pbr==0.11.1,pep8==1.5.7,posix-ipc==1.0.0,prettytable==0.7.2,psycopg2==2.6.1,pyasn1==0.1.8,pycadf==0.8.0,pycparser==2.14,pycrypto==2.6.1,pyflakes==0.8.1,Pygments==2.0.2,pyOpenSSL==0.15.1,pyparsing==2.0.3,python-barbicanclient==3.0.3,python-glanceclient==0.17.3,python-keystoneclient==1.3.4,python-mimeparse==0.1.4,python-novaclient==2.23.3,python-subunit==1.1.0,python-swiftclient==2.4.0,pytz==2015.4,PyYAML==3.11,repoze.lru==0.6,requests==2.7.0,retrying==1.3.3,Routes==2.1,rtslib-fb==2.1.57,simplejson==3.7.3,six==1.9.0,Sphinx==1.2.3,SQLAlchemy==0.9.10,sqlalchemy-migrate==0.9.6,sqlparse==0.1.15,stevedore==1.3.0,suds==0.4,taskflow==0.7.1,tempest-lib==0.4.0,Tempita==0.5.2,testrepository==0.0.20,testresources==0.2.7,testscenarios==0.5.0,testtools==1.8.0,traceback2==1.4.0,trollius==1.0.4,unittest2==1.1.0,urllib3==1.10.4,warlock==1.1.0,WebOb==1.4.1
pep8 runtests: PYTHONHASHSEED='0'
pep8 runtests: commands[0] | flake8 . cinder/common
pep8 runtests: commands[1] | bash -c find cinder -type f -regex '.*\.pot?' -print0|xargs -0 -n 1 msgfmt --check-format -o /dev/null
___________________________________ summary ____________________________________
  pep8: commands succeeded
  congratulations :)
```

*Tempest results for iSCSI*:
```
======
Totals
======
Ran: 314 tests in 1133.0000 sec.
 - Passed: 304
 - Skipped: 10
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 739.5302 sec.
```

*Tempest results for NFS*:
```
======
Totals
======
Ran: 314 tests in 1265.0000 sec.
 - Passed: 304
 - Skipped: 10
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 805.0124 sec.
```