### PR TITLE
Fixed typos, makes pylint happy

### DIFF
--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -22,8 +22,6 @@ from oslo_log import log as logging
 from oslo_utils import units
 from six.moves import urllib
 
-from cinder import context
-from cinder import db
 from cinder import exception
 from cinder.i18n import _
 from cinder import interface


### PR DESCRIPTION
Changes:
* Remove unused modules
* Code cleanup

Pep8:
```
+ tox -e pep8
pep8 develop-inst-noop: /opt/stack/cinder
pep8 installed: alabaster==0.7.11,alembic==1.0.0,amqp==2.3.2,appdirs==1.4.3,asn1crypto==0.24.0,automaton==1.15.0,Babel==2.6.0,bandit==1.5.1,bcrypt==3.1.4,cachetools==2.1.0,castellan==0.20.1,certifi==2018.8.24,cffi==1.11.5,chardet==3.0.4,-e git://git.openstack.org/openstack/cinder.git@677966470df66aa196c9f442036aa42ca2460dad#egg=cinder,cliff==2.13.0,cmd2==0.8.9,contextlib2==0.5.5,coverage==4.5.1,cryptography==2.3.1,cursive==0.2.2,ddt==1.2.0,debtcollector==1.20.0,decorator==4.3.0,defusedxml==0.5.0,deprecation==2.0.6,dnspython==1.15.0,docutils==0.14,dogpile.cache==0.6.7,dulwich==0.19.6,enum34==1.1.6,eventlet==0.24.1,extras==1.0.0,fasteners==0.14.1,fixtures==3.0.0,flake8==2.5.5,funcsigs==1.0.2,functools32==3.2.3.post2,future==0.16.0,futures==3.2.0,futurist==1.7.0,gitdb2==2.0.4,GitPython==2.1.11,google-api-python-client==1.7.4,google-auth==1.5.1,google-auth-httplib2==0.0.3,greenlet==0.4.15,hacking==0.12.0,httplib2==0.11.3,idna==2.7,imagesize==1.1.0,ipaddress==1.0.22,iso8601==0.1.12,Jinja2==2.10,jmespath==0.9.3,jsonpatch==1.23,jsonpointer==2.0,jsonschema==2.6.0,keystoneauth1==3.11.0,keystonemiddleware==5.2.0,kombu==4.2.1,linecache2==1.0.0,lxml==4.2.5,Mako==1.0.7,MarkupSafe==1.0,mccabe==0.2.1,mock==2.0.0,monotonic==1.5,mox3==0.26.0,msgpack==0.5.6,munch==2.3.2,netaddr==0.7.19,netifaces==0.10.7,networkx==2.2,oauth2client==4.1.3,openstackdocstheme==1.25.1,openstacksdk==0.17.2,os-api-ref==1.5.0,os-brick==2.5.3,os-client-config==1.31.2,os-service-types==1.3.0,os-win==4.0.1,oslo.cache==1.30.1,oslo.concurrency==3.28.1,oslo.config==6.5.1,oslo.context==2.21.0,oslo.db==4.41.1,oslo.i18n==3.22.1,oslo.log==3.40.1,oslo.messaging==8.1.0,oslo.middleware==3.36.0,oslo.policy==1.39.1,oslo.privsep==1.30.1,oslo.reports==1.29.1,oslo.rootwrap==5.14.1,oslo.serialization==2.28.1,oslo.service==1.32.0,oslo.utils==3.37.0,oslo.versionedobjects==1.34.1,oslo.vmware==2.32.1,oslotest==3.6.0,osprofiler==2.4.1,packaging==18.0,paramiko==2.4.2,Paste==2.0.3,PasteDeploy==1.5.2,pbr==4.2.0,pep8==1.5.7,prettytable==0.7.2,psutil==5.4.7,psycopg2==2.7.5,pyasn1==0.4.4,pyasn1-modules==0.2.2,pycadf==2.8.0,pycparser==2.19,pydot==1.2.4,pyflakes==0.8.1,Pygments==2.2.0,pyinotify==0.9.6,PyMySQL==0.9.2,PyNaCl==1.3.0,pyOpenSSL==18.0.0,pyparsing==2.2.1,pyperclip==1.7.0,python-barbicanclient==4.7.0,python-dateutil==2.7.3,python-editor==1.0.3,python-glanceclient==2.12.1,python-keystoneclient==3.17.0,python-mimeparse==1.6.0,python-novaclient==11.0.0,python-subunit==1.3.0,python-swiftclient==3.6.0,pytz==2018.5,pyudev==0.21.0,PyYAML==3.13,reno==2.11.0,repoze.lru==0.7,requests==2.19.1,requestsexceptions==1.4.0,retrying==1.3.3,rfc3986==1.1.0,Routes==2.4.1,rsa==4.0,rtslib-fb==2.1.66,simplejson==3.16.0,six==1.11.0,smmap2==2.0.4,snowballstemmer==1.2.1,Sphinx==1.8.1,sphinx-feature-classification==0.3.0,sphinxcontrib-websupport==1.1.0,SQLAlchemy==1.2.12,sqlalchemy-migrate==0.11.0,sqlparse==0.2.4,statsd==3.3.0,stestr==2.1.1,stevedore==1.29.0,subprocess32==3.5.2,suds-jurko==0.6,taskflow==3.3.1,Tempita==0.5.2,tenacity==5.0.2,testresources==2.0.1,testscenarios==0.5.0,testtools==2.3.0,tooz==1.62.0,traceback2==1.4.0,typing==3.6.6,unicodecsv==0.14.1,unittest2==1.1.0,uritemplate==3.0.0,urllib3==1.23,vine==1.1.4,voluptuous==0.11.5,warlock==1.3.0,wcwidth==0.1.7,WebOb==1.8.2,wrapt==1.10.11
pep8 run-test-pre: PYTHONHASHSEED='2346020259'
pep8 runtests: commands[0] | python setup.py check --restructuredtext --strict
running check
pep8 runtests: commands[1] | flake8 .
pep8 runtests: commands[2] | /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 runtests: commands[3] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder /opt/stack/cinder/doc/source/ /opt/stack/cinder/releasenotes/notes
___________________________________ summary ____________________________________
  pep8: commands succeeded
  congratulations :)
```

Tempest for iSCSI:
```
======
Totals
======
Ran: 272 tests in 3939.0000 sec.
 - Passed: 266
 - Skipped: 6
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3128.7366 sec.
```

Tempest for NFS:
```
======
Totals
======
Ran: 272 tests in 3944.0000 sec.
 - Passed: 265
 - Skipped: 7
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3085.7016 sec.
```