### PR TITLE
Refactored REST API common code, NFS and iSCSI drivers.

### DIFF
--- a/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -14,330 +14,568 @@
 #    under the License.
 
 import json
-import requests
-import six
-import time
+import os
 
+from eventlet import greenthread
 from oslo_log import log as logging
 
-from cinder import exception
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+from requests.packages.urllib3.util.timeout import Timeout
+
+from six.moves import urllib
+
+from cinder.exception import VolumeDriverException
 from cinder.i18n import _
-from cinder.utils import retry
-from cinder.volume.drivers.nexenta import utils
-from oslo_serialization import jsonutils
-from requests.cookies import extract_cookies_to_jar
-from requests.packages.urllib3 import exceptions
 
 LOG = logging.getLogger(__name__)
-TIMEOUT = 60
-APPLIANCE = 'NexentaStor Appliance'
-
-requests.packages.urllib3.disable_warnings(exceptions.InsecureRequestWarning)
-requests.packages.urllib3.disable_warnings(exceptions.InsecurePlatformWarning)
 
 
-def check_error(response):
-    code = response.status_code
-    if code not in (200, 201, 202):
-        reason = response.reason
-        body = response.content
-        try:
-            content = jsonutils.loads(body) if body else None
-        except ValueError:
-            msg = (_('Could not parse response from %(appliance)s: '
-                     '%(code)s %(reason)s %(body)s')
-                   % {'appliance': APPLIANCE,
-                      'code': code,
-                      'reason': reason,
-                      'body': body})
-            raise exception.NexentaException(msg)
-        if content and 'code' in content:
-            raise exception.NexentaException(content)
-        msg = (_('Got bad response from %(appliance)s: '
-                 '%(code)s %(reason)s %(content)s')
-               % {'appliance': APPLIANCE,
-                  'code': code,
-                  'reason': reason,
-                  'content': content})
-        raise exception.NexentaException(msg)
-
-
-class RESTCaller(object):
-
-    retry_exc_tuple = (
-        requests.exceptions.ConnectionError,
-        requests.exceptions.ConnectTimeout
-    )
-
-    def __init__(self, proxy, method):
-        self.__proxy = proxy
-        self.__method = method
-
-    def get_full_url(self, path):
-        return '/'.join((self.__proxy.url, path))
-
-    @retry(retry_exc_tuple, interval=1, retries=6)
-    def __call__(self, *args):
-        url = self.get_full_url(args[0])
-        kwargs = {'timeout': TIMEOUT, 'verify': self.__proxy.verify}
-        data = None
-        if len(args) > 1:
-            kwargs['json'] = args[1]
-            data = args[1]
-
-        LOG.debug('Issuing call to %(appliance)s: '
-                  '%(url)s %(method)s data: %(data)s',
-                  {'appliance': APPLIANCE,
-                   'url': url,
-                   'method': self.__method,
-                   'data': data})
-
-        try:
-            response = getattr(
-                self.__proxy.session, self.__method)(url, **kwargs)
-        except requests.exceptions.ConnectionError:
-            LOG.warning('Connection error on call to %(appliance)s: '
-                        '%(url)s %(method)s data: %(data)s',
-                        {'appliance': APPLIANCE,
-                         'url': self.__proxy.url,
-                         'method': self.__method,
-                         'data': data})
-            self.handle_failover()
-            url = self.get_full_url(args[0])
-            response = getattr(
-                self.__proxy.session, self.__method)(url, **kwargs)
-        try:
-            check_error(response)
-        except exception.NexentaException as ex:
-            err = utils.ex2err(ex)
-            if err['code'] == 'ENOENT':
-                LOG.warning('Exception on call to %(appliance)s: '
-                            '%(url)s %(method)s data: %(data)s '
-                            'returned message: %(message)s',
-                            {'appliance': APPLIANCE,
-                             'url': url,
-                             'method': self.__method,
-                             'data': data,
-                             'message': six.text_type(err)})
-                if (err['source'] == 'hpr' and
-                        'Destination pool' in err['message']):
-                    return None
-                self.handle_failover()
-                url = self.get_full_url(args[0])
-                response = getattr(
-                    self.__proxy.session, self.__method)(url, **kwargs)
-            else:
-                raise
-        check_error(response)
-        content = json.loads(response.content) if response.content else None
-        LOG.debug('Got response from %(appliance)s: '
-                  '%(code)s %(reason)s %(content)s',
-                  {'appliance': APPLIANCE,
-                   'code': response.status_code,
-                   'reason': response.reason,
-                   'content': content})
-
-        if response.status_code == 202 and content:
-            url = self.get_full_url(content['links'][0]['href'])
-            keep_going = True
-            while keep_going:
-                time.sleep(1)
-                response = self.__proxy.session.get(
-                    url, verify=self.__proxy.verify)
-                try:
-                    check_error(response)
-                except exception.NexentaException as ex:
-                    err = utils.ex2err(ex)
-                    if err['code'] == 'ENOENT':
-                        LOG.debug('Exception on call to %(appliance)s: '
-                                  '%(url)s %(method)s data: %(data)s '
-                                  'returned message: %(message)s',
-                                  {'appliance': APPLIANCE,
-                                   'url': url,
-                                   'method': self.__method,
-                                   'data': data,
-                                   'message': six.text_type(err)})
-                        if (err['source'] == 'hpr' and
-                                'Destination pool' in err['message']):
-                            return content
-                        self.handle_failover()
-                        url = self.get_full_url(args[0])
-                        response = getattr(
-                            self.__proxy.session, self.__method)(url, **kwargs)
+class NefException(VolumeDriverException):
+    def __init__(self, message=None, **kwargs):
+        defaults = {
+            'source': os.path.basename(__file__),
+            'name': 'NexentaCinderDriver',
+            'code': 'EBADMSG',
+            'message': 'UnknownError'
+        }
+        if message:
+            if isinstance(message, dict):
+                for key in defaults:
+                    if key in kwargs:
+                        continue
+                    if key in message:
+                        kwargs[key] = message[key]
                     else:
-                        raise
-                LOG.debug('Got response from %(appliance)s: '
-                          '%(code)s %(reason)s',
-                          {'appliance': APPLIANCE,
-                           'code': response.status_code,
-                           'reason': response.reason})
-                content = response.json() if response.content else None
-                keep_going = response.status_code == 202
+                        kwargs[key] = defaults[key]
+            elif isinstance(message, str):
+                if 'message' not in kwargs:
+                    kwargs['message'] = message
+        for key in defaults:
+            if key not in kwargs:
+                kwargs[key] = defaults[key]
+        message = (_('%(message)s (source: %(source)s, '
+                     'name: %(name)s, code: %(code)s)')
+                   % kwargs)
+        self.code = kwargs['code']
+        del kwargs['message']
+        super(NefException, self).__init__(message, **kwargs)
+
+
+class NefRequest(object):
+    def __init__(self, proxy, method):
+        self.proxy = proxy
+        self.method = method
+        self.path = None
+        self.lock = False
+        self.time = 0
+        self.data = []
+        self.payload = {}
+        self.stat = {}
+        self.hooks = {
+            'response': self.hook
+        }
+        self.kwargs = {
+            'hooks': self.hooks,
+            'timeout': self.proxy.timeout
+        }
+
+    def __call__(self, *args):
+        LOG.debug('Nef request start: %(method)s %(args)s',
+                  {'method': self.method, 'args': args})
+        if not args:
+            message = (_('Nef request path is required'))
+            raise NefException({'code': 'EINVAL', 'message': message})
+        self.path = args[0]
+        if len(args) > 1:
+            payload = args[1]
+            if not isinstance(payload, dict):
+                message = (_('Nef request body must be a dictionary'))
+                raise NefException({'code': 'EINVAL', 'message': message})
+            if self.method in ['get', 'delete']:
+                self.payload = {'params': payload}
+            elif self.method in ['put', 'post']:
+                self.payload = {'data': json.dumps(payload)}
+        try:
+            response = self.request(self.method, self.path, **self.payload)
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout) as error:
+            LOG.debug('Failed to %(method)s %(path)s %(payload)s: %(error)s',
+                      {'method': self.method, 'path': self.path,
+                       'payload': self.payload, 'error': error})
+            if not self.failover():
+                raise error
+            LOG.debug('Retry initial request after failover: '
+                      '%(method)s %(path)s %(payload)s',
+                      {'method': self.method,
+                       'path': self.path,
+                       'payload': self.payload})
+            response = self.request(self.method, self.path, **self.payload)
+        LOG.debug('Nef request done: %(method)s %(args)s. '
+                  'Total response time: %(time)s seconds, '
+                  'total requests count: %(count)s, '
+                  'requests statistics: %(stat)s',
+                  {'method': self.method,
+                   'args': args,
+                   'time': self.time,
+                   'count': sum(self.stat.values()),
+                   'stat': self.stat})
+        if response.ok and not response.content:
+            return None
+        content = json.loads(response.content)
+        if not response.ok:
+            raise NefException(content)
+        if isinstance(content, dict) and 'data' in content:
+            return self.data
         return content
 
-    def handle_failover(self):
-        if self.__proxy.backup:
-            LOG.info('Primary %(appliance)s %(host)s is unavailable, '
-                     'failing over to secondary %(backup)s',
-                     {'appliance': APPLIANCE,
-                      'host': self.__proxy.host,
-                      'backup': self.__proxy.backup})
-            host = '%s,%s' % (self.__proxy.backup, self.__proxy.host)
-            self.__proxy.__init__(
-                host, self.__proxy.port, self.__proxy.user,
-                self.__proxy.password, self.__proxy.use_https,
-                self.__proxy.pool, self.__proxy.verify)
-            url = self.get_full_url('rsf/clusters')
-            response = self.__proxy.session.get(
-                url, verify=self.__proxy.verify)
-            content = response.json() if response.content else None
-            if not content:
-                raise exception.NexentaException(response)
-            cluster_name = content['data'][0]['clusterName']
-            for node in content['data'][0]['nodes']:
-                if node['ipAddress'] == self.__proxy.host:
-                    node_name = node['machineName']
-            counter = 0
-            interval = 5
-            url = self.get_full_url(
-                'rsf/clusters/%s/services' % cluster_name)
-            while counter < 24:
-                counter += 1
-                response = self.__proxy.session.get(
-                    url, verify=self.__proxy.verify)
-                content = response.json() if response.content else None
-                if content:
-                    for service in content['data']:
-                        if service['serviceName'] == self.__proxy.pool:
-                            if len(service['vips']) == 0:
-                                continue
-                            for mapping in service['vips'][0]['nodeMapping']:
-                                if (mapping['node'] == node_name and
-                                        mapping['status'] == 'up'):
-                                    return
-                LOG.debug('Pool %(pool)s service is not ready, '
-                          'sleeping for %(interval)ss',
-                          {'pool': self.__proxy.pool,
-                           'interval': interval})
-                time.sleep(interval)
-            msg = (_('Waited for %(period)ss, but pool %(pool)s '
-                     'service is still not running')
-                   % {'period': counter * interval,
-                      'pool': self.__proxy.pool})
-            raise exception.NexentaException(msg)
-        else:
-            raise
+    def request(self, method, path, **kwargs):
+        url = self.proxy.url(path)
+        LOG.debug('Perform session request: %(method)s %(url)s %(body)s',
+                  {'method': method, 'url': url, 'body': kwargs})
+        kwargs.update(self.kwargs)
+        return self.proxy.session.request(method, url, **kwargs)
+
+    def hook(self, response, **kwargs):
+        initial_text = (_('initial request %(method)s %(path)s %(body)s')
+                        % {'method': self.method,
+                           'path': self.path,
+                           'body': self.payload})
+        request_text = (_('session request %(method)s %(url)s %(body)s')
+                        % {'method': response.request.method,
+                           'url': response.request.url,
+                           'body': response.request.body})
+        response_text = (_('session response %(code)s %(content)s')
+                         % {'code': response.status_code,
+                            'content': response.content})
+        text = (_('%(request_text)s and %(response_text)s')
+                % {'request_text': request_text,
+                   'response_text': response_text})
+        LOG.debug('Hook start on %(text)s', {'text': text})
+
+        if response.status_code not in self.stat:
+            self.stat[response.status_code] = 0
+        self.stat[response.status_code] += 1
+        self.time += response.elapsed.total_seconds()
+
+        if response.ok and not response.content:
+            LOG.debug('Hook done on %(text)s: '
+                      'empty response content',
+                      {'text': text})
+            return response
+
+        if not response.content:
+            message = (_('There is no response content '
+                         'is available for %(text)s')
+                       % {'text': text})
+            raise NefException({'code': 'ENODATA', 'message': message})
+
+        try:
+            content = json.loads(response.content)
+        except (TypeError, ValueError) as error:
+            message = (_('Failed to decode JSON for %(text)s: %(error)s')
+                       % {'text': text, 'error': error})
+            raise NefException({'code': 'ENOMSG', 'message': message})
+
+        method = 'get'
+        if response.status_code == requests.codes.unauthorized:
+            if self.stat[response.status_code] > self.proxy.retries:
+                raise NefException(content)
+            self.auth()
+            request = response.request.copy()
+            request.headers.update(self.proxy.session.headers)
+            LOG.debug('Retry last %(text)s after authentication',
+                      {'text': request_text})
+            return self.proxy.session.send(request, **kwargs)
+        elif response.status_code == requests.codes.not_found:
+            if self.lock:
+                LOG.debug('Hook done on %(text)s: '
+                          'nested failover is detected',
+                          {'text': text})
+                return response
+            if self.stat[response.status_code] > self.proxy.retries:
+                raise NefException(content)
+            if not self.failover():
+                LOG.debug('Hook done on %(text)s: '
+                          'no valid hosts found',
+                          {'text': text})
+                return response
+            LOG.debug('Retry %(text)s after failover',
+                      {'text': initial_text})
+            return self.request(self.method, self.path, **self.payload)
+        elif response.status_code == requests.codes.server_error:
+            if not (isinstance(content, dict) and
+                    'code' in content and
+                    content['code'] == 'EBUSY'):
+                raise NefException(content)
+            if self.stat[response.status_code] > self.proxy.retries:
+                raise NefException(content)
+            self.proxy.delay(self.stat[response.status_code])
+            LOG.debug('Retry %(text)s after delay',
+                      {'text': initial_text})
+            return self.request(self.method, self.path, **self.payload)
+        elif response.status_code == requests.codes.accepted:
+            path = self.getpath(content, 'monitor')
+            if not path:
+                message = (_('There is no monitor path '
+                             'available for %(text)s')
+                           % {'text': text})
+                raise NefException({'code': 'ENOMSG', 'message': message})
+            self.proxy.delay(self.stat[response.status_code])
+            return self.request(method, path)
+        elif response.status_code == requests.codes.ok:
+            if not (isinstance(content, dict) and 'data' in content):
+                LOG.debug('Hook done on %(text)s: there '
+                          'is no JSON data available',
+                          {'text': text})
+                return response
+            LOG.debug('Append %(count)s data items to response',
+                      {'count': len(content['data'])})
+            self.data += content['data']
+            path = self.getpath(content, 'next')
+            if not path:
+                LOG.debug('Hook done on %(text)s: there '
+                          'is no next path available',
+                          {'text': text})
+                return response
+            LOG.debug('Perform next session request %(method)s %(path)s',
+                      {'method': method, 'path': path})
+            return self.request(method, path)
+        LOG.debug('Hook done on %(text)s and '
+                  'returned original response',
+                  {'text': text})
+        return response
+
+    def auth(self):
+        method = 'post'
+        path = 'auth/login'
+        payload = {'username': self.proxy.username,
+                   'password': self.proxy.password}
+        data = json.dumps(payload)
+        kwargs = {'data': data}
+        self.proxy.delete_bearer()
+        response = self.request(method, path, **kwargs)
+        content = json.loads(response.content)
+        if not (isinstance(content, dict) and 'token' in content):
+            message = (_('There is no authentication token available '
+                         'for authentication request %(method)s %(url)s '
+                         '%(body)s and response %(code)s %(content)s')
+                       % {'method': response.request.method,
+                          'url': response.request.url,
+                          'body': response.request.body,
+                          'code': response.status_code,
+                          'content': response.content})
+            raise NefException({'code': 'ENODATA', 'message': message})
+        token = content['token']
+        self.proxy.update_token(token)
+
+    def failover(self):
+        result = False
+        self.lock = True
+        host = self.proxy.host
+        method = 'get'
+        pool = NefPools(self.proxy)
+        path = pool.path(self.proxy.pool)
+        for item in self.proxy.hosts:
+            if item == host:
+                continue
+            self.proxy.update_host(item)
+            LOG.debug('Try to failover pool %(pool)s to %(host)s',
+                      {'pool': self.proxy.pool, 'host': item})
+            try:
+                response = self.request(method, path)
+            except (requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout) as error:
+                LOG.debug('Skip unavailable host %(host)s: %(error)s',
+                          {'host': item, 'error': error})
+                continue
+            LOG.debug('Failover result: %(code)s %(content)s',
+                      {'code': response.status_code,
+                       'content': response.content})
+            if response.status_code == requests.codes.ok:
+                LOG.debug('Successful %(pool)s failover to %(host)s',
+                          {'pool': self.proxy.pool, 'host': item})
+                result = True
+                break
+            else:
+                LOG.debug('Skip unsuitable host %(host)s: '
+                          'there is no pool %(pool)s found',
+                          {'host': item, 'pool': self.proxy.pool})
+        self.lock = False
+        return result
+
+    @staticmethod
+    def getpath(content, name):
+        if isinstance(content, dict) and 'links' in content:
+            for link in content['links']:
+                if not isinstance(link, dict):
+                    continue
+                if 'rel' in link and 'href' in link:
+                    if link['rel'] == name:
+                        return link['href']
+        return None
 
 
-class HTTPSAuth(requests.auth.AuthBase):
+class NefCollections(object):
+    subj = 'collection'
+    root = '/'
 
-    def __init__(self, url, username, password, verify):
-        self.url = url
-        self.username = username
-        self.password = password
-        self.token = None
-        self.verify = verify
+    def __init__(self, proxy):
+        self.proxy = proxy
 
-    def __eq__(self, other):
-        return all([
-            self.url == getattr(other, 'url', None),
-            self.username == getattr(other, 'username', None),
-            self.password == getattr(other, 'password', None),
-            self.token == getattr(other, 'token', None)
-        ])
+    def path(self, name):
+        return '%s/%s' % (self.root, urllib.parse.quote_plus(name))
 
-    def __ne__(self, other):
-        return not self == other
+    def get(self, name, *args):
+        LOG.debug('Get properties of %(subj)s %(name)s: %(args)s',
+                  {'subj': self.subj, 'name': name, 'args': args})
+        path = self.path(name)
+        return self.proxy.get(path, *args)
 
-    def handle_401(self, r, **kwargs):
-        if r.status_code == 401:
-            LOG.debug('Got [401] response from %(appliance)s: '
-                      'trying to reauthenticate ...',
-                      {'appliance': APPLIANCE})
-            self.token = self.https_auth()
-            # Consume content and release the original connection
-            # to allow our new request to reuse the same one.
-            r.content
-            r.close()
-            prep = r.request.copy()
-            extract_cookies_to_jar(prep._cookies, r.request, r.raw)
-            prep.prepare_cookies(prep._cookies)
+    def set(self, name, *args):
+        LOG.debug('Modify properties of %(subj)s %(name)s: %(args)s',
+                  {'subj': self.subj, 'name': name, 'args': args})
+        path = self.path(name)
+        return self.proxy.put(path, *args)
 
-            prep.headers['Authorization'] = 'Bearer %s' % self.token
-            _r = r.connection.send(prep, **kwargs)
-            _r.history.append(r)
-            _r.request = prep
+    def list(self, *args):
+        LOG.debug('List of %(subj)ss: %(args)s',
+                  {'subj': self.subj, 'args': args})
+        return self.proxy.get(self.root, *args)
 
-            return _r
-        return r
+    def create(self, *args):
+        LOG.debug('Create %(subj)s: %(args)s',
+                  {'subj': self.subj, 'args': args})
+        try:
+            return self.proxy.post(self.root, *args)
+        except NefException as error:
+            if error.code != 'EEXIST':
+                raise error
 
-    def __call__(self, r):
-        if not self.token:
-            self.token = self.https_auth()
-        r.headers['Authorization'] = 'Bearer %s' % self.token
-        r.register_hook('response', self.handle_401)
-        return r
-
-    def https_auth(self):
-        LOG.debug('Sending auth request to %(appliance)s: %(url)s',
-                  {'appliance': APPLIANCE,
-                   'url': self.url})
-        url = '/'.join((self.url, 'auth/login'))
-        headers = {'Content-Type': 'application/json'}
-        data = {'username': self.username, 'password': self.password}
-        response = requests.post(url, json=data, verify=self.verify,
-                                 headers=headers, timeout=TIMEOUT)
-        content = json.loads(response.content) if response.content else None
-        LOG.debug('Auth response from %(appliance)s: '
-                  '%(code)s %(reason)s %(content)s',
-                  {'appliance': APPLIANCE,
-                   'code': response.status_code,
-                   'reason': response.reason,
-                   'content': content})
-        check_error(response)
-        response.close()
-        if response.content:
-            token = content['token']
-            del content['token']
-            return token
-        msg = (_('Got bad response from %(appliance)s: '
-                 '%(code)s %(reason)s')
-               % {'appliance': APPLIANCE,
-                  'code': response.status_code,
-                  'reason': response.reason})
-        raise exception.NexentaException(msg)
+    def delete(self, name, *args):
+        LOG.debug('Delete %(subj)s %(name)s: %(args)s',
+                  {'subj': self.subj, 'name': name, 'args': args})
+        path = self.path(name)
+        try:
+            return self.proxy.delete(path, *args)
+        except NefException as error:
+            if error.code != 'ENOENT':
+                raise error
 
 
-class NexentaJSONProxy(object):
+class NefPools(NefCollections):
+    subj = 'pool'
+    root = '/storage/pools'
 
-    def __init__(self, host, port, user, password, use_https, pool, verify):
+
+class NefDatasets(NefCollections):
+    subj = 'dataset'
+    root = '/storage/datasets'
+
+    def rename(self, name, *args):
+        LOG.debug('Rename %(subj)s %(name)s: %(args)s',
+                  {'subj': self.subj, 'name': name, 'args': args})
+        path = '%s/%s' % (self.path(name), 'rename')
+        return self.proxy.post(path, *args)
+
+
+class NefSnapshots(NefDatasets, NefCollections):
+    subj = 'snapshot'
+    root = '/storage/snapshots'
+
+    def clone(self, name, *args):
+        LOG.debug('Clone %(subj)s %(name)s: %(args)s',
+                  {'subj': self.subj, 'name': name, 'args': args})
+        path = '%s/%s' % (self.path(name), 'clone')
+        return self.proxy.post(path, *args)
+
+
+class NefVolumeGroups(NefDatasets, NefCollections):
+    subj = 'volume group'
+    root = 'storage/volumeGroups'
+
+    def rollback(self, name, *args):
+        LOG.debug('Rollback %(subj)s %(name)s: %(args)s',
+                  {'subj': self.subj, 'name': name, 'args': args})
+        path = '%s/%s' % (self.path(name), 'rollback')
+        return self.proxy.post(path, *args)
+
+
+class NefVolumes(NefVolumeGroups, NefDatasets, NefCollections):
+    subj = 'volume'
+    root = '/storage/volumes'
+
+    def promote(self, name, *args):
+        LOG.debug('Promote %(subj)s %(name)s: %(args)s',
+                  {'subj': self.subj, 'name': name, 'args': args})
+        path = '%s/%s' % (self.path(name), 'promote')
+        return self.proxy.post(path, *args)
+
+
+class NefFilesystems(NefVolumes, NefVolumeGroups, NefDatasets, NefCollections):
+    subj = 'filesystem'
+    root = '/storage/filesystems'
+
+    def mount(self, name, *args):
+        LOG.debug('Mount %(subj)s %(name)s: %(args)s',
+                  {'subj': self.subj, 'name': name, 'args': args})
+        path = '%s/%s' % (self.path(name), 'mount')
+        return self.proxy.post(path, *args)
+
+    def unmount(self, name, *args):
+        LOG.debug('Unmount %(subj)s %(name)s: %(args)s',
+                  {'subj': self.subj, 'name': name, 'args': args})
+        path = '%s/%s' % (self.path(name), 'unmount')
+        return self.proxy.post(path, *args)
+
+    def acl(self, name, *args):
+        LOG.debug('Set %(subj)s %(name)s ACL: %(args)s',
+                  {'subj': self.subj, 'name': name, 'args': args})
+        path = '%s/%s' % (self.path(name), 'acl')
+        return self.proxy.post(path, *args)
+
+
+class NefHpr(NefCollections):
+    subj = 'HPR service'
+    root = '/hpr'
+
+    def activate(self, *args):
+        LOG.debug('Activate %(args)s', {'args': args})
+        path = '%s/%s' % (self.root, 'activate')
+        return self.proxy.post(path, *args)
+
+    def start(self, name, *args):
+        LOG.debug('Start %(subj)s %(name)s: %(args)s',
+                  {'subj': self.subj, 'name': name, 'args': args})
+        path = '%s/%s' % (self.path(name), 'start')
+        return self.proxy.post(path, *args)
+
+
+class NefServices(NefCollections):
+    subj = 'service'
+    root = '/services'
+
+
+class NefNfs(NefCollections):
+    subj = 'NFS'
+    root = '/nas/nfs'
+
+
+class NefTargets(NefCollections):
+    subj = 'iSCSI target'
+    root = '/san/iscsi/targets'
+
+
+class NefHostGroups(NefCollections):
+    subj = 'host group'
+    root = '/san/hostgroups'
+
+
+class NefTargetsGroups(NefCollections):
+    subj = 'target group'
+    root = '/san/targetgroups'
+
+
+class NefLunMappings(NefCollections):
+    subj = 'LUN mapping'
+    root = '/san/lunMappings'
+
+
+class NefLogicalUnits(NefCollections):
+    subj = 'LU'
+    root = 'san/logicalUnits'
+
+
+class NefNetAddresses(NefCollections):
+    subj = 'network address'
+    root = '/network/addresses'
+
+
+class NefProxy(object):
+    def __init__(self, conf):
         self.session = requests.Session()
-        self.session.headers.update({'Content-Type': 'application/json'})
-        self.pool = pool
-        self.user = user
-        self.verify = verify
-        self.password = password
-        self.use_https = use_https
-        parts = host.split(',')
-        self.host = parts[0].strip()
-        self.backup = parts[1].strip() if len(parts) > 1 else None
-        if use_https:
+        self.pools = NefPools(self)
+        self.filesystems = NefFilesystems(self)
+        self.volumegroups = NefVolumeGroups(self)
+        self.volumes = NefVolumes(self)
+        self.snapshots = NefSnapshots(self)
+        self.services = NefServices(self)
+        self.nfs = NefNfs(self)
+        self.targets = NefTargets(self)
+        self.hostgroups = NefHostGroups(self)
+        self.targetgroups = NefTargetsGroups(self)
+        self.mappings = NefLunMappings(self)
+        self.logicalunits = NefLogicalUnits(self)
+        self.netaddrs = NefNetAddresses(self)
+        self.tokens = {}
+        self.headers = {
+            'Content-Type': 'application/json',
+            'X-XSS-Protection': '1'
+        }
+        if conf.nexenta_use_https:
             self.scheme = 'https'
-            self.port = port if port else 8443
-            self.session.auth = HTTPSAuth(self.url, user, password, verify)
         else:
             self.scheme = 'http'
-            self.port = port if port else 8080
-            self.session.auth = (user, password)
-
-    @property
-    def url(self):
-        return '{}://{}:{}'.format(self.scheme, self.host, self.port)
+        self.username = conf.nexenta_user
+        self.password = conf.nexenta_password
+        self.hosts = []
+        if conf.nexenta_rest_address:
+            for host in conf.nexenta_rest_address.split(','):
+                self.hosts.append(host.strip())
+        else:
+            self.hosts.append(conf.nexenta_host)
+        self.host = self.hosts[0]
+        if conf.nexenta_rest_port:
+            self.port = conf.nexenta_rest_port
+        else:
+            if conf.nexenta_use_https:
+                self.port = 8443
+            else:
+                self.port = 8080
+        self.pool = conf.nexenta_volume
+        self.backoff_factor = conf.nexenta_rest_backoff_factor
+        self.retries = len(self.hosts) * conf.nexenta_rest_retry_count
+        self.timeout = Timeout(connect=conf.nexenta_rest_connect_timeout,
+                               read=conf.nexenta_rest_read_timeout)
+        max_retries = Retry(total=conf.nexenta_rest_retry_count,
+                            backoff_factor=conf.nexenta_rest_backoff_factor)
+        adapter = HTTPAdapter(max_retries=max_retries)
+        self.session.verify = conf.driver_ssl_cert_verify
+        self.session.headers.update(self.headers)
+        self.session.mount('%s://' % self.scheme, adapter)
+        if not conf.driver_ssl_cert_verify:
+            requests.packages.urllib3.disable_warnings()
 
     def __getattr__(self, name):
-        if name in ('get', 'post', 'put', 'delete'):
-            return RESTCaller(self, name)
-        return super(NexentaJSONProxy, self).__getattribute__(name)
+        return NefRequest(self, name)
 
-    def __repr__(self):
-        return 'HTTP JSON proxy: %s' % self.url
+    def delete_bearer(self):
+        if 'Authorization' in self.session.headers:
+            del self.session.headers['Authorization']
+
+    def update_bearer(self, token):
+        bearer = 'Bearer %s' % token
+        self.session.headers['Authorization'] = bearer
+
+    def update_token(self, token):
+        self.tokens[self.host] = token
+        self.update_bearer(token)
+
+    def update_host(self, host):
+        self.host = host
+        if host in self.tokens:
+            token = self.tokens[host]
+            self.update_bearer(token)
+
+    def url(self, path):
+        netloc = '%s:%d' % (self.host, int(self.port))
+        components = (self.scheme, netloc, str(path), None, None)
+        url = urllib.parse.urlunsplit(components)
+        return url
+
+    def delay(self, attempt):
+        interval = int(self.backoff_factor * (2 ** (attempt - 1)))
+        LOG.debug('Waiting for %(interval)s seconds',
+                  {'interval': interval})
+        greenthread.sleep(interval)

--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -15,25 +15,21 @@
 
 import hashlib
 import os
-import six
 
-from eventlet import greenthread
 from oslo_log import log as logging
 from oslo_utils import units
-from six.moves import urllib
 
-from cinder import exception
-from cinder.i18n import _
+from cinder import coordination
 from cinder import interface
+from cinder.i18n import _
 import cinder.privsep.fs
-from cinder.volume.drivers.nexenta.ns5 import jsonrpc
-from cinder.volume.drivers.nexenta import options
-from cinder.volume.drivers.nexenta import utils
 from cinder.volume.drivers import nfs
+from cinder.volume.drivers.nexenta import options
+from cinder.volume.drivers.nexenta.ns5.jsonrpc import NefProxy
+from cinder.volume.drivers.nexenta.ns5.jsonrpc import NefException
 
-VERSION = '1.7.1'
+VERSION = '1.8.0'
 LOG = logging.getLogger(__name__)
-BLOCK_SIZE_MB = 1
 
 
 @interface.volumedriver
@@ -67,6 +63,15 @@ class NexentaNfsDriver(nfs.NfsDriver):
         1.7.0 - Added consistency group support.
         1.7.1 - Removed redundant hpr/activate call from initialize_connection.
         1.7.2 - Merged upstream changes for umount.
+        1.8.0 - Refactored NFS driver.
+              - Added pagination support.
+              - Added configuration parameters for REST API connect/read
+                timeouts, connection retries and backoff factor.
+              - Fixed HA failover.
+              - Added retries on EBUSY errors.
+              - Fixed HTTP authentication.
+              - Disabled non-blocking mandatory locks.
+              - Added coordination for dataset operations.
     """
 
     driver_prefix = 'nexenta'
@@ -85,22 +90,20 @@ class NexentaNfsDriver(nfs.NfsDriver):
                 options.NEXENTA_NFS_OPTS)
             self.configuration.append_config_values(
                 options.NEXENTA_DATASET_OPTS)
-
-        self.verify_ssl = self.configuration.driver_ssl_cert_verify
-        self.nfs_mount_point_base = self.configuration.nexenta_mount_point_base
+        self.nef = None
+        self.root_mount_point = None
+        self.nas_host = self.configuration.nas_host
+        self.root_path = self.configuration.nas_share_path
+        self.pool = self.root_path.split('/')[0]
+        self.configuration.nexenta_volume = self.pool
+        self.dataset_sparsed = self.configuration.nexenta_sparse
+        self.dataset_deduplication = self.configuration.nexenta_dataset_dedup
         self.dataset_compression = (
             self.configuration.nexenta_dataset_compression)
         self.dataset_description = (
             self.configuration.nexenta_dataset_description)
-        self.sparsed_volumes = self.configuration.nexenta_sparsed_volumes
-        self.nef = None
-        self.use_https = self.configuration.nexenta_use_https
-        self.nef_host = self.configuration.nexenta_rest_address
-        self.nas_host = self.configuration.nas_host
-        self.share = self.configuration.nas_share_path
-        self.nef_port = self.configuration.nexenta_rest_port
-        self.nef_user = self.configuration.nexenta_user
-        self.nef_password = self.configuration.nexenta_password
+        self.mount_point_base = self.configuration.nexenta_mount_point_base
+        self.lock = '%s:%s' % (self.backend_name, self.root_path)
 
     @property
     def backend_name(self):
@@ -112,40 +115,69 @@ class NexentaNfsDriver(nfs.NfsDriver):
         return backend_name
 
     def do_setup(self, context):
-        host = self.nef_host or self.nas_host
-        pool_name, fs = self._get_share_datasets(self.share)
-        self.nef = jsonrpc.NexentaJSONProxy(
-            host, self.nef_port, self.nef_user,
-            self.nef_password, self.use_https, pool_name, self.verify_ssl)
+        self.nef = NefProxy(self.configuration)
 
     def check_for_setup_error(self):
-        """Verify that nas_share_path is shared over NFS."""
-        pool_name, fs = self._get_share_datasets(self.share)
-        url = 'storage/pools/%s' % (pool_name)
-        self.nef.get(url)
-
-        url = 'nas/nfs?filesystem=%s' % urllib.parse.quote_plus(self.share)
-        data = self.nef.get(url).get('data')
-        if not (data and data[0].get('shareState') == 'online'):
-            msg = (_('NFS share %(share)s is not accessible')
-                   % {'share': self.share})
-            raise exception.NexentaException(msg)
+        """Check ZFS pool, filesystem and NFS server service."""
+        self.nef.pools.get(self.pool)
+        filesystem = self.nef.filesystems.get(self.root_path)
+        if filesystem['mountPoint'] == 'none':
+            message = (_('NFS root filesystem %(path)s is not writable')
+                       % {'path': filesystem['mountPoint']})
+            raise NefException({'code': 'ENOENT', 'message': message})
+        if not filesystem['isMounted']:
+            message = (_('NFS root filesystem %(path)s is not mounted')
+                       % {'path': filesystem['mountPoint']})
+            raise NefException({'code': 'ENOTDIR', 'message': message})
+        if filesystem['nonBlockingMandatoryMode']:
+            payload = {'nonBlockingMandatoryMode': False}
+            self.nef.filesystems.set(self.root_path, payload)
+        self.root_mount_point = filesystem['mountPoint']
+        service = self.nef.services.get('nfs')
+        if service['state'] != 'online':
+            message = (_('NFS server service is not online: %(state)s')
+                       % {'state': service['state']})
+            raise NefException({'code': 'ESRCH', 'message': message})
+        share = self.nef.nfs.get(self.root_path)
+        if share['shareState'] != 'online':
+            message = (_('NFS share %(share)s is not online: %(state)s')
+                       % {'share': self.root_path,
+                          'state': share['shareState']})
+            raise NefException({'code': 'ESRCH', 'message': message})
 
     def create_volume(self, volume):
         """Creates a volume.
 
         :param volume: volume reference
-        :returns: provider_location update dict for database
         """
-        LOG.debug('Create volume %(volume)s',
-                  {'volume': volume['name']})
-        self._do_create_volume(volume)
-        return {'provider_location': volume['provider_location']}
+        volume_path = self._get_volume_path(volume)
+        payload = {'path': volume_path, 'compressionMode': 'off'}
+        self.nef.filesystems.create(payload)
+        try:
+            self._set_volume_acl(volume)
+            self._mount_volume(volume)
+            volume_file = self.local_path(volume)
+            if self.dataset_sparsed:
+                self._create_sparsed_file(volume_file, volume['size'])
+            else:
+                self._create_regular_file(volume_file, volume['size'])
+                if self.dataset_compression != 'off':
+                    payload = {'compressionMode': self.dataset_compression}
+                    self.nef.filesystems.set(volume_path, payload)
+        except NefException as create_error:
+            try:
+                payload = {'force': True}
+                self.nef.filesystems.delete(volume_path, payload)
+            except NefException as delete_error:
+                LOG.debug('Failed to delete volume %(path)s: %(error)s',
+                          {'path': volume_path, 'error': delete_error})
+            raise create_error
+        finally:
+            self._unmount_volume(volume)
 
     def copy_image_to_volume(self, context, volume, image_service, image_id):
         LOG.debug('Copy image %(image)s to volume %(volume)s',
-                  {'image': image_id,
-                   'volume': volume['name']})
+                  {'image': image_id, 'volume': volume['name']})
         self._mount_volume(volume)
         super(NexentaNfsDriver, self).copy_image_to_volume(
             context, volume, image_service, image_id)
@@ -153,150 +185,59 @@ class NexentaNfsDriver(nfs.NfsDriver):
 
     def copy_volume_to_image(self, context, volume, image_service, image_meta):
         LOG.debug('Copy volume %(volume)s to image %(image)s',
-                  {'volume': volume['name'],
-                   'image': image_meta['id']})
+                  {'volume': volume['name'], 'image': image_meta['id']})
         self._mount_volume(volume)
         super(NexentaNfsDriver, self).copy_volume_to_image(
             context, volume, image_service, image_meta)
         self._unmount_volume(volume)
 
-    def _do_create_volume(self, volume):
-        pool, fs = self._get_share_datasets(self.share)
-        filesystem = '%s/%s/%s' % (pool, fs, volume['name'])
-        LOG.debug('Create filesystem %(filesystem)s',
-                  {'filesystem': filesystem})
-        url = 'storage/filesystems'
-        data = {
-            'path': '/'.join([pool, fs, volume['name']]),
-            'compressionMode': self.dataset_compression,
-        }
-        try:
-            self.nef.post(url, data)
-        except exception.NexentaException as ex:
-            err = utils.ex2err(ex)
-            if err['code'] == 'EEXIST':
-                LOG.debug('Filesystem %(filesystem)s already exists, '
-                          'reuse existing filesystem',
-                          {'filesystem': filesystem})
-            else:
-                raise ex
-        volume['provider_location'] = '%s:/%s/%s' % (
-            self.nas_host, self.share, volume['name'])
-        try:
-            self._share_folder(fs, volume['name'])
-            self._mount_volume(volume)
-            volume_size = volume['size']
-            if getattr(self.configuration,
-                       self.driver_prefix + '_sparsed_volumes'):
-                self._create_sparsed_file(self.local_path(volume), volume_size)
-            else:
-                url = 'storage/filesystems/%s' % (
-                    '%2F'.join([pool, fs, volume['name']]))
-                compression = self.nef.get(url).get('compressionMode')
-                if compression != 'off':
-                    # Disable compression, because otherwise will not use space
-                    # on disk.
-                    self.nef.put(url, {'compressionMode': 'off'})
-                try:
-                    self._create_regular_file(
-                        self.local_path(volume), volume_size)
-                finally:
-                    if compression != 'off':
-                        # Backup default compression value if it was changed.
-                        self.nef.put(url, {'compressionMode': compression})
-
-        except exception.NexentaException as ex:
-            try:
-                url = 'storage/filesystems/%s' % (
-                    '%2F'.join([pool, fs, volume['name']]))
-                self.nef.delete(url)
-            except exception.NexentaException:
-                LOG.debug('Cannot destroy created filesystem '
-                          '%(pool)s/%(filesystem)s/%(volume)s: %(error)s',
-                          {'pool': pool,
-                           'filesystem': fs,
-                           'volume': volume['name'],
-                           'error': six.text_type(ex)})
-            raise ex
-        finally:
-            self._unmount_volume(volume)
-
-    def _ensure_share_unmounted(self, nfs_share, mount_path=None):
+    def _ensure_share_unmounted(self, share):
         """Ensure that NFS share is unmounted on the host.
 
-        :param nfs_share: NFS share name
-        :param mount_path: mount path on the host
+        :param share: share path
         """
-
-        num_attempts = max(1, self.configuration.nfs_mount_attempts)
-
-        if mount_path is None:
-            mount_path = self._get_mount_point_for_share(nfs_share)
-
-        if mount_path not in self._remotefsclient._read_mounts():
+        attempts = max(1, self.configuration.nfs_mount_attempts)
+        path = self._get_mount_point_for_share(share)
+        if path not in self._remotefsclient._read_mounts():
             LOG.debug('NFS share %(share)s is not mounted at %(path)s',
-                      {'share': nfs_share,
-                       'path': mount_path})
+                      {'share': share, 'path': path})
             return
-
-        for attempt in range(num_attempts):
+        for attempt in range(0, attempts):
             try:
-                cinder.privsep.fs.umount(mount_path)
+                cinder.privsep.fs.umount(path)
                 LOG.debug('NFS share %(share)s has been unmounted at %(path)s',
-                          {'share': nfs_share,
-                           'path': mount_path})
+                          {'share': share, 'path': path})
                 break
-            except Exception as ex:
-                msg = six.text_type(ex)
-                if attempt == (num_attempts - 1):
-                    LOG.error('Unmount failure for %(share)s after '
-                              '%(count)d attempts',
-                              {'share': nfs_share,
-                               'count': num_attempts})
-                    raise exception.NfsException(msg)
-                LOG.warning('Unmount attempt %(attempt)d failed: %(msg)s, '
-                            'retrying unmount %(share)s from %(path)s',
-                            {'attempt': attempt,
-                             'msg': msg,
-                             'share': nfs_share,
-                             'path': mount_path})
-                greenthread.sleep(1)
-
-        self._delete(mount_path)
+            except Exception as error:
+                if attempt == (attempts - 1):
+                    LOG.error('Failed to unmount NFS share %(share)s '
+                              'after %(attempts)s attempts',
+                              {'share': share, 'attempts': attempts})
+                    raise error
+                LOG.debug('Unmount attempt %(attempt)s failed: %(error)s, '
+                          'retrying unmount %(share)s from %(path)s',
+                          {'attempt': attempt, 'error': error,
+                           'share': share, 'path': path})
+                self.nef.delay(attempt)
+        self._delete(path)
 
     def _mount_volume(self, volume):
         """Ensure that volume is activated and mounted on the host."""
-        dataset_path = self._get_dataset_path(volume['name'])
-        dataset_url = 'storage/filesystems/%s' % (
-            urllib.parse.quote_plus(dataset_path))
-        dataset = self.nef.get(dataset_url)
-        dataset_mount_point = dataset.get('mountPoint')
-        dataset_ready = dataset.get('isMounted')
-        if dataset_mount_point == 'none':
-            hpr_url = 'hpr/activate'
-            data = {'datasetName': dataset_path}
-            self.nef.post(hpr_url, data)
-            dataset = self.nef.get(dataset_url)
-            dataset_mount_point = dataset.get('mountPoint')
-        elif not dataset_ready:
-            dataset_url = 'storage/filesystems/%s/mount' % (
-                urllib.parse.quote_plus(dataset_path))
-            self.nef.post(dataset_url)
-        nfs_share = '%s:%s' % (self.nas_host, dataset_mount_point)
-        self._ensure_share_mounted(nfs_share)
+        volume_path = self._get_volume_path(volume)
+        filesystem = self.nef.filesystems.get(volume_path)
+        if filesystem['mountPoint'] == 'none':
+            payload = {'datasetName': volume_path}
+            self.nef.hpr.activate(payload)
+            filesystem = self.nef.filesystems.get(volume_path)
+        elif not filesystem['isMounted']:
+            self.nef.filesystems.mount(volume_path)
+        share = '%s:%s' % (self.nas_host, filesystem['mountPoint'])
+        self._ensure_share_mounted(share)
 
     def _unmount_volume(self, volume):
         """Ensure that volume is unmounted on the host."""
-        dataset_path = self._get_dataset_path(volume['name'])
-        params = {'path': dataset_path}
-        url = 'storage/filesystems?%s' % urllib.parse.urlencode(params)
-        data = self.nef.get(url).get('data')
-        if not data:
-            return
-        dataset = data[0]
-        dataset_mount_point = dataset.get('mountPoint')
-        nfs_share = '%s:%s' % (self.nas_host, dataset_mount_point)
-        self._ensure_share_unmounted(nfs_share)
+        share = self._get_volume_share(volume)
+        self._ensure_share_unmounted(share)
 
     def _create_sparsed_file(self, path, size):
         """Creates file with 0 disk usage."""
@@ -305,29 +246,26 @@ class NexentaNfsDriver(nfs.NfsDriver):
         else:
             super(NexentaNfsDriver, self)._create_sparsed_file(path, size)
 
-    def migrate_volume(self, ctxt, volume, host):
+    def migrate_volume(self, context, volume, host):
         """Migrate if volume and host are managed by Nexenta appliance.
 
-        :param ctxt: context
+        :param context: context
         :param volume: a dictionary describing the volume to migrate
         :param host: a dictionary describing the host to migrate to
         """
         LOG.debug('Migrate volume %(volume)s to host %(host)s',
-                  {'volume': volume['name'],
-                   'host': host})
+                  {'volume': volume['name'], 'host': host})
 
         false_ret = (False, None)
 
         if volume['status'] not in ('available', 'retyping'):
             LOG.error('Volume %(volume)s status must be available or '
                       'retyping, current volume status is %(status)s',
-                      {'volume': volume['name'],
-                       'status': volume['status']})
+                      {'volume': volume['name'], 'status': volume['status']})
             return false_ret
 
         if 'capabilities' not in host:
-            LOG.error('Unsupported host %(host)s: '
-                      'no capabilities found',
+            LOG.error('Unsupported host %(host)s: no capabilities found',
                       {'host': host})
             return false_ret
 
@@ -341,187 +279,163 @@ class NexentaNfsDriver(nfs.NfsDriver):
                       {'host': host})
             return false_ret
 
-        dst_driver_name = capabilities['location_info'].split(':')[0]
-        dst_fs = capabilities['location_info'].split(':/')[1]
+        driver_name = capabilities['location_info'].split(':')[0]
+        dst_root = capabilities['location_info'].split(':/')[1]
 
         if not (capabilities['vendor_name'] == 'Nexenta' and
-                dst_driver_name == self.__class__.__name__):
+                driver_name == self.__class__.__name__):
             LOG.error('Unsupported host %(host)s: incompatible '
                       'vendor %(vendor)s or driver %(driver)s',
                       {'host': host,
                        'vendor': capabilities['vendor_name'],
-                       'driver': dst_driver_name})
+                       'driver': driver_name})
             return false_ret
 
         if capabilities['free_capacity_gb'] < volume['size']:
             LOG.error('There is not enough space available on the '
                       'host %(host)s to migrate volume %(volume), '
                       'free space: %(free)d, required: %(size)d',
-                      {'host': host,
-                       'volume': volume['name'],
+                      {'host': host, 'volume': volume['name'],
                        'free': capabilities['free_capacity_gb'],
                        'size': volume['size']})
             return false_ret
 
+        src_path = self._get_volume_path(volume)
+        dst_path = '%s/%s' % (dst_root, volume['name'])
         nef_ips = capabilities['nef_url'].split(',')
         nef_ips.append(None)
-        pool, fs = self._get_share_datasets(self.share)
-        url = 'hpr/services'
         svc = 'cinder-migrate-%s' % volume['name']
-        data = {
-            'name': svc,
-            'sourceDataset': '/'.join([pool, fs, volume['name']]),
-            'destinationDataset': '/'.join([dst_fs, volume['name']]),
-            'type': 'scheduled',
-            'sendShareNfs': True
-        }
         for nef_ip in nef_ips:
-            hpr = data
+            payload = {'name': svc,
+                       'sourceDataset': src_path,
+                       'destinationDataset': dst_path,
+                       'type': 'scheduled',
+                       'sendShareNfs': True}
             if nef_ip is not None:
-                hpr['isSource'] = True
-                hpr['remoteNode'] = {
+                payload['isSource'] = True
+                payload['remoteNode'] = {
                     'host': nef_ip,
                     'port': capabilities['nef_port']
                 }
             try:
-                self.nef.post(url, hpr)
+                self.nef.hpr.create(payload)
                 break
-            except exception.NexentaException as ex:
-                err = utils.ex2err(ex)
-                if nef_ip is None or err['code'] not in ('EINVAL', 'ENOENT'):
+            except NefException as error:
+                if nef_ip is None or error.code not in ('EINVAL', 'ENOENT'):
                     LOG.error('Failed to create replication '
-                              'service %(data)s: %(error)s',
-                              {'data': data,
-                               'error': six.text_type(err)})
+                              'service %(payload)s: %(error)s',
+                              {'payload': payload, 'error': error})
                     return false_ret
 
-        url = 'hpr/services/%s/start' % svc
         try:
-            self.nef.post(url)
-        except exception.NexentaException as ex:
-            err = utils.ex2err(ex)
+            self.nef.hpr.start(svc)
+        except NefException as error:
             LOG.error('Failed to start replication '
                       'service %(svc)s: %(error)s',
-                      {'svc': svc,
-                       'error': six.text_type(err)})
+                      {'svc': svc, 'error': error})
+            try:
+                payload = {'force': True}
+                self.nef.hpr.delete(svc, payload)
+            except NefException as error:
+                LOG.error('Failed to delete replication '
+                          'service %(svc)s: %(error)s',
+                          {'svc': svc, 'error': error})
             return false_ret
 
-        provider_location = '/'.join([
-            capabilities['location_info'].lstrip('%s:' % dst_driver_name),
-            volume['name']])
-
-        data = {
-            'destroySourceSnapshots': True,
-            'destroyDestinationSnapshots': True
-        }
-        params = urllib.parse.urlencode(data)
-        in_progress = True
-        url = 'hpr/services/%s' % svc
-        timeout = 1
-        while in_progress:
-            state = self.nef.get(url)['state']
+        payload = {'destroySourceSnapshots': True,
+                   'destroyDestinationSnapshots': True}
+        progress = True
+        retry = 0
+        while progress:
+            retry += 1
+            hpr = self.nef.hpr.get(svc)
+            state = hpr['state']
             if state == 'disabled':
-                in_progress = False
+                progress = False
             elif state == 'enabled':
-                greenthread.sleep(timeout)
-                timeout = timeout * 2
+                self.nef.delay(retry)
             else:
-                url = 'hpr/services/%s?%s' % (svc, params)
-                self.nef.delete(url)
+                self.nef.hpr.delete(svc, payload)
                 return false_ret
-
-        url = 'hpr/services/%s?%s' % (svc, params)
-        self.nef.delete(url)
+        self.nef.hpr.delete(svc, payload)
 
         try:
             self.delete_volume(volume)
-        except exception.NexentaException as ex:
-            LOG.warning('Cannot delete source volume %(volume)s: %(error)s',
-                        {'volume': volume['name'],
-                         'error': six.text_type(ex)})
-
-        return True, {'provider_location': provider_location}
+        except NefException as error:
+            LOG.debug('Failed to delete source volume %(volume)s: %(error)s',
+                      {'volume': volume['name'], 'error': error})
+        return True, None
 
     def terminate_connection(self, volume, connector, **kwargs):
+        """Terminate a connection to a volume.
+
+        :param volume: a volume object
+        :param connector: a connector object
+        :returns: dictionary of connection information
+        """
         LOG.debug('Terminate volume connection for %(volume)s',
                   {'volume': volume['name']})
         self._unmount_volume(volume)
 
     def initialize_connection(self, volume, connector):
+        """Terminate a connection to a volume.
+
+        :param volume: a volume object
+        :param connector: a connector object
+        :returns: dictionary of connection information
+        """
         LOG.debug('Initialize volume connection for %(volume)s',
                   {'volume': volume['name']})
-        self._mount_volume(volume)
-        data = {'export': volume['provider_location'], 'name': 'volume'}
+        share = self._get_volume_share(volume)
         return {
             'driver_volume_type': self.driver_volume_type,
-            'data': data,
-            'mount_point_base': self.nfs_mount_point_base
+            'mount_point_base': self.mount_point_base,
+            'data': {
+                'export': share,
+                'name': 'volume'
+            }
         }
 
+    def ensure_export(self, context, volume):
+        """Synchronously recreate an export for a volume."""
+        pass
+
+    @coordination.synchronized('{self.lock}')
     def delete_volume(self, volume):
-        """Deletes a logical volume.
+        """Deletes a volume.
 
         :param volume: volume reference
         """
-        LOG.debug('Delete volume %(volume)s',
-                  {'volume': volume['name']})
-        path = self._get_dataset_path(volume['name'])
-        params = {'path': path}
-        url = 'storage/filesystems?%s' % (
-            urllib.parse.urlencode(params))
-        fs_data = self.nef.get(url).get('data')
-        if not fs_data:
-            return
+        volume_path = self._get_volume_path(volume)
         self._unmount_volume(volume)
-        params = {
-            'force': True,
-            'snapshots': True
-        }
-        url = 'storage/filesystems/%s?%s' % (
-            urllib.parse.quote_plus(path),
-            urllib.parse.urlencode(params))
+        delete_payload = {'force': True, 'snapshots': True}
         try:
-            self.nef.delete(url)
-        except exception.NexentaException as ex:
-            err = utils.ex2err(ex)
-            if err['code'] == 'EEXIST':
-                params = {'parent': path}
-                url = 'storage/snapshots?%s' % (
-                    urllib.parse.urlencode(params))
-                snap_map = {}
-                for snap in self.nef.get(url)['data']:
-                    url = 'storage/snapshots/%s' % (
-                        urllib.parse.quote_plus(snap['path']))
-                    data = self.nef.get(url)
-                    if data and data.get('clones'):
-                        snap_map[data['creationTxg']] = snap['path']
-                if snap_map:
-                    snap = snap_map[max(snap_map)]
-                    url = 'storage/snapshots/%s' % urllib.parse.quote_plus(
-                        snap)
-                    clone = self.nef.get(url)['clones'][0]
-                    url = 'storage/filesystems/%s/promote' % (
-                        urllib.parse.quote_plus(clone))
-                    self.nef.post(url)
-                params = {
-                    'force': True,
-                    'snapshots': True
-                }
-                url = 'storage/filesystems/%s?%s' % (
-                    urllib.parse.quote_plus(path),
-                    urllib.parse.urlencode(params))
-                self.nef.delete(url)
-            else:
-                raise ex
+            self.nef.filesystems.delete(volume_path, delete_payload)
+        except NefException as error:
+            if error.code != 'EEXIST':
+                raise error
+            snapshots_tree = {}
+            snapshots_payload = {'parent': volume_path, 'fields': 'path'}
+            snapshots = self.nef.snapshots.list(snapshots_payload)
+            for snapshot in snapshots:
+                clones_payload = {'fields': 'clones,creationTxg'}
+                data = self.nef.snapshots.get(snapshot['path'], clones_payload)
+                if data['clones']:
+                    snapshots_tree[data['creationTxg']] = data['clones'][0]
+            if snapshots_tree:
+                clone_path = snapshots_tree[max(snapshots_tree)]
+                self.nef.filesystems.promote(clone_path)
+            self.nef.filesystems.delete(volume_path, delete_payload)
 
     def _delete(self, path):
+        """Override parent method for safe remove mountpoint."""
         try:
             os.rmdir(path)
             LOG.debug('The mountpoint %(path)s has been successfully removed',
                       {'path': path})
-        except OSError as ex:
-            LOG.debug('Unable to remove mountpoint %(path)s: %(error)s',
-                      {'path': path, 'error': ex.strerror})
+        except OSError as error:
+            LOG.debug('Failed to remove mountpoint %(path)s: %(error)s',
+                      {'path': path, 'error': error.strerror})
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -529,54 +443,47 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: volume reference
         :param new_size: volume new size in GB
         """
-        LOG.info('Extending volume: %(volume)s, new size: %(size)sGB',
-                 {'volume': volume['name'],
-                  'size': new_size})
+        LOG.info('Extend volume %(volume)s, new size: %(size)sGB',
+                 {'volume': volume['name'], 'size': new_size})
         self._mount_volume(volume)
-        if self.sparsed_volumes:
-            self._execute('truncate', '-s', '%sG' % new_size,
-                          self.local_path(volume),
+        volume_file = self.local_path(volume)
+        if self.dataset_sparsed:
+            self._execute('truncate', '-s',
+                          '%sG' % new_size,
+                          volume_file,
                           run_as_root=True)
         else:
-            seek = (volume['size'] * units.Gi //
-                    (BLOCK_SIZE_MB * units.Mi))
-            count = ((new_size - volume['size']) * units.Gi //
-                     (BLOCK_SIZE_MB * units.Mi))
-            self._execute(
-                'dd', 'if=/dev/zero',
-                'seek=%d' % seek,
-                'of=%s' % self.local_path(volume),
-                'bs=%dM' % BLOCK_SIZE_MB,
-                'count=%d' % count,
-                run_as_root=True)
+            seek = volume['size'] * units.Ki
+            count = (new_size - volume['size']) * units.Ki
+            self._execute('dd',
+                          'if=/dev/zero',
+                          'of=%s' % volume_file,
+                          'bs=%d' % units.Mi,
+                          'seek=%d' % seek,
+                          'count=%d' % count,
+                          run_as_root=True)
         self._unmount_volume(volume)
 
+    @coordination.synchronized('{self.lock}')
     def create_snapshot(self, snapshot):
         """Creates a snapshot.
 
         :param snapshot: snapshot reference
         """
-        LOG.debug('Create snapshot %(snapshot)s for volume %(volume)s',
-                  {'snapshot': snapshot['name'],
-                   'volume': snapshot['volume_name']})
-        dataset_path = self._get_dataset_path(snapshot['volume_name'])
-        snapshot_path = '%s@%s' % (dataset_path, snapshot['name'])
-        url = 'storage/snapshots'
-        data = {'path': snapshot_path}
-        self.nef.post(url, data)
+        snapshot_path = self._get_snapshot_path(snapshot)
+        payload = {'path': snapshot_path}
+        self.nef.snapshots.create(payload)
 
     def delete_snapshot(self, snapshot):
         """Deletes a snapshot.
 
         :param snapshot: snapshot reference
         """
-        LOG.debug('Delete snapshot %(snapshot)s',
-                  {'snapshot': snapshot['name']})
-        dataset_path = self._get_dataset_path(snapshot['volume_name'])
-        snapshot_path = '%s@%s' % (dataset_path, snapshot['name'])
+        snapshot_path = self._get_snapshot_path(snapshot)
         self._delete_snapshot(snapshot_path)
 
-    def _delete_snapshot(self, path, recursive=False, defer=True):
+    @coordination.synchronized('{self.lock}')
+    def _delete_snapshot(self, snapshot_path, recursive=False, defer=True):
         """Deletes a snapshot.
 
         :param path: absolute snapshot path
@@ -586,16 +493,8 @@ class NexentaNfsDriver(nfs.NfsDriver):
                       destroy when there are not any active references
                       to it (for example, clones)
         """
-        params = {'path': path}
-        url = 'storage/snapshots?%s' % urllib.parse.urlencode(params)
-        data = self.nef.get(url).get('data')
-        if not data:
-            return
-        params = {'recursive': recursive, 'defer': defer}
-        url = 'storage/snapshots/%s?%s' % (
-            urllib.parse.quote_plus(path),
-            urllib.parse.urlencode(params))
-        self.nef.delete(url)
+        payload = {'recursive': recursive, 'defer': defer}
+        self.nef.snapshots.delete(snapshot_path, payload)
 
     def snapshot_revert_use_temp_snapshot(self):
         # Considering that NexentaStor based drivers use COW images
@@ -606,15 +505,11 @@ class NexentaNfsDriver(nfs.NfsDriver):
 
     def revert_to_snapshot(self, context, volume, snapshot):
         """Revert volume to snapshot."""
-        pool, fs = self._get_share_datasets(self.share)
-        fs_path = '/'.join([pool, fs, volume['name']])
-        LOG.debug('Revert volume %(volume)s to snapshot %(snapshot)s',
-                  {'volume': fs_path,
-                   'snapshot': snapshot['name']})
-        url = 'storage/filesystems/%s/rollback' % urllib.parse.quote_plus(
-            fs_path)
-        self.nef.post(url, {'snapshot': snapshot['name']})
+        volume_path = self._get_volume_path(volume)
+        payload = {'snapshot': snapshot['name']}
+        self.nef.filesystems.rollback(volume_path, payload)
 
+    @coordination.synchronized('{self.lock}')
     def create_volume_from_snapshot(self, volume, snapshot):
         """Create new volume from other's snapshot on appliance.
 
@@ -622,43 +517,19 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param snapshot: reference of source snapshot
         """
         LOG.debug('Create volume %(volume)s from snapshot %(snapshot)s',
-                  {'volume': volume['name'],
-                   'snapshot': snapshot['name']})
-        volume['provider_location'] = '%s:/%s/%s' % (
-            self.nas_host, self.share, volume['name'])
-        pool, fs = self._get_share_datasets(self.share)
-        fs_path = '%2F'.join([pool, fs, snapshot['volume_name']])
-        url = ('storage/snapshots/%s/clone') % (
-            '@'.join([fs_path, snapshot['name']]))
-        path = '/'.join([pool, fs, volume['name']])
-        data = {'targetPath': path}
-        self.nef.post(url, data)
-
-        self.nef.post(
-            'storage/filesystems/%s/unmount' % urllib.parse.quote_plus(path))
-        self.nef.post(
-            'storage/filesystems/%s/mount' % urllib.parse.quote_plus(path))
-        dataset_path = '%s/%s' % (pool, fs)
-        try:
-            self._share_folder(fs, volume['name'])
-
-        except exception.NexentaException as ex:
-            try:
-                url = ('storage/filesystems/') % (
-                    '%2F'.join([pool, fs, volume['name']]))
-                self.nef.delete(url)
-            except exception.NexentaException:
-                LOG.warning('Cannot destroy cloned filesystem: '
-                            '%(volume)s/%(filesystem)s',
-                            {'volume': dataset_path,
-                             'filesystem': volume['name']})
-            raise ex
+                  {'volume': volume['name'], 'snapshot': snapshot['name']})
+        snapshot_path = self._get_snapshot_path(snapshot)
+        clone_path = self._get_volume_path(volume)
+        payload = {'targetPath': clone_path}
+        self.nef.snapshots.clone(snapshot_path, payload)
+        self.nef.filesystems.unmount(clone_path)
+        self.nef.filesystems.mount(clone_path)
+        self._set_volume_acl(volume)
         if volume['size'] > snapshot['volume_size']:
             new_size = volume['size']
             volume['size'] = snapshot['volume_size']
             self.extend_volume(volume, new_size)
             volume['size'] = new_size
-        return {'provider_location': volume['provider_location']}
 
     def create_cloned_volume(self, volume, src_vref):
         """Creates a clone of the specified volume.
@@ -666,32 +537,32 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: new volume reference
         :param src_vref: source volume reference
         """
-        snapshot_name = self._get_clone_snapshot_name(volume['id'])
+        snapshot_name = self._get_clone_snapshot_name(volume)
         snapshot = {'name': snapshot_name,
-                    'volume_name': src_vref['name'],
                     'volume_id': src_vref['id'],
+                    'volume_name': src_vref['name'],
                     'volume_size': src_vref['size']}
-        LOG.debug('Create temporary snapshot %(snapshot)s '
-                  'for the original volume %(volume)s',
-                  {'snapshot': snapshot['name'],
-                   'volume': snapshot['volume_name']})
         self.create_snapshot(snapshot)
         try:
-            pl = self.create_volume_from_snapshot(volume, snapshot)
-            return pl
-        except exception.NexentaException as ex:
-            LOG.debug('Volume creation failed, deleting temporary '
-                      'snapshot %(volume)s@%(snapshot)s',
-                      {'volume': snapshot['volume_name'],
+            return self.create_volume_from_snapshot(volume, snapshot)
+        except NefException as volume_error:
+            LOG.debug('Failed to create cloned volume: '
+                      '%(error)s. Delete temporary snapshot '
+                      '%(volume)s@%(snapshot)s',
+                      {'error': volume_error,
+                       'volume': snapshot['volume_name'],
                        'snapshot': snapshot['name']})
             try:
                 self.delete_snapshot(snapshot)
-            except (exception.NexentaException, exception.SnapshotIsBusy):
+            except NefException as snapshot_error:
                 LOG.debug('Failed to delete temporary snapshot '
-                          '%(volume)s@%(snapshot)s',
+                          '%(volume)s@%(snapshot)s: %(error)s',
                           {'volume': snapshot['volume_name'],
-                           'snapshot': snapshot['name']})
-            raise ex
+                           'snapshot': snapshot['name'],
+                           'error': snapshot_error})
+            raise volume_error
+        snapshot_path = self._get_snapshot_path(snapshot)
+        self._delete_snapshot(snapshot_path)
 
     def create_consistencygroup(self, context, group):
         """Creates a consistencygroup.
@@ -733,6 +604,13 @@ class NexentaNfsDriver(nfs.NfsDriver):
         remove_volumes_update = []
         return group_model_update, add_volumes_update, remove_volumes_update
 
+    @coordination.synchronized('{self.lock}')
+    def _rename_cgsnapshot(self, cgsnapshot, snapshot):
+        path = '%s/%s@%s' % (self.root_path, snapshot['volume_name'],
+                             self._get_cgsnapshot_name(cgsnapshot))
+        payload = {'newName': snapshot['name']}
+        self.nef.snapshots.rename(path, payload)
+
     def create_cgsnapshot(self, context, cgsnapshot, snapshots):
         """Creates a consistency group snapshot.
 
@@ -743,19 +621,12 @@ class NexentaNfsDriver(nfs.NfsDriver):
         """
         group_model_update = {}
         snapshots_model_update = []
-        cgsnapshot_name = 'cgsnapshot-%s' % cgsnapshot['id']
-        cgsnapshot_path = '%s@%s' % (self.share, cgsnapshot_name)
-        url = 'storage/snapshots'
-        data = {'path': cgsnapshot_path, 'recursive': True}
-        self.nef.post(url, data)
+        path = self._get_cgsnapshot_path(cgsnapshot)
+        payload = {'path': path, 'recursive': True}
+        self.nef.snapshots.create(payload)
         for snapshot in snapshots:
-            dataset_path = self._get_dataset_path(snapshot['volume_name'])
-            snapshot_path = '%s@%s' % (dataset_path, cgsnapshot_name)
-            url = 'storage/snapshots/%s/rename' % (
-                urllib.parse.quote_plus(snapshot_path))
-            data = {'newName': snapshot['name']}
-            self.nef.post(url, data)
-        self._delete_snapshot(cgsnapshot_path, True)
+            self._rename_cgsnapshot(cgsnapshot, snapshot)
+        self._delete_snapshot(path, True)
         return group_model_update, snapshots_model_update
 
     def delete_cgsnapshot(self, context, cgsnapshot, snapshots):
@@ -792,63 +663,44 @@ class NexentaNfsDriver(nfs.NfsDriver):
             for volume, snapshot in zip(volumes, snapshots):
                 self.create_volume_from_snapshot(volume, snapshot)
         elif source_cg and source_vols:
-            cgsnapshot_name = 'cgsnapshot-%s' % group['id']
-            cgsnapshot_path = '%s@%s' % (self.share, cgsnapshot_name)
-            url = 'storage/snapshots'
-            data = {'path': cgsnapshot_path, 'recursive': True}
-            self.nef.post(url, data)
+            path = self._get_cgsnapshot_path(group)
+            payload = {'path': path, 'recursive': True}
+            self.nef.snapshots.create(payload)
             for volume, source_vol in zip(volumes, source_vols):
-                source_path = self._get_dataset_path(source_vol['name'])
-                snapshot_path = '%s@%s' % (source_path, cgsnapshot_name)
-                snapshot_name = self._get_clone_snapshot_name(volume['id'])
-                url = 'storage/snapshots/%s/rename' % (
-                    urllib.parse.quote_plus(snapshot_path))
-                data = {'newName': snapshot_name}
-                self.nef.post(url, data)
+                snapshot_name = self._get_clone_snapshot_name(volume)
                 snapshot = {'name': snapshot_name,
                             'volume_id': source_vol['id'],
                             'volume_name': source_vol['name'],
                             'volume_size': source_vol['size']}
+                self._rename_cgsnapshot(group, snapshot)
                 self.create_volume_from_snapshot(volume, snapshot)
-            self._delete_snapshot(cgsnapshot_path, True)
+            self._delete_snapshot(path, True)
         return group_model_update, volumes_model_update
 
-    def _get_share_path(self, nas_host, share, volume_name):
-        url = 'storage/filesystems/%s' % urllib.parse.quote_plus(
-            '%s/%s' % (share, volume_name))
-        return '%s:%s' % (nas_host, self.nef.get(url)['mountPoint'])
+    def _local_volume_dir(self, volume):
+        """Get volume dir (mounted locally fs path) for given volume.
+
+        :param volume: volume reference
+        """
+        share = self._get_volume_share(volume)
+        path = hashlib.md5(share).hexdigest()
+        return os.path.join(self.mount_point_base, path)
 
     def local_path(self, volume):
         """Get volume path (mounted locally fs path) for given volume.
 
         :param volume: volume reference
         """
-        share_path = self._get_share_path(
-            self.nas_host, self.share, volume['name'])
-        return os.path.join(self._get_mount_point_for_share(share_path),
-                            'volume')
+        volume_dir = self._local_volume_dir(volume)
+        return os.path.join(volume_dir, 'volume')
 
-    def _get_mount_point_for_share(self, nfs_share):
-        """Returns path to mount point NFS share.
+    def _set_volume_acl(self, volume):
+        """Sets access permissions for given volume.
 
-        :param nfs_share: example 172.18.194.100:/var/nfs
+        :param volume: volume reference
         """
-        nfs_share = nfs_share.encode('utf-8')
-        return os.path.join(self.configuration.nexenta_mount_point_base,
-                            hashlib.md5(nfs_share).hexdigest())
-
-    def _share_folder(self, path, filesystem):
-        """Share NFS filesystem on NexentaStor Appliance.
-
-        :param path: path to parent filesystem
-        :param filesystem: filesystem that needs to be shared
-        """
-        pool = self.share.split('/')[0]
-        LOG.debug('Creating ACL for filesystem %(filesystem)s',
-                  {'filesystem': filesystem})
-        url = 'storage/filesystems/%s/acl' % (
-            '%2F'.join([pool, urllib.parse.quote_plus(path), filesystem]))
-        data = {
+        volume_path = self._get_volume_path(volume)
+        payload = {
             "type": "allow",
             "principal": "everyone@",
             "permissions": [
@@ -875,65 +727,73 @@ class NexentaNfsDriver(nfs.NfsDriver):
                 "dir_inherit"
             ]
         }
-        self.nef.post(url, data)
-        LOG.debug('Successfully shared filesystem %(path)s/%(filesystem)s',
-                  {'path': path,
-                   'filesystem': filesystem})
+        self.nef.filesystems.acl(volume_path, payload)
 
-    def _get_capacity_info(self, path):
-        """Calculate available space on the NFS share.
+    def _get_volume_share(self, volume):
+        """Return NFS share path for the volume."""
+        return '%s:%s/%s' % (self.nas_host,
+                             self.root_mount_point,
+                             volume['name'])
 
-        :param path: example pool/nfs
-        """
-        pool, fs = self._get_share_datasets(path)
-        url = 'storage/filesystems/%s' % '%2F'.join([pool, fs])
-        data = self.nef.get(url)
-        free = utils.str2size(data['bytesAvailable'])
-        allocated = utils.str2size(data['bytesUsed'])
-        total = free + allocated
-        return total, free, allocated
+    def _get_volume_path(self, volume):
+        """Return ZFS dataset path for the volume."""
+        return '%s/%s' % (self.root_path, volume['name'])
 
-    def _get_share_datasets(self, nfs_share):
-        pool_name, fs = nfs_share.split('/', 1)
-        return pool_name, urllib.parse.quote_plus(fs)
+    def _get_snapshot_path(self, snapshot):
+        """Return ZFS snapshot path for the snapshot."""
+        return '%s/%s@%s' % (self.root_path,
+                             snapshot['volume_name'],
+                             snapshot['name'])
 
-    def _get_dataset_path(self, volume_name):
-        """Returns ZFS dataset path for a volume."""
-        return '%s/%s' % (self.share, volume_name)
+    def _get_cgsnapshot_path(self, cgsnapshot):
+        """Return ZFS snapshot path for the consistency group snapshot."""
+        snapshot_name = self._get_cgsnapshot_name(cgsnapshot)
+        return '%s@%s' % (self.root_path, snapshot_name)
 
     @staticmethod
-    def _get_clone_snapshot_name(volume_id):
-        """Return name for snapshot that will be used to clone the volume."""
-        return 'cinder-clone-snapshot-%s' % volume_id
+    def _get_clone_snapshot_name(volume):
+        """Return snapshot name that will be used to clone the volume."""
+        return 'cinder-clone-snapshot-%s' % volume['id']
 
-    def _is_clone_snapshot_name(self, snapshot):
-        """Check if snapshot is created for cloning."""
-        name = snapshot.split('@')[-1]
-        return name.startswith('cinder-clone-snapshot-')
+    @staticmethod
+    def _get_cgsnapshot_name(cgsnapshot):
+        """Return cgsnapshot name for the consistency group snapshot."""
+        return 'cgsnapshot-%s' % cgsnapshot['id']
+
+    def get_volume_stats(self, refresh=False):
+        """Get volume stats.
+
+        If 'refresh' is True, update the stats first.
+        """
+        if refresh or not self._stats:
+            self._update_volume_stats()
+
+        return self._stats
 
     def _update_volume_stats(self):
-        """Retrieve stats info for NexentaStor appliance."""
+        """Retrieve stats info for NexentaStor Appliance."""
         LOG.debug('Updating volume stats')
-        total, free, allocated = self._get_capacity_info(self.share)
-        total_space = utils.str2gib_size(total)
-        free_space = utils.str2gib_size(free)
-        share = ':/'.join([self.nas_host, self.share])
-
+        payload = {'fields': 'bytesAvailable,bytesUsed'}
+        stats = self.nef.filesystems.get(self.root_path, payload)
+        free = stats['bytesAvailable'] // units.Gi
+        allocated = stats['bytesUsed'] // units.Gi
+        share = '%s:%s' % (self.nas_host, self.root_mount_point)
         location_info = '%(driver)s:%(share)s' % {
             'driver': self.__class__.__name__,
             'share': share
         }
         self._stats = {
             'vendor_name': 'Nexenta',
+            'dedup': self.dataset_deduplication,
             'compression': self.dataset_compression,
             'description': self.dataset_description,
-            'nef_url': self.nef_host,
-            'nef_port': self.nef_port,
+            'nef_url': self.nef.host,
+            'nef_port': self.nef.port,
             'driver_version': self.VERSION,
             'storage_protocol': 'NFS',
-            'sparsed_volumes': self.sparsed_volumes,
-            'total_capacity_gb': total_space,
-            'free_capacity_gb': free_space,
+            'sparsed_volumes': self.dataset_sparsed,
+            'total_capacity_gb': free + allocated,
+            'free_capacity_gb': free,
             'reserved_percentage': self.configuration.reserved_percentage,
             'QoS_support': False,
             'consistencygroup_support': True,
@@ -941,5 +801,5 @@ class NexentaNfsDriver(nfs.NfsDriver):
             'multiattach': True,
             'location_info': location_info,
             'volume_backend_name': self.backend_name,
-            'nfs_mount_point_base': self.nfs_mount_point_base
+            'nfs_mount_point_base': self.mount_point_base
         }

--- a/cinder/volume/drivers/nexenta/options.py
+++ b/cinder/volume/drivers/nexenta/options.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -14,10 +14,8 @@
 #    under the License.
 
 from oslo_config import cfg
-
 from cinder.volume import configuration as conf
 
-POLL_RETRIES = 5
 DEFAULT_ISCSI_PORT = 3260
 DEFAULT_HOST_GROUP = 'all'
 DEFAULT_TARGET_GROUP = 'all'
@@ -63,31 +61,53 @@ NEXENTA_EDGE_OPTS = [
 ]
 
 NEXENTA_CONNECTION_OPTS = [
+    cfg.StrOpt('nexenta_host',
+               default='',
+               help='IP address of NexentaStor Appliance'),
     cfg.StrOpt('nexenta_rest_address',
                deprecated_for_removal=True,
                deprecated_reason='Rest address should now be set using '
                                  'the common param depending on driver type, '
                                  'san_ip or nas_host',
                default='',
-               help='IP address of NexentaEdge management REST API endpoint'),
-    cfg.StrOpt('nexenta_host',
-               default='',
-               help='IP address of Nexenta SA'),
+               help='IP address of NexentaStor management REST API endpoint'),
     cfg.IntOpt('nexenta_rest_port',
                deprecated_for_removal=True,
                deprecated_reason='Rest address should now be set using '
                                  'the common param san_api_port.',
                default=0,
-               help='HTTP(S) port to connect to Nexenta REST API server. '
-                    'If it is equal zero, 8443 for HTTPS and 8080 for HTTP '
-                    'is used'),
+               help='HTTP(S) port to connect to NexentaStor management '
+                    'REST API server. If it is equal zero, 8443 for '
+                    'HTTPS and 8080 for HTTP is used'),
     cfg.StrOpt('nexenta_rest_protocol',
                default='auto',
                choices=['http', 'https', 'auto'],
-               help='Use http or https for REST connection (default auto)'),
+               help='Use http or https for NexentaStor management '
+                    'REST API connection (default auto)'),
+    cfg.FloatOpt('nexenta_rest_connect_timeout',
+                 default=30,
+                 help='Specifies the time limit (in seconds), within '
+                      'which the connection to NexentaStor management '
+                      'REST API server must be established'),
+    cfg.FloatOpt('nexenta_rest_read_timeout',
+                 default=300,
+                 help='Specifies the time limit (in seconds), '
+                      'within which NexentaStor management '
+                      'REST API server must send a response'),
+    cfg.FloatOpt('nexenta_rest_backoff_factor',
+                 default=1,
+                 help='Specifies the backoff factor to apply '
+                      'between connection attempts to NexentaStor '
+                      'management REST API server'),
+    cfg.IntOpt('nexenta_rest_retry_count',
+               default=5,
+               help='Specifies the number of times to repeat NexentaStor '
+                    'management REST API call in case of connection errors '
+                    'and NexentaStor appliance EBUSY or ENOENT errors'),
     cfg.BoolOpt('nexenta_use_https',
                 default=True,
-                help='Use secure HTTP for REST connection (default True)'),
+                help='Use HTTP secure protocol for NexentaStor '
+                     'management REST API connections'),
     cfg.BoolOpt('nexenta_lu_writebackcache_disabled',
                 default=False,
                 help='Postponed write to backing store or not'),
@@ -97,21 +117,23 @@ NEXENTA_CONNECTION_OPTS = [
                                  'depending on the driver type: '
                                  'san_login or nas_login',
                default='admin',
-               help='User name to connect to Nexenta SA'),
+               help='User name to connect to NexentaStor '
+                    'management REST API server'),
     cfg.StrOpt('nexenta_password',
                deprecated_for_removal=True,
                deprecated_reason='Common password parameters should be used '
                                  'depending on the driver type: '
                                  'san_password or nas_password',
                default='nexenta',
-               help='Password to connect to Nexenta SA',
-               secret=True),
+               help='Password to connect to NexentaStor '
+                    'management REST API server',
+               secret=True)
 ]
 
 NEXENTA_ISCSI_OPTS = [
     cfg.StrOpt('nexenta_iscsi_target_portal_groups',
                default='',
-               help='Nexenta target portal groups'),
+               help='NexentaStor target portal groups'),
     cfg.StrOpt('nexenta_iscsi_target_portals',
                default='',
                help='Comma separated list of portals for NexentaStor5, in'
@@ -122,22 +144,22 @@ NEXENTA_ISCSI_OPTS = [
                help='Group of hosts which are allowed to access volumes'),
     cfg.IntOpt('nexenta_iscsi_target_portal_port',
                default=3260,
-               help='Nexenta target portal port'),
+               help='Nexenta appliance iSCSI target portal port'),
     cfg.IntOpt('nexenta_luns_per_target',
                default=100,
-               help='Amount of iSCSI LUNs per each target'),
+               help='Amount of LUNs per iSCSI target'),
     cfg.StrOpt('nexenta_volume',
                default='cinder',
-               help='SA Pool that holds all volumes'),
+               help='NexentaStor pool name that holds all volumes'),
     cfg.StrOpt('nexenta_target_prefix',
                default='iqn.1986-03.com.sun:02:cinder',
-               help='IQN prefix for iSCSI targets'),
+               help='iqn prefix for NexentaStor iSCSI targets'),
     cfg.StrOpt('nexenta_target_group_prefix',
                default='cinder',
-               help='Prefix for iSCSI target groups on SA'),
+               help='Prefix for iSCSI target groups on NexentaStor'),
     cfg.StrOpt('nexenta_host_group_prefix',
                default='cinder',
-               help='Prefix for iSCSI host groups on SA'),
+               help='Prefix for iSCSI host groups on NexentaStor'),
     cfg.StrOpt('nexenta_volume_group',
                default='iscsi',
                help='Volume group for NexentaStor5 iSCSI'),


### PR DESCRIPTION
- Added pagination support.
- Added configuration parameters for REST API connect/read
  timeouts, connection retries and backoff factor.
- Fixed HA failover.
- Added retries on EBUSY errors.
- Fixed HTTP authentication.
- Disabled non-blocking mandatory locks.

pep8
```
pep8 run-test-pre: PYTHONHASHSEED='1540489231'
pep8 runtests: commands[0] | flake8 .
pep8 runtests: commands[1] | /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 runtests: commands[2] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder /opt/stack/cinder/doc/source/ /opt/stack/cinder/releasenotes/notes
___________________________________ summary ____________________________________
  pep8: commands succeeded
  congratulations :)
```

Tempest iSCSI
```
======
Totals
======
Ran: 273 tests in 4389.0000 sec.
 - Passed: 267
 - Skipped: 6
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3492.6979 sec.
```

Tempest NFS
```
======
Totals
======
Ran: 273 tests in 7428.0000 sec.
 - Passed: 266
 - Skipped: 7
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 6033.1749 sec.
```

pylint
```
stack@openstack-master-ns5-iscsi:~/cinder$ pylint cinder/volume/drivers/nexenta/ns5
Using config file /opt/stack/cinder/.pylintrc

------------------------------------
Your code has been rated at 10.00/10
```