### PR TITLE
NEX-17918 Coordination backend does not get started in the cinder backup driver

### DIFF
--- a/cinder/volume/drivers/nexenta/iscsi.py
+++ b/cinder/volume/drivers/nexenta/iscsi.py
@@ -656,7 +656,6 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
     def ensure_export(self, _ctx, volume):
         self._do_export(_ctx, volume)
 
-    @coordination.synchronized('{self.lock}')
     def _do_export(self, _ctx, volume):
         """Recreate parts of export if necessary.
 
@@ -695,7 +694,6 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             model_update = {'provider_location': provider_location}
         return model_update
 
-    @coordination.synchronized('{self.lock}')
     def remove_export(self, _ctx, volume):
         """Destroy all resources created to export zvol.
 


### PR DESCRIPTION
*NEX-17918 Coordination backend does not get started in the cinder backup driver*

Remove coordination decorator for Mitaka branch. 
All other coordination changes still exists. We can provide custom patch for Cinder:

https://bugs.launchpad.net/cinder/+bug/1669521

Custom Cinder patch for Mitaka: https://github.com/Nexenta/devstack-ci/blob/master/custom-patches/NEX-17918.diff

Tempest
```
======
Totals
======
Ran: 299 tests in 1927.0000 sec.
 - Passed: 293
 - Skipped: 6
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 1504.5348 sec.
```

Pep8
```
+ tox -e pep8
pep8 develop-inst-noop: /opt/stack/cinder
pep8 installed: alembic==0.8.4,amqp==1.4.9,anyjson==0.3.3,appdirs==1.4.0,automaton==1.2.0,Babel==2.2.0,bandit==1.0.1,cachetools==1.1.5,certifi==2016.2.28,-e git://git.openstack.org/openstack/cinder.git@13ea6dd60dce6f27c7557a3b1df51c90ed1ac597#egg=cinder,cliff==2.0.0,cmd2==0.6.8,contextlib2==0.5.1,coverage==4.0.3,ddt==1.0.1,debtcollector==1.3.0,decorator==4.0.9,docutils==0.12,dulwich==0.19.5,ecdsa==0.13,enum34==1.1.2,eventlet==0.18.4,extras==0.0.3,fasteners==0.14.1,fixtures==1.4.0,flake8==2.2.4,funcsigs==0.4,functools32==3.2.3.post2,futures==3.0.5,futurist==0.13.0,gitdb==0.6.4,GitPython==1.0.2,google-api-python-client==1.5.0,greenlet==0.4.9,hacking==0.10.3,httplib2==0.9.2,iso8601==0.1.11,Jinja2==2.8,jsonpatch==1.13,jsonpointer==1.10,jsonschema==2.5.1,kazoo==2.2.1,keystoneauth1==2.4.3,keystonemiddleware==4.4.1,kombu==3.0.34,linecache2==1.0.0,lxml==3.5.0,Mako==1.0.3,MarkupSafe==0.23,mccabe==0.2.1,mock==1.3.0,monotonic==0.6,mox3==0.14.0,msgpack-python==0.4.7,netaddr==0.7.18,netifaces==0.10.4,networkx==1.11,oauth2client==2.0.1,os-brick==1.2.0,os-client-config==1.16.0,os-testr==0.6.0,os-win==0.4.2,oslo.concurrency==3.7.1,oslo.config==3.9.0,oslo.context==2.2.0,oslo.db==4.7.1,oslo.i18n==3.5.0,oslo.log==3.3.0,oslo.messaging==4.6.1,oslo.middleware==3.8.0,oslo.policy==1.6.0,oslo.reports==1.7.0,oslo.rootwrap==4.1.0,oslo.serialization==2.4.0,oslo.service==1.8.0,oslo.utils==3.8.0,oslo.versionedobjects==1.8.0,oslo.vmware==2.5.0,oslosphinx==4.3.0,oslotest==2.4.0,osprofiler==1.2.0,paramiko==1.16.0,Paste==2.0.2,PasteDeploy==1.5.2,pbr==1.8.1,pep8==1.5.7,pika==0.10.0,pika-pool==0.1.3,positional==1.0.1,prettytable==0.7.2,psutil==1.2.1,psycopg2==2.6.1,pyasn1==0.1.9,pyasn1-modules==0.0.8,pycadf==2.2.0,pycrypto==2.6.1,pyflakes==0.8.1,Pygments==2.1.3,pyinotify==0.9.6,PyMySQL==0.7.2,pyparsing==2.1.10,pyrsistent==0.11.12,python-barbicanclient==4.0.1,python-dateutil==2.5.0,python-editor==0.5,python-glanceclient==2.0.1,python-keystoneclient==2.3.2,python-mimeparse==1.5.1,python-novaclient==3.3.2,python-subunit==1.2.0,python-swiftclient==3.0.0,pytz==2015.7,PyYAML==3.11,reno==2.9.2,repoze.lru==0.6,requests==2.9.1,requestsexceptions==1.1.3,retrying==1.3.3,Routes==2.2,rsa==3.3,rtslib-fb==2.1.58,simplejson==3.8.2,six==1.10.0,smmap==0.9.0,Sphinx==1.2.3,SQLAlchemy==1.0.12,sqlalchemy-migrate==0.10.0,sqlparse==0.1.18,stevedore==1.12.0,suds-jurko==0.6,taskflow==1.30.0,tempest-lib==1.0.0,Tempita==0.5.2,testrepository==0.0.20,testresources==1.0.0,testscenarios==0.5.0,testtools==2.0.0,tooz==1.34.0,traceback2==1.4.0,unicodecsv==0.14.1,unittest2==1.1.0,uritemplate==0.6,urllib3==1.14,voluptuous==0.8.8,warlock==1.2.0,WebOb==1.5.1,wrapt==1.10.6,zake==0.2.2
pep8 runtests: PYTHONHASHSEED='0'
pep8 runtests: commands[0] | flake8 .
pep8 runtests: commands[1] | bash -c 'find cinder -type f -regex '"'"'.*\.pot?'"'"' -print0|xargs -0 -n 1 msgfmt --check-format -o /dev/null'
pep8 runtests: commands[2] | /opt/stack/cinder/tools/config/check_uptodate.sh --checkopts
pep8 runtests: commands[3] | /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 runtests: commands[4] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder
___________________________________ summary ____________________________________
  pep8: commands succeeded
  congratulations :)
```