### PR TITLE
NEX-19177 Openstack volume read only issue - again

### DIFF
--- a/cinder/volume/drivers/nexenta/iscsi.py
+++ b/cinder/volume/drivers/nexenta/iscsi.py
@@ -30,7 +30,7 @@ from cinder.volume.drivers.nexenta import jsonrpc
 from cinder.volume.drivers.nexenta import options
 from cinder.volume.drivers.nexenta import utils
 
-VERSION = '1.3.5'
+VERSION = '1.3.6'
 LOG = logging.getLogger(__name__)
 
 
@@ -66,6 +66,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 Fixed collection of backend statistics.
                 Refactored LUN creation, use host group for LUN mappings.
                 Added deferred deletion for snapshots.
+        1.3.6 - More informative exception messages for REST API.
     """
 
     VERSION = VERSION

--- a/cinder/volume/drivers/nexenta/nfs.py
+++ b/cinder/volume/drivers/nexenta/nfs.py
@@ -58,6 +58,7 @@ class NexentaNfsDriver(nfs.NfsDriver):  # pylint: disable=R0921
         1.3.2 - Pass mount_point_base in init_conn to support host-based
                 migration.
         1.3.3 - Fixed automatic mode for nexenta_rest_protocol, improved logging.
+        1.3.4 - More informative exception messages for REST API.
     """
 
     driver_prefix = 'nexenta'


### PR DESCRIPTION
More informative exception messages for REST API:

old style:
```
2018-11-11 07:01:53.949 39858 ERROR oslo_service.periodic_task NexentaException: Got bad response from NexentaStor4 Appliance: http://192.168.24.29:8457/rest/nms, status: 503, reason: Service Unavailable, content: XXX

2018-11-11 07:01:53.949 39858 ERROR oslo_service.periodic_task JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

new style:
```
2018-11-11 07:01:53.949 39858 ERROR oslo_service.periodic_task NexentaException: Got bad response from NexentaStor4 Appliance: http://10.3.35.44:8457/rest/nms, data: {"object": "folder", "params": ["pool2", "available|used"], "method": "get_child_props"}, status: 503, reason: Service Unavailable, content: XXX

2018-11-11 07:01:53.949 39858 ERROR oslo_service.periodic_task NexentaException: Got bad JSON from NexentaStor4 Appliance: http://10.3.35.44:8457/rest/nms, data: {"object": "appliance", "params": [], "method": "get_license_info"}, status: 200, reason: OK, content: <!DOCTYPE html>
...
2018-11-29 20:42:20.231 16423 ERROR cinder.volume.manager </body>
error: Expecting value: line 1 column 1 (char 0)
```

Tempest:
```
======
Totals
======
Ran: 336 tests in 2474.0000 sec.
 - Passed: 328
 - Skipped: 8
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 1970.4962 sec.
```