### PR TITLE
NEX-19313 TypeError: coercing to Unicode: need string or buffer, dict found

### DIFF
--- a/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
@@ -51,8 +51,6 @@ def check_error(response):
                       'reason': reason,
                       'body': body})
             raise exception.NexentaException(msg)
-        if content and 'code' in content:
-            raise exception.NexentaException(content)
         msg = (_('Got bad response from %(appliance)s: '
                  '%(code)s %(reason)s %(content)s')
                % {'appliance': APPLIANCE,


### PR DESCRIPTION
NEX-19313 TypeError: coercing to Unicode: need string or buffer, dict found

Fix error message for:
```
Dec 11 04:54:07 openstack-rocky-ns5-nfs cinder-volume[1912]: DEBUG cinder.volume.drivers.nexenta.ns5.jsonrpc [req-b670fad8-11ed-4748-9b42-374b514e3f4d req-3fc03d4a-6f13-4667-9ab3-db55329b0ce5 admin None] Got response from NexentaStor Appliance: 202 Accepted {{__call__ /opt/stack/cinder/cinder/volume/drivers/nexenta/ns5/jsonrpc.py:174}}
Dec 11 04:54:08 openstack-rocky-ns5-nfs cinder-volume[1912]: DEBUG cinder.volume.drivers.nexenta.ns5.jsonrpc [req-b670fad8-11ed-4748-9b42-374b514e3f4d req-3fc03d4a-6f13-4667-9ab3-db55329b0ce5 admin None] Got response from NexentaStor Appliance: 202 Accepted {{__call__ /opt/stack/cinder/cinder/volume/drivers/nexenta/ns5/jsonrpc.py:174}}
Dec 11 04:54:09 openstack-rocky-ns5-nfs cinder-volume[1912]: DEBUG cinder.volume.drivers.nexenta.ns5.jsonrpc [req-a86f60ff-c887-4f08-a3f5-2d777ed3a6d1 req-2457874e-6620-4952-8bdf-af1af756522e admin None]  ===> X content={u'source': u'rest', u'message': u'Request to dataset.getProto on ipc:///var/lib/nef/broker.ipc timed out (15000 ms)', u'code': u'ETIMEDOUT', u'name': u'NefError'} {{check_error /opt/stack/cinder/cinder/volume/drivers/nexenta/ns5/jsonrpc.py:55}}
Dec 11 04:54:09 openstack-rocky-ns5-nfs cinder-volume[1912]: ERROR oslo_messaging.rpc.server [req-a86f60ff-c887-4f08-a3f5-2d777ed3a6d1 req-2457874e-6620-4952-8bdf-af1af756522e admin None] Exception during message handling: TypeError: coercing to Unicode: need string or buffer, dict found
                                                             ERROR oslo_messaging.rpc.server Traceback (most recent call last):
                                                             ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/server.py", line 163, in _process_incoming
                                                             ERROR oslo_messaging.rpc.server     res = self.dispatcher.dispatch(message)
                                                             ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 265, in dispatch
                                                             ERROR oslo_messaging.rpc.server     return self._do_dispatch(endpoint, method, ctxt, args)
                                                             ERROR oslo_messaging.rpc.server   File "/usr/local/lib/python2.7/dist-packages/oslo_messaging/rpc/dispatcher.py", line 194, in _do_dispatch
                                                             ERROR oslo_messaging.rpc.server     result = func(ctxt, **new_args)
                                                             ERROR oslo_messaging.rpc.server   File "/opt/stack/cinder/cinder/volume/manager.py", line 4501, in attachment_delete
                                                             ERROR oslo_messaging.rpc.server     self._do_attachment_delete(context, vref, attachment_ref)
                                                             ERROR oslo_messaging.rpc.server   File "/opt/stack/cinder/cinder/volume/manager.py", line 4508, in _do_attachment_delete
                                                             ERROR oslo_messaging.rpc.server     attachment)
                                                             ERROR oslo_messaging.rpc.server   File "/opt/stack/cinder/cinder/volume/manager.py", line 4471, in _connection_terminate
                                                             ERROR oslo_messaging.rpc.server     % {'err': six.text_type(err)})
                                                             ERROR oslo_messaging.rpc.server TypeError: coercing to Unicode: need string or buffer, dict found
```