### PR TITLE
NEX-19807 Nexenta Cinder driver: support for manage/unmanage volumes

### DIFF
--- a/cinder/tests/unit/volume/drivers/nexenta/test_nexenta.py
+++ b/cinder/tests/unit/volume/drivers/nexenta/test_nexenta.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -77,8 +77,11 @@ class TestNexentaISCSIDriver(test.TestCase):
         self.cfg.nexenta_iscsi_target_portal_port = 3260
         self.cfg.nexenta_target_prefix = 'iqn:cinder-'
         self.cfg.nexenta_target_group_prefix = 'cinder-'
+        self.cfg.nexenta_iscsi_target_portal_groups = 'cinder'
         self.cfg.nexenta_blocksize = '8K'
         self.cfg.nexenta_sparse = True
+        self.cfg.driver_ssl_cert_verify = False
+        self.cfg.nexenta_folder = 'nas'
         self.cfg.nexenta_dataset_compression = 'on'
         self.cfg.nexenta_dataset_dedup = 'off'
         self.cfg.nexenta_rrmgr_compression = 1
@@ -86,8 +89,9 @@ class TestNexentaISCSIDriver(test.TestCase):
         self.cfg.nexenta_rrmgr_connections = 2
         self.cfg.reserved_percentage = 20
         self.nms_mock = mock.Mock()
-        for mod in ['volume', 'zvol', 'iscsitarget', 'appliance',
-                    'stmf', 'scsidisk', 'snapshot']:
+        for mod in ['appliance', 'plugin', 'rsf_plugin',
+                    'volume', 'folder', 'zvol', 'stmf',
+                    'snapshot', 'scsidisk', 'iscsitarget']:
             setattr(self.nms_mock, mod, mock.Mock())
         self.mock_object(jsonrpc, 'NexentaJSONProxy',
                          return_value=self.nms_mock)
@@ -391,6 +395,7 @@ class TestNexentaNfsDriver(test.TestCase):
         self.cfg.nfs_mount_options = None
         self.cfg.nas_mount_options = None
         self.cfg.nexenta_nms_cache_volroot = False
+        self.cfg.driver_ssl_cert_verify = False
         self.cfg.nfs_mount_attempts = 3
         self.cfg.reserved_percentage = 20
         self.cfg.max_over_subscription_ratio = 20.0

--- a/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_iscsi.py
+++ b/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_iscsi.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -15,72 +15,47 @@
 """
 Unit tests for OpenStack Cinder volume driver
 """
-
-import mock
-from mock import patch
-from oslo_utils import units
 import uuid
 
-from six.moves import urllib
+from mock import Mock
+from mock import patch
+
+from oslo_utils import units
 
 from cinder import context
 from cinder import db
-from cinder import exception
 from cinder import test
+from cinder.tests.unit import fake_constants as fake
+from cinder.tests.unit.fake_snapshot import fake_snapshot_obj as fake_snapshot
+from cinder.tests.unit.fake_volume import fake_volume_obj as fake_volume
+from cinder.tests.unit.consistencygroup.fake_consistencygroup import (
+    fake_consistencyobject_obj as fake_cgroup)
+from cinder.tests.unit.consistencygroup.fake_cgsnapshot import (
+    fake_cgsnapshot_obj as fake_cgsnapshot)
 from cinder.volume import configuration as conf
 from cinder.volume.drivers.nexenta.ns5 import iscsi
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 
 
 class TestNexentaISCSIDriver(test.TestCase):
-    TEST_VOLUME_NAME = 'volume-1'
-    TEST_VOLUME_NAME2 = 'volume-2'
-    TEST_VOLUME_NAME3 = 'volume-3'
-    TEST_SNAPSHOT_NAME = 'snapshot-1'
-    TEST_VOLUME_REF = {
-        'name': TEST_VOLUME_NAME,
-        'size': 1,
-        'id': '1',
-        'status': 'available',
-        'volume_attachment': [{
-            'connector': {'initiator': 'iqn:test', 'multipath': True}}]
-    }
-    TEST_VOLUME_REF2 = {
-        'name': TEST_VOLUME_NAME2,
-        'size': 1,
-        'id': '2',
-        'status': 'in-use'
-    }
-    TEST_VOLUME_REF3 = {
-        'name': TEST_VOLUME_NAME3,
-        'size': 2,
-        'id': '2',
-        'status': 'in-use'
-    }
-    TEST_SNAPSHOT_REF = {
-        'name': TEST_SNAPSHOT_NAME,
-        'volume_name': TEST_VOLUME_NAME,
-        'volume_id': '1',
-        'volume_size': 1
-    }
-
-    def __init__(self, method):
-        super(TestNexentaISCSIDriver, self).__init__(method)
 
     def setUp(self):
         super(TestNexentaISCSIDriver, self).setUp()
-        self.cfg = mock.Mock(spec=conf.Configuration)
         self.ctxt = context.get_admin_context()
+        self.cfg = Mock(spec=conf.Configuration)
+        self.cfg.volume_backend_name = 'nexenta_iscsi'
+        self.cfg.nexenta_group_snapshot_template = 'group-snapshot-%s'
+        self.cfg.nexenta_origin_snapshot_template = 'origin-snapshot-%s'
         self.cfg.nexenta_dataset_description = ''
         self.cfg.nexenta_host = '1.1.1.1'
         self.cfg.nexenta_user = 'admin'
         self.cfg.nexenta_password = 'nexenta'
         self.cfg.nexenta_volume = 'cinder'
-        self.cfg.nexenta_rest_port = 2000
+        self.cfg.nexenta_rest_port = 8443
         self.cfg.nexenta_use_https = False
-        self.cfg.nexenta_iscsi_target_portal_port = 8080
+        self.cfg.nexenta_iscsi_target_portal_port = 3260
         self.cfg.nexenta_target_prefix = 'iqn:cinder'
-        self.cfg.nexenta_target_group_prefix = 'cinder-'
+        self.cfg.nexenta_target_group_prefix = 'cinder'
         self.cfg.nexenta_ns5_blocksize = 32
         self.cfg.nexenta_sparse = True
         self.cfg.nexenta_lu_writebackcache_disabled = True
@@ -92,200 +67,335 @@ class TestNexentaISCSIDriver(test.TestCase):
         self.cfg.driver_ssl_cert_verify = False
         self.cfg.nexenta_luns_per_target = 20
         self.cfg.driver_ssl_cert_verify = False
-        self.cfg.nexenta_iscsi_target_portals = ''
+        self.cfg.nexenta_iscsi_target_portals = '1.1.1.1:3260,2.2.2.2:3260'
         self.cfg.nexenta_iscsi_target_host_group = 'all'
         self.cfg.nexenta_rest_address = '1.1.1.1'
+        self.cfg.nexenta_rest_backoff_factor = 1
+        self.cfg.nexenta_rest_retry_count = 3
+        self.cfg.nexenta_rest_connect_timeout = 1
+        self.cfg.nexenta_rest_read_timeout = 1
         self.cfg.nexenta_volume_group = 'vg'
-        self.nef_mock = mock.Mock()
-        self.mock_object(jsonrpc, 'NexentaJSONProxy',
+        self.cfg.safe_get = self.fake_safe_get
+        self.nef_mock = Mock()
+        self.mock_object(jsonrpc, 'NefRequest',
                          return_value=self.nef_mock)
         self.drv = iscsi.NexentaISCSIDriver(
             configuration=self.cfg)
         self.drv.db = db
-        self.drv._fetch_volumes = lambda: None
         self.drv.do_setup(self.ctxt)
 
-    def _create_volume_db_entry(self):
-        vol = {
-            'id': '1',
-            'size': 1,
-            'status': 'available',
-            'provider_location': self.TEST_VOLUME_NAME
-        }
-        return db.volume_create(self.ctxt, vol)['id']
-
-    def test_do_setup(self):
-        self.nef_mock.post.side_effect = exception.NexentaException(
-            {"msg": "Could not create volume group", "code": "ENOENT"})
-        self.assertRaises(
-            exception.NexentaException,
-            self.drv.do_setup, self.ctxt)
-
-        self.nef_mock.post.side_effect = exception.NexentaException(
-            {"code": "EEXIST"})
-        self.assertIsNone(self.drv.do_setup(self.ctxt))
-
-    def test_check_for_setup_error(self):
-        def get_side_effect(*args, **kwargs):
-            if ('storage/pools' or 'storage/volumeGroups') in args[0]:
-                return {}
-            else:
-                return {'data': [{'name': 'iscsit', 'state': 'offline'}]}
-
-        self.nef_mock.get.side_effect = get_side_effect
-        self.assertRaises(
-            exception.NexentaException, self.drv.check_for_setup_error)
-
-    def test_create_volume(self):
-        self.drv.create_volume(self.TEST_VOLUME_REF)
-        url = 'storage/volumes'
-        path = '%s/%s' % (self.drv.dataset, self.TEST_VOLUME_NAME)
-        self.nef_mock.post.assert_called_with(url, {
-            'path': path,
-            'volumeSize': 1 * units.Gi,
-            'volumeBlockSize': 32768,
-            'sparseVolume': self.cfg.nexenta_sparse})
-
-    def test_delete_volume(self):
-        self.nef_mock.get.return_value = {
-            'data': [{'originalSnapshot': 'clone-1'}]}
-        self.assertIsNone(self.drv.delete_volume(self.TEST_VOLUME_REF))
-
-    def test_extend_volume(self):
-        self.drv.extend_volume(self.TEST_VOLUME_REF, 2)
-        path = '%s/%s' % (self.drv.dataset, self.TEST_VOLUME_NAME)
-        url = 'storage/volumes/%s' % urllib.parse.quote_plus(path)
-        self.nef_mock.put.assert_called_with(url, {
-            'volumeSize': 2 * units.Gi})
-
-    def test_delete_snapshot(self):
-        self._create_volume_db_entry()
-        self.nef_mock.get.return_value = {'data': ['volume']}
-        path = '%s/%s@%s' % (
-            self.drv.dataset, self.TEST_VOLUME_NAME,
-            self.TEST_SNAPSHOT_NAME)
-        params = {'recursive': False, 'defer': True}
-        url = 'storage/snapshots/%s?%s' % (
-            urllib.parse.quote_plus(path),
-            urllib.parse.urlencode(params))
-        self.drv.delete_snapshot(self.TEST_SNAPSHOT_REF)
-        self.nef_mock.delete.assert_called_with(url)
-
-    @patch('cinder.volume.drivers.nexenta.ns5.iscsi.'
-           'NexentaISCSIDriver.create_snapshot')
-    @patch('cinder.volume.drivers.nexenta.ns5.iscsi.'
-           'NexentaISCSIDriver.delete_snapshot')
-    @patch('cinder.volume.drivers.nexenta.ns5.iscsi.'
-           'NexentaISCSIDriver.create_volume_from_snapshot')
-    def test_create_cloned_volume(self, crt_vol, dlt_snap, crt_snap):
-        self._create_volume_db_entry()
-        vol = self.TEST_VOLUME_REF2
-        src_vref = self.TEST_VOLUME_REF
-        crt_vol.side_effect = exception.NexentaException(reason='error')
-        dlt_snap.side_effect = exception.NexentaException(reason='err2')
-        self.assertRaises(
-            exception.NexentaException,
-            self.drv.create_cloned_volume, vol, src_vref)
-
-    def test_create_snapshot(self):
-        self._create_volume_db_entry()
-        self.drv.create_snapshot(self.TEST_SNAPSHOT_REF)
-        url = 'storage/snapshots'
-        self.nef_mock.post.assert_called_with(
-            url, {'path': '%s/%s@%s' % (
-                self.drv.dataset, self.TEST_VOLUME_NAME,
-                self.TEST_SNAPSHOT_NAME)})
-
-    def test_create_larger_volume_from_snapshot(self):
-        self._create_volume_db_entry()
-        vol = self.TEST_VOLUME_REF3
-        src_vref = self.TEST_SNAPSHOT_REF
-
-        self.drv.create_volume_from_snapshot(vol, src_vref)
-
-        path = '%s/%s' % (self.drv.dataset, self.TEST_VOLUME_NAME3)
-        # make sure the volume get extended!
-        url = 'storage/volumes/%s' % urllib.parse.quote_plus(path)
-        self.nef_mock.put.assert_called_with(url, {
-            'volumeSize': 2 * units.Gi})
+    def fake_safe_get(self, key):
+        try:
+            value = getattr(self.cfg, key)
+        except AttributeError:
+            value = None
+        return value
 
     def fake_uuid4():
         return uuid.UUID('38d18a48-b791-4046-b523-a84aad966310')
 
+    def test_do_setup(self):
+        self.assertIsNone(self.drv.do_setup(self.ctxt))
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefServices.get')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefVolumeGroups.create')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefVolumeGroups.get')
+    def test_check_for_setup_error(self, volume_group_get,
+                                   volume_group_create,
+                                   service_get):
+        path = self.drv.root_path
+        bs = self.cfg.nexenta_ns5_blocksize * units.Ki
+        name = 'iscsit'
+        state = 'online'
+        volume_group_get.return_value = {'path': path}
+        service_get.return_value = {'name': name, 'state': state}
+        self.assertIsNone(self.drv.check_for_setup_error())
+        volume_group_get.assert_called_with(path)
+        service_get.assert_called_with(name)
+
+        volume_group_get.side_effect = jsonrpc.NefException({
+            'message': 'Failed to open dataset',
+            'code': 'ENOENT'
+        })
+        volume_group_create.return_value = {}
+        self.assertIsNone(self.drv.check_for_setup_error())
+        volume_group_get.assert_called_with(path)
+        payload = {'path': path, 'volumeBlockSize': bs}
+        volume_group_create.assert_called_with(payload)
+        service_get.assert_called_with(name)
+
+        state = 'offline'
+        volume_group_get.return_value = {'path': path}
+        service_get.return_value = {'name': name, 'state': state}
+        self.assertRaises(jsonrpc.NefException,
+                          self.drv.check_for_setup_error)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefVolumes.create')
+    def test_create_volume(self, create_volume):
+        volume = fake_volume(self.ctxt)
+        self.assertIsNone(self.drv.create_volume(volume))
+        path = self.drv._get_volume_path(volume)
+        size = volume['size'] * units.Gi
+        bs = self.cfg.nexenta_ns5_blocksize * units.Ki
+        payload = {
+            'path': path,
+            'volumeSize': size,
+            'volumeBlockSize': bs,
+            'compressionMode': self.cfg.nexenta_dataset_compression,
+            'sparseVolume': self.cfg.nexenta_sparse
+        }
+        create_volume.assert_called_with(payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefVolumes.delete')
+    def test_delete_volume(self, delete_volume):
+        volume = fake_volume(self.ctxt)
+        self.assertIsNone(self.drv.delete_volume(volume))
+        path = self.drv._get_volume_path(volume)
+        payload = {'snapshots': True}
+        delete_volume.assert_called_with(path, payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefVolumes.set')
+    def test_extend_volume(self, extend_volume):
+        volume = fake_volume(self.ctxt)
+        size = volume['size'] * 2
+        self.assertIsNone(self.drv.extend_volume(volume, size))
+        path = self.drv._get_volume_path(volume)
+        size = size * units.Gi
+        payload = {'volumeSize': size}
+        extend_volume.assert_called_with(path, payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.delete')
+    def test_delete_snapshot(self, delete_snapshot):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        delete_snapshot.return_value = {}
+        self.assertIsNone(self.drv.delete_snapshot(snapshot))
+        path = self.drv._get_snapshot_path(snapshot)
+        payload = {'defer': True}
+        delete_snapshot.assert_called_with(path, payload)
+
+    def test_snapshot_revert_use_temp_snapshot(self):
+        result = self.drv.snapshot_revert_use_temp_snapshot()
+        expected = False
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefVolumes.rollback')
+    def test_revert_to_snapshot(self, rollback_volume):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        rollback_volume.return_value = {}
+        self.assertIsNone(
+            self.drv.revert_to_snapshot(self.ctxt, volume, snapshot)
+        )
+        path = self.drv._get_volume_path(volume)
+        payload = {'snapshot': snapshot['name']}
+        rollback_volume.assert_called_with(path, payload)
+
     @patch('cinder.volume.drivers.nexenta.ns5.iscsi.'
-           'NexentaISCSIDriver._create_target_group')
+           'NexentaISCSIDriver.delete_snapshot')
     @patch('cinder.volume.drivers.nexenta.ns5.iscsi.'
-           'NexentaISCSIDriver._create_target')
+           'NexentaISCSIDriver.create_volume_from_snapshot')
     @patch('cinder.volume.drivers.nexenta.ns5.iscsi.'
-           'NexentaISCSIDriver._target_group_props')
-    @patch('cinder.volume.drivers.nexenta.ns5.iscsi.'
-           'NexentaISCSIDriver._get_host_portals')
-    @patch('cinder.volume.drivers.nexenta.ns5.iscsi.'
-           'NexentaISCSIDriver._get_host_group')
+           'NexentaISCSIDriver.create_snapshot')
+    def test_create_cloned_volume(self, create_snapshot, create_volume,
+                                  delete_snapshot):
+        volume = fake_volume(self.ctxt)
+        clone_spec = {'id': fake.VOLUME2_ID}
+        clone = fake_volume(self.ctxt, **clone_spec)
+        create_snapshot.return_value = {}
+        create_volume.return_value = {}
+        delete_snapshot.return_value = {}
+        self.assertIsNone(self.drv.create_cloned_volume(clone, volume))
+        snapshot = {
+            'name': self.drv.origin_snapshot_template % clone['id'],
+            'volume_id': volume['id'],
+            'volume_name': volume['name'],
+            'volume_size': volume['size']
+        }
+        create_snapshot.assert_called_with(snapshot)
+        create_volume.assert_called_with(clone, snapshot)
+        create_volume.side_effect = jsonrpc.NefException({
+            'message': 'Failed to create volume',
+            'code': 'EBUSY'
+        })
+        self.assertRaises(jsonrpc.NefException,
+                          self.drv.create_cloned_volume,
+                          clone, volume)
+        create_snapshot.side_effect = jsonrpc.NefException({
+            'message': 'Failed to open dataset',
+            'code': 'ENOENT'
+        })
+        self.assertRaises(jsonrpc.NefException,
+                          self.drv.create_cloned_volume,
+                          clone, volume)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.create')
+    def test_create_snapshot(self, create_snapshot):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        create_snapshot.return_value = {}
+        self.assertIsNone(self.drv.create_snapshot(snapshot))
+        path = self.drv._get_snapshot_path(snapshot)
+        payload = {'path': path}
+        create_snapshot.assert_called_with(payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver.extend_volume')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.clone')
+    def test_create_volume_from_snapshot(self, clone_snapshot,
+                                         extend_volume):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        clone_size = 10
+        clone_spec = {
+            'id': fake.VOLUME2_ID,
+            'size': clone_size
+        }
+        clone = fake_volume(self.ctxt, **clone_spec)
+        snapshot_path = self.drv._get_snapshot_path(snapshot)
+        clone_path = self.drv._get_volume_path(clone)
+        clone_snapshot.return_value = {}
+        extend_volume.return_value = None
+        self.assertIsNone(
+            self.drv.create_volume_from_snapshot(clone, snapshot)
+        )
+        clone_payload = {'targetPath': clone_path}
+        clone_snapshot.assert_called_with(snapshot_path, clone_payload)
+        extend_volume.assert_called_with(clone, clone_size)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefLunMappings.list')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver._create_target_group')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver._create_target')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver._target_group_props')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver._get_host_portals')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver._get_host_group')
     @patch('uuid.uuid4', fake_uuid4)
-    def test_initialize_connection(
-            self, get_hg, get_hp, tg_props, create_t, create_tg):
-        get_hp.return_value = ['portal1', 'portal2']
-        target_name = 'iqn:cinder-%s' % '38d18a48b7914046b523a84aad966310'
-        lun = 0
+    def test_initialize_connection(self, get_host_group, get_host_portals,
+                                   get_target_group_props, create_target,
+                                   create_target_group, list_mappings):
+        volume = fake_volume(self.ctxt)
+        host_iqn = 'iqn:cinder-client'
+        target_iqn = 'iqn:cinder-target'
+        connector = {'initiator': host_iqn, 'multipath': True}
+        host_group = 'cinder-host-group'
+        target_group = 'cinder-target-group'
+        target_portals = self.cfg.nexenta_iscsi_target_portals.split(',')
+        get_host_group.return_value = host_group
+        get_host_portals.return_value = {
+            target_iqn: target_portals
+        }
+        list_mappings.return_value = [{
+            'id': '309F9B9013CF627A00000000',
+            'lun': 0,
+            'hostGroup': host_group,
+            'targetGroup': target_group
+        }]
+        get_target_group_props.return_value = {
+            target_iqn: target_portals
+        }
+        create_target.return_value = {}
+        create_target_group.return_value = {}
+        result = self.drv.initialize_connection(volume, connector)
+        expected = {
+            'driver_volume_type': 'iscsi',
+            'data': {
+                'target_discovered': False,
+                'encrypted': False,
+                'qos_specs': None,
+                'target_luns': [0] * len(target_portals),
+                'access_mode': 'rw',
+                'volume_id': volume['id'],
+                'target_portals': target_portals,
+                'target_iqns': [target_iqn] * len(target_portals)
+            }
+        }
+        self.assertEqual(expected, result)
 
-        class GetSideEffect(object):
-            def __init__(self):
-                self.lm_counter = -1
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefLunMappings.delete')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefLunMappings.list')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver._get_host_group')
+    def test_terminate_connection(self, get_host_group,
+                                  list_mappings, delete_mapping):
+        volume = fake_volume(self.ctxt)
+        host_group = 'cinder-host-group'
+        target_group = 'cinder-target-group'
+        connector = {'initiator': 'iqn:test'}
+        get_host_group.return_value = host_group
+        list_mappings.return_value = [{
+            'id': '309F9B9013CF627A00000000',
+            'lun': 0,
+            'hostGroup': host_group,
+            'targetGroup': target_group
+        }]
+        delete_mapping.return_value = {}
+        expected = {'driver_volume_type': 'iscsi', 'data': {}}
+        result = self.drv.terminate_connection(volume, connector)
+        self.assertEqual(expected, result)
 
-            def __call__(self, *args, **kwargs):
-                # Find out whether the volume is exported
-                if 'san/lunMappings' in args[0]:
-                    self.lm_counter += 1
-                    # a value for the first call
-                    if self.lm_counter == 0:
-                        return {'data': []}
-                    else:
-                        return {'data': [{'lun': lun}]}
-                # Get the name of just created target
-                elif 'san/iscsi/targets' in args[0]:
-                    return {'data': [{'name': target_name}]}
-                elif 'san/targetgroups' in args[0]:
-                    return {'data': [
-                        {'name': 'cinder-tg-1', 'members': [target_name]}]}
+    def test_create_export(self):
+        volume = fake_volume(self.ctxt)
+        connector = {'initiator': 'iqn:test'}
+        self.assertIsNone(
+            self.drv.create_export(self.ctxt, volume, connector)
+        )
 
-        def post_side_effect(*args, **kwargs):
-            if 'san/iscsi/targets' in args[0]:
-                return {'data': [{'name': target_name}]}
+    def test_ensure_export(self):
+        volume = fake_volume(self.ctxt)
+        self.assertIsNone(
+            self.drv.ensure_export(self.ctxt, volume)
+        )
 
-        self.nef_mock.get.side_effect = GetSideEffect()
-        self.nef_mock.post.side_effect = post_side_effect
-        res = self.drv.initialize_connection(
-            self.TEST_VOLUME_REF, {'initiator': 'iqn:test', 'multipath': True})
-        expected = {'data': {
-            'access_mode': 'rw',
-            'encrypted': False,
-            'qos_specs': None,
-            'target_discovered': False,
-            'target_iqns': ['iqn:cinder-38d18a48b7914046b523a84aad966310',
-                            'iqn:cinder-38d18a48b7914046b523a84aad966310'],
-            'target_luns': [0, 0],
-            'target_portals': ['portal1', 'portal2'],
-            'volume_id': '1'}, 'driver_volume_type': 'iscsi'}
-        self.assertEqual(expected, res)
+    def test_remove_export(self):
+        volume = fake_volume(self.ctxt)
+        self.assertIsNone(
+            self.drv.remove_export(self.ctxt, volume)
+        )
 
-    @patch('cinder.volume.drivers.nexenta.ns5.iscsi.'
-           'NexentaISCSIDriver._get_host_group')
-    def test_terminate_connection(self, get_hg):
-        mapping_id = '1234567890'
-        self.nef_mock.get.return_value = {'data': [{'id': mapping_id}]}
-        retval = {'driver_volume_type': 'iscsi', 'data': {}}
-        self.assertEqual(
-            retval, self.drv.terminate_connection(
-                self.TEST_VOLUME_REF,
-                {}))
-        url = 'san/lunMappings/%s' % mapping_id
-        self.nef_mock.delete.assert_called_with(url)
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefVolumeGroups.get')
+    def test_get_volume_stats(self, get_volume_group):
+        available = 100
+        used = 75
+        get_volume_group.return_value = {
+            'bytesAvailable': available * units.Gi,
+            'bytesUsed': used * units.Gi
+        }
+        result = self.drv.get_volume_stats(True)
+        payload = {'fields': 'bytesAvailable,bytesUsed'}
+        get_volume_group.assert_called_with(self.drv.root_path, payload)
+        self.assertEqual(self.drv._stats, result)
 
-    def test_update_volume_stats(self):
-        self.nef_mock.get.return_value = {
-            'bytesAvailable': 8 * units.Gi,
-            'bytesUsed': 2 * units.Gi
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefVolumeGroups.get')
+    def test_update_volume_stats(self, get_volume_group):
+        available = 8
+        used = 2
+        get_volume_group.return_value = {
+            'bytesAvailable': available * units.Gi,
+            'bytesUsed': used * units.Gi
         }
         location_info = '%(driver)s:%(host)s:%(pool)s/%(group)s' % {
             'driver': self.drv.__class__.__name__,
@@ -293,26 +403,637 @@ class TestNexentaISCSIDriver(test.TestCase):
             'pool': self.cfg.nexenta_volume,
             'group': self.cfg.nexenta_volume_group,
         }
-        stats = {
+        expected = {
             'vendor_name': 'Nexenta',
             'dedup': self.cfg.nexenta_dataset_dedup,
             'compression': self.cfg.nexenta_dataset_compression,
-            'consistencygroup_support': True,
-            'consistent_group_snapshot_enabled': True,
             'description': self.cfg.nexenta_dataset_description,
             'driver_version': self.drv.VERSION,
             'storage_protocol': 'iSCSI',
-            'total_capacity_gb': 10,
-            'free_capacity_gb': 8,
-            'sparsed_volumes': True,
+            'sparsed_volumes': self.cfg.nexenta_sparse,
+            'total_capacity_gb': used + available,
+            'free_capacity_gb': available,
             'reserved_percentage': self.cfg.reserved_percentage,
             'QoS_support': False,
-            'volume_backend_name': self.drv.backend_name,
-            'location_info': location_info,
             'multiattach': True,
+            'consistencygroup_support': True,
+            'consistent_group_snapshot_enabled': True,
+            'volume_backend_name': self.cfg.volume_backend_name,
+            'location_info': location_info,
             'iscsi_target_portal_port': (
                 self.cfg.nexenta_iscsi_target_portal_port),
-            'nef_url': self.drv.nef.url
+            'nef_url': self.cfg.nexenta_rest_address,
+            'nef_port': self.cfg.nexenta_rest_port
         }
-        self.drv._update_volume_stats()
-        self.assertEqual(stats, self.drv._stats)
+        self.assertIsNone(self.drv._update_volume_stats())
+        self.assertEqual(expected, self.drv._stats)
+
+    def test__get_volume_path(self):
+        volume = fake_volume(self.ctxt)
+        result = self.drv._get_volume_path(volume)
+        expected = '%s/%s/%s' % (self.cfg.nexenta_volume,
+                                 self.cfg.nexenta_volume_group,
+                                 volume['name'])
+        self.assertEqual(expected, result)
+
+    def test__get_snapshot_path(self):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        result = self.drv._get_snapshot_path(snapshot)
+        expected = '%s/%s/%s@%s' % (self.cfg.nexenta_volume,
+                                    self.cfg.nexenta_volume_group,
+                                    snapshot['volume_name'],
+                                    snapshot['name'])
+        self.assertEqual(expected, result)
+
+    def test__get_target_group_name(self):
+        target_iqn = '%s-test' % self.cfg.nexenta_target_prefix
+        result = self.drv._get_target_group_name(target_iqn)
+        expected = '%s-test' % self.cfg.nexenta_target_group_prefix
+        self.assertEqual(expected, result)
+
+    def test__get_target_name(self):
+        target_group = '%s-test' % self.cfg.nexenta_target_group_prefix
+        result = self.drv._get_target_name(target_group)
+        expected = '%s-test' % self.cfg.nexenta_target_prefix
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefNetAddresses.list')
+    def test__get_host_addresses(self, list_addresses):
+        expected = ['1.1.1.1', '2.2.2.2', '3.3.3.3']
+        return_value = []
+        for address in expected:
+            return_value.append({
+                'addressType': 'static',
+                'address': '%s/24' % address
+            })
+        list_addresses.return_value = return_value
+        result = self.drv._get_host_addresses()
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver._get_host_addresses')
+    def test__get_host_portals(self, list_addresses):
+        list_addresses.return_value = ['1.1.1.1', '2.2.2.2', '3.3.3.3']
+        expected = ['1.1.1.1:3260', '2.2.2.2:3260']
+        result = self.drv._get_host_portals()
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefTargets.list')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefTargetsGroups.list')
+    def test__target_group_props(self, list_target_groups, list_targets):
+        host_portals = ['1.1.1.1:3260', '2.2.2.2:3260']
+        target_group = 'cinder-test'
+        list_target_groups.return_value = [{
+            'name': target_group,
+            'members': [
+                'iqn:cinder-test'
+            ]
+        }]
+        list_targets.return_value = [{
+            'name': 'iqn:cinder-test',
+            'portals': [
+                {
+                    'address': '1.1.1.1',
+                    'port': 3260
+                },
+                {
+                    'address': '2.2.2.2',
+                    'port': 3260
+                }
+            ]
+        }]
+        expected = {'iqn:cinder-test': host_portals}
+        result = self.drv._target_group_props(target_group, host_portals)
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefTargetsGroups.create')
+    def test__create_target_group(self, create_target_group):
+        name = 'name'
+        members = ['a', 'b', 'c']
+        create_target_group.return_value = {}
+        self.assertIsNone(self.drv._create_target_group(name, members))
+        payload = {'name': name, 'members': members}
+        create_target_group.assert_called_with(payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefTargetsGroups.set')
+    def test__update_target_group(self, update_target_group):
+        name = 'name'
+        members = ['a', 'b', 'c']
+        update_target_group.return_value = {}
+        self.assertIsNone(self.drv._update_target_group(name, members))
+        payload = {'members': members}
+        update_target_group.assert_called_with(name, payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefLunMappings.delete')
+    def test__delete_lun_mapping(self, delete_mapping):
+        name = 'name'
+        delete_mapping.return_value = {}
+        self.assertIsNone(self.drv._delete_lun_mapping(name))
+        delete_mapping.assert_called_with(name)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefTargets.create')
+    def test__create_target(self, create_target):
+        name = 'name'
+        portals = ['1.1.1.1:3260', '2.2.2.2:3260']
+        create_target.return_value = {}
+        self.assertIsNone(self.drv._create_target(name, portals))
+        payload = {
+            'name': name,
+            'portals': [
+                {
+                    'address': '1.1.1.1',
+                    'port': 3260
+                },
+                {
+                    'address': '2.2.2.2',
+                    'port': 3260
+                }
+            ]
+        }
+        create_target.assert_called_with(payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefHostGroups.list')
+    def test__get_host_group(self, get_hostgroup):
+        member = 'member1'
+        get_hostgroup.return_value = [
+            {
+                'name': 'name1',
+                'members': [
+                    'member1',
+                    'member2',
+                    'member3'
+                ]
+            },
+            {
+                'name': 'name2',
+                'members': [
+                    'member4',
+                    'member5',
+                    'member6'
+                ]
+            }
+        ]
+        expected = 'name1'
+        result = self.drv._get_host_group(member)
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefHostGroups.create')
+    def test__create_host_group(self, create_host_group):
+        name = 'name'
+        members = ['a', 'b', 'c']
+        create_host_group.return_value = {}
+        self.assertIsNone(self.drv._create_host_group(name, members))
+        payload = {'name': name, 'members': members}
+        create_host_group.assert_called_with(payload)
+
+    def test__s2d(self):
+        portals = ['1.1.1.1:3260', '2.2.2.2:3260']
+        expected = [
+            {
+                'address': '1.1.1.1',
+                'port': 3260
+            },
+            {
+                'address': '2.2.2.2',
+                'port': 3260
+            }
+        ]
+        result = self.drv._s2d(portals)
+        self.assertEqual(expected, result)
+
+    def test__d2s(self):
+        portals = [
+            {
+                'address': '1.1.1.1',
+                'port': 3260
+            },
+            {
+                'address': '2.2.2.2',
+                'port': 3260
+            }
+        ]
+        expected = ['1.1.1.1:3260', '2.2.2.2:3260']
+        result = self.drv._d2s(portals)
+        self.assertEqual(expected, result)
+
+    def test_create_consistencygroup(self):
+        cgroup = fake_cgroup(self.ctxt)
+        result = self.drv.create_consistencygroup(self.ctxt, cgroup)
+        expected = {}
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver.delete_volume')
+    def test_delete_consistencygroup(self, delete_volume):
+        cgroup = fake_cgroup(self.ctxt)
+        volume1 = fake_volume(self.ctxt)
+        volume2_spec = {'id': fake.VOLUME2_ID}
+        volume2 = fake_volume(self.ctxt, **volume2_spec)
+        volumes = [volume1, volume2]
+        delete_volume.return_value = {}
+        result = self.drv.delete_consistencygroup(self.ctxt,
+                                                  cgroup,
+                                                  volumes)
+        expected = ({}, [])
+        self.assertEqual(expected, result)
+
+    def test_update_consistencygroup(self):
+        cgroup = fake_cgroup(self.ctxt)
+        volume1 = fake_volume(self.ctxt)
+        volume2_spec = {'id': fake.VOLUME2_ID}
+        volume2 = fake_volume(self.ctxt, **volume2_spec)
+        volume3_spec = {'id': fake.VOLUME3_ID}
+        volume3 = fake_volume(self.ctxt, **volume3_spec)
+        volume4_spec = {'id': fake.VOLUME4_ID}
+        volume4 = fake_volume(self.ctxt, **volume4_spec)
+        add_volumes = [volume1, volume2]
+        remove_volumes = [volume3, volume4]
+        result = self.drv.update_consistencygroup(self.ctxt,
+                                                  cgroup,
+                                                  add_volumes,
+                                                  remove_volumes)
+        expected = ({}, [], [])
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.delete')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.rename')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.create')
+    def test_create_cgsnapshot(self, create_snapshot,
+                               rename_snapshot,
+                               delete_snapshot):
+        cgsnapshot = fake_cgsnapshot(self.ctxt)
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        snapshots = [snapshot]
+        cgsnapshot_name = (
+            self.cfg.nexenta_group_snapshot_template % cgsnapshot['id'])
+        cgsnapshot_path = '%s@%s' % (self.drv.root_path, cgsnapshot_name)
+        snapshot_path = '%s/%s@%s' % (self.drv.root_path,
+                                      snapshot['volume_name'],
+                                      cgsnapshot_name)
+        create_snapshot.return_value = {}
+        rename_snapshot.return_value = {}
+        delete_snapshot.return_value = {}
+        result = self.drv.create_cgsnapshot(self.ctxt,
+                                            cgsnapshot,
+                                            snapshots)
+        create_payload = {'path': cgsnapshot_path, 'recursive': True}
+        create_snapshot.assert_called_with(create_payload)
+        rename_payload = {'newName': snapshot['name']}
+        rename_snapshot.assert_called_with(snapshot_path, rename_payload)
+        delete_payload = {'defer': True, 'recursive': True}
+        delete_snapshot.assert_called_with(cgsnapshot_path, delete_payload)
+        expected = ({}, [])
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver.delete_snapshot')
+    def test_delete_cgsnapshot(self, delete_snapshot):
+        cgsnapshot = fake_cgsnapshot(self.ctxt)
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        snapshots = [snapshot]
+        delete_snapshot.return_value = {}
+        result = self.drv.delete_cgsnapshot(self.ctxt,
+                                            cgsnapshot,
+                                            snapshots)
+        delete_snapshot.assert_called_with(snapshot)
+        expected = ({}, [])
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver.create_volume_from_snapshot')
+    def test_create_consistencygroup_from_src_snapshots(self, create_volume):
+        cgroup = fake_cgroup(self.ctxt)
+        cgsnapshot = fake_cgsnapshot(self.ctxt)
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        snapshots = [snapshot]
+        clone_spec = {'id': fake.VOLUME2_ID}
+        clone = fake_volume(self.ctxt, **clone_spec)
+        clones = [clone]
+        create_volume.return_value = {}
+        result = self.drv.create_consistencygroup_from_src(self.ctxt, cgroup,
+                                                           clones, cgsnapshot,
+                                                           snapshots, None,
+                                                           None)
+        create_volume.assert_called_with(clone, snapshot)
+        expected = ({}, [])
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.delete')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver.create_volume_from_snapshot')
+    @patch('cinder.volume.drivers.nexenta.ns5.jsonrpc.NefSnapshots.create')
+    def test_create_consistencygroup_from_src_volumes(self,
+                                                      create_snapshot,
+                                                      create_volume,
+                                                      delete_snapshot):
+        src_cgroup = fake_cgroup(self.ctxt)
+        dst_cgroup_spec = {'id': fake.CONSISTENCY_GROUP2_ID}
+        dst_cgroup = fake_cgroup(self.ctxt, **dst_cgroup_spec)
+        src_volume = fake_volume(self.ctxt)
+        src_volumes = [src_volume]
+        dst_volume_spec = {'id': fake.VOLUME2_ID}
+        dst_volume = fake_volume(self.ctxt, **dst_volume_spec)
+        dst_volumes = [dst_volume]
+        create_snapshot.return_value = {}
+        create_volume.return_value = {}
+        delete_snapshot.return_value = {}
+        result = self.drv.create_consistencygroup_from_src(self.ctxt,
+                                                           dst_cgroup,
+                                                           dst_volumes,
+                                                           None, None,
+                                                           src_cgroup,
+                                                           src_volumes)
+        snapshot_name = (
+            self.cfg.nexenta_origin_snapshot_template % dst_cgroup['id'])
+        snapshot_path = '%s@%s' % (self.drv.root_path, snapshot_name)
+        create_payload = {'path': snapshot_path, 'recursive': True}
+        create_snapshot.assert_called_with(create_payload)
+        snapshot = {
+            'name': snapshot_name,
+            'volume_id': src_volume['id'],
+            'volume_name': src_volume['name'],
+            'volume_size': src_volume['size']
+        }
+        create_volume.assert_called_with(dst_volume, snapshot)
+        delete_payload = {'defer': True, 'recursive': True}
+        delete_snapshot.assert_called_with(snapshot_path, delete_payload)
+        expected = ({}, [])
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefVolumes.list')
+    def test__get_existing_volume(self, list_volumes):
+        volume = fake_volume(self.ctxt)
+        parent = self.drv.root_path
+        name = volume['name']
+        size = volume['size']
+        path = self.drv._get_volume_path(volume)
+        list_volumes.return_value = [{
+            'name': name,
+            'path': path,
+            'volumeSize': size * units.Gi
+        }]
+        result = self.drv._get_existing_volume({'source-name': name})
+        payload = {
+            'parent': parent,
+            'fields': 'name,path,volumeSize',
+            'name': name
+        }
+        list_volumes.assert_called_with(payload)
+        expected = {
+            'name': name,
+            'path': path,
+            'size': size
+        }
+        self.assertEqual(expected, result)
+
+    def test__check_already_managed_snapshot(self):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        result = self.drv._check_already_managed_snapshot(snapshot)
+        expected = False
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.list')
+    def test__get_existing_snapshot(self, list_snapshots):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        name = snapshot['name']
+        path = self.drv._get_snapshot_path(snapshot)
+        parent = self.drv._get_volume_path(volume)
+        list_snapshots.return_value = [{
+            'name': name,
+            'path': path
+        }]
+        payload = {'source-name': name}
+        result = self.drv._get_existing_snapshot(snapshot, payload)
+        payload = {
+            'parent': parent,
+            'fields': 'name,path',
+            'recursive': False,
+            'name': name
+        }
+        list_snapshots.assert_called_with(payload)
+        expected = {
+            'name': name,
+            'path': path,
+            'volume_name': volume['name'],
+            'volume_size': volume['size']
+        }
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefVolumes.rename')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefLunMappings.list')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver._get_existing_volume')
+    def test_manage_existing(self, get_existing_volume,
+                             list_mappings, rename_volume):
+        existing_volume = fake_volume(self.ctxt)
+        manage_volume_spec = {'id': fake.VOLUME2_ID}
+        manage_volume = fake_volume(self.ctxt, **manage_volume_spec)
+        existing_name = existing_volume['name']
+        existing_path = self.drv._get_volume_path(existing_volume)
+        existing_size = existing_volume['size']
+        manage_path = self.drv._get_volume_path(manage_volume)
+        get_existing_volume.return_value = {
+            'name': existing_name,
+            'path': existing_path,
+            'size': existing_size
+        }
+        list_mappings.return_value = []
+        payload = {'source-name': existing_name}
+        self.assertIsNone(self.drv.manage_existing(manage_volume, payload))
+        get_existing_volume.assert_called_with(payload)
+        payload = {'volume': existing_path}
+        list_mappings.assert_called_with(payload)
+        payload = {'newPath': manage_path}
+        rename_volume.assert_called_with(existing_path, payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.iscsi.'
+           'NexentaISCSIDriver._get_existing_volume')
+    def test_manage_existing_get_size(self, get_volume):
+        volume = fake_volume(self.ctxt)
+        name = volume['name']
+        size = volume['size']
+        path = self.drv._get_volume_path(volume)
+        get_volume.return_value = {
+            'name': name,
+            'path': path,
+            'size': size
+        }
+        payload = {'source-name': name}
+        result = self.drv.manage_existing_get_size(volume, payload)
+        expected = size
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefVolumes.list')
+    def test_get_manageable_volumes(self, list_volumes):
+        volume = fake_volume(self.ctxt)
+        volumes = [volume]
+        name = volume['name']
+        size = volume['size']
+        path = self.drv._get_volume_path(volume)
+        guid = 12345
+        parent = self.drv.root_path
+        list_volumes.return_value = [{
+            'name': name,
+            'path': path,
+            'guid': guid,
+            'volumeSize': size * units.Gi
+        }]
+        result = self.drv.get_manageable_volumes(volumes, None, 1,
+                                                 0, 'size', 'asc')
+        payload = {
+            'parent': parent,
+            'fields': 'name,guid,path,volumeSize',
+            'recursive': False
+        }
+        list_volumes.assert_called_with(payload)
+        expected = [{
+            'cinder_id': volume['id'],
+            'extra_info': None,
+            'reason_not_safe': 'Volume already managed',
+            'reference': {
+                'source-guid': guid,
+                'source-name': volume['name']
+            },
+            'safe_to_manage': False,
+            'size': volume['size']
+        }]
+        self.assertEqual(expected, result)
+
+    def test_unmanage(self):
+        volume = fake_volume(self.ctxt)
+        self.assertIsNone(self.drv.unmanage(volume))
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.rename')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver._get_existing_snapshot')
+    def test_manage_existing_snapshot(self, get_existing_snapshot,
+                                      rename_snapshot):
+        volume = fake_volume(self.ctxt)
+        existing_snapshot = fake_snapshot(self.ctxt)
+        existing_snapshot.volume = volume
+        manage_snapshot_spec = {'id': fake.SNAPSHOT2_ID}
+        manage_snapshot = fake_snapshot(self.ctxt, **manage_snapshot_spec)
+        manage_snapshot.volume = volume
+        existing_name = existing_snapshot['name']
+        manage_name = manage_snapshot['name']
+        volume_name = volume['name']
+        volume_size = volume['size']
+        existing_path = self.drv._get_snapshot_path(existing_snapshot)
+        get_existing_snapshot.return_value = {
+            'name': existing_name,
+            'path': existing_path,
+            'volume_name': volume_name,
+            'volume_size': volume_size
+        }
+        rename_snapshot.return_value = {}
+        payload = {'source-name': existing_name}
+        self.assertIsNone(
+            self.drv.manage_existing_snapshot(manage_snapshot, payload)
+        )
+        get_existing_snapshot.assert_called_with(manage_snapshot, payload)
+        payload = {'newName': manage_name}
+        rename_snapshot.assert_called_with(existing_path, payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'iscsi.NexentaISCSIDriver._get_existing_snapshot')
+    def test_manage_existing_snapshot_get_size(self, get_snapshot):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        snapshot_name = snapshot['name']
+        volume_name = volume['name']
+        volume_size = volume['size']
+        snapshot_path = self.drv._get_snapshot_path(snapshot)
+        get_snapshot.return_value = {
+            'name': snapshot_name,
+            'path': snapshot_path,
+            'volume_name': volume_name,
+            'volume_size': volume_size
+        }
+        payload = {'source-name': snapshot_name}
+        result = self.drv.manage_existing_snapshot_get_size(volume, payload)
+        expected = volume['size']
+        self.assertEqual(expected, result)
+
+    @patch('cinder.objects.VolumeList.get_all_by_host')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.list')
+    def test_get_manageable_snapshots(self, list_snapshots, list_volumes):
+        volume = fake_volume(self.ctxt)
+        volumes = [volume]
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        snapshots = [snapshot]
+        guid = 12345
+        name = snapshot['name']
+        path = self.drv._get_snapshot_path(snapshot)
+        parent = self.drv._get_volume_path(volume)
+        list_snapshots.return_value = [{
+            'name': name,
+            'path': path,
+            'guid': guid,
+            'parent': parent,
+            'hprService': '',
+            'snaplistId': ''
+        }]
+        list_volumes.return_value = volumes
+        result = self.drv.get_manageable_snapshots(snapshots, None, 1,
+                                                   0, 'size', 'asc')
+        payload = {
+            'parent': self.drv.root_path,
+            'fields': 'name,guid,path,parent,hprService,snaplistId',
+            'recursive': True
+        }
+        list_snapshots.assert_called_with(payload)
+        expected = [{
+            'cinder_id': snapshot['id'],
+            'extra_info': None,
+            'reason_not_safe': 'Snapshot already managed',
+            'source_reference': {
+                'name': volume['name']
+            },
+            'reference': {
+                'source-guid': guid,
+                'source-name': snapshot['name']
+            },
+            'safe_to_manage': False,
+            'size': volume['size']
+        }]
+        self.assertEqual(expected, result)
+
+    def test_unmanage_snapshot(self):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        self.assertIsNone(self.drv.unmanage_snapshot(snapshot))

--- a/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_jsonrpc.py
+++ b/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_jsonrpc.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -16,233 +16,809 @@
 Unit tests for NexentaStor 5 REST API helper
 """
 
-import mock
-import requests
+import json
+import hashlib
+import posixpath
 import uuid
 
-from cinder import exception
-from cinder import test
-from cinder.volume.drivers.nexenta.ns5 import jsonrpc
+from mock import Mock
 from mock import patch
-from oslo_serialization import jsonutils
-from requests import adapters
 
-HOST = '1.1.1.1'
-USERNAME = 'user'
-PASSWORD = 'pass'
+import requests
+import six
 
-
-def gen_response(code=200, json=None):
-    r = requests.Response()
-    r.headers['Content-Type'] = 'application/json'
-    r.encoding = 'utf8'
-    r.status_code = code
-    r.reason = 'FAKE REASON'
-    r.raw = mock.Mock()
-    r._content = ''
-    if json:
-        r._content = jsonutils.dumps(json)
-    return r
+from cinder import test
+from cinder.volume import configuration as conf
+from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 
 
-class TestNexentaJSONProxyAuth(test.TestCase):
+class FakeSession(object):
 
-    @patch('cinder.volume.drivers.nexenta.ns5.jsonrpc.requests.post')
-    def test_https_auth(self, post):
-        use_https = True
-        port = 8443
-        auth_uri = 'auth/login'
-        rnd_url = 'some/random/url'
+    def __init__(self):
+        self.headers = {}
 
-        class PostSideEffect(object):
-            def __call__(self, *args, **kwargs):
-                r = gen_response()
-                if args[0] == '{}://{}:{}/{}'.format(
-                        'https', HOST, port, auth_uri):
-                    token = uuid.uuid4().hex
-                    content = {'token': token}
-                    r._content = jsonutils.dumps(content)
-                return r
-        post_side_effect = PostSideEffect()
-        post.side_effect = post_side_effect
+    def request(self, method, url, **kwargs):
+        return {
+            'method': method,
+            'url': url,
+            'kwargs': kwargs
+        }
 
-        class TestAdapter(adapters.HTTPAdapter):
+    def send(self, request, **kwargs):
+        return {
+            'request': request,
+            'kwargs': kwargs
+        }
 
-            def __init__(self):
-                super(TestAdapter, self).__init__()
-                self.counter = 0
+class FakeNefProxy(object):
 
-            def send(self, request, *args, **kwargs):
-                # an url is being requested for the second time
-                if self.counter == 1:
-                    # make the fake backend respond 401
-                    r = gen_response(401)
-                    r._content = ''
-                    r.connection = mock.Mock()
-                    r_ = gen_response(json={'data': []})
-                    r.connection.send = lambda prep, **kwargs_: r_
-                else:
-                    r = gen_response(json={'data': []})
-                r.request = request
-                self.counter += 1
-                return r
+    def __init__(self):
+        self.scheme = 'https'
+        self.port = 8443
+        self.hosts = ['1.1.1.1', '2.2.2.2']
+        self.host = self.hosts[0]
+        self.root = 'pool/share'
+        self.username = 'username'
+        self.password = 'password'
+        self.retries = 3
+        self.timeout = 5
+        self.session = FakeSession()
 
-        nef = jsonrpc.NexentaJSONProxy(HOST, port, USERNAME, PASSWORD,
-                                       use_https, 'pool', False)
-        adapter = TestAdapter()
-        nef.session.mount('{}://{}:{}/{}'.format('https', HOST, port, rnd_url),
-                          adapter)
+    def __getattr__(self, name):
+        return FakeNefRequest(self, name)
 
-        # successful authorization
-        self.assertEqual(nef.get(rnd_url), {'data': []})
+    def delay(self, interval):
+        pass
 
-        # session timeout simulation. Client must authenticate newly
-        self.assertEqual(nef.get(rnd_url), {'data': []})
-        # auth URL mast be requested two times at this moment
-        self.assertEqual(2, post.call_count)
+    def delete_bearer(self):
+        pass
 
-        # continue with the last (second) token
-        self.assertEqual(nef.get(rnd_url), {'data': []})
-        # auth URL must be requested two times
-        self.assertEqual(2, post.call_count)
+    def update_lock(self):
+        pass
+
+    def update_token(self, token):
+        pass
+
+    def update_host(self, host):
+        pass
+
+    def url(self, path):
+        return '%s://%s:%s/%s' % (self.scheme, self.host, self.port, path)
 
 
-class TestNexentaJSONProxy(test.TestCase):
+class FakeNefRequest(object):
+
+    def __init__(self, proxy, method):
+        self.proxy = proxy
+        self.method = method
+        self.path = None
+        self.payload = {}
+
+    def __call__(self, *args):
+        if args:
+            self.path = args[0]
+        if len(args) > 1:
+            self.payload = args[1]
+        return {
+            'method': self.method,
+            'path': self.path,
+            'payload': self.payload
+        }
+
+
+class TestNefException(test.TestCase):
+
+    def test_message(self):
+        message = 'test message 1'
+        result = jsonrpc.NefException(message)
+        self.assertIn(message, result.msg)
+
+    def test_dict(self):
+        code = 'ENOENT'
+        message = 'test message 2'
+        result = jsonrpc.NefException({'code': code, 'message': message})
+        self.assertEqual(code, result.code)
+        self.assertIn(message, result.msg)
+
+    def test_kwargs(self):
+        code = 'EPERM'
+        message = 'test message 3'
+        result = jsonrpc.NefException(code=code, message=message)
+        self.assertEqual(code, result.code)
+        self.assertIn(message, result.msg)
+
+    def test_defaults(self):
+        code = 'EBADMSG'
+        message = 'NexentaError'
+        result = jsonrpc.NefException()
+        self.assertEqual(code, result.code)
+        self.assertIn(message, result.msg)
+
+
+class TestNefRequest(test.TestCase):
 
     def setUp(self):
-        super(TestNexentaJSONProxy, self).setUp()
-        self.nef = jsonrpc.NexentaJSONProxy(
-            HOST, 0, USERNAME, PASSWORD, False, 'pool', False)
+        super(TestNefRequest, self).setUp()
+        self.proxy = FakeNefProxy()
 
-    def gen_adapter(self, code, json=None):
-        class TestAdapter(adapters.HTTPAdapter):
+    def fake_response(self, method, path, payload, code, content):
+        request = requests.Request()
+        request.method = method
+        request.url = self.proxy.url(path)
+        request.body = None
+        if method in ['get', 'delete']:
+            request.params = payload
+        elif method in ['put', 'post']:
+            request.data = json.dumps(payload)
+        response = requests.Response()
+        response.request = request
+        response.headers['Content-Type'] = 'application/json'
+        response.status_code = code
+        if content:
+            response._content = json.dumps(content)
+        else:
+            response._content = ''
+        return response
 
-            def __init__(self):
-                super(TestAdapter, self).__init__()
+    def test___call___no_path(self):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        args = []
+        self.assertRaises(jsonrpc.NefException, instance, *args)
 
-            def send(self, request, *args, **kwargs):
-                r = gen_response(code, json)
-                r.request = request
-                return r
+    def test___call___no_data(self):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        args = [path, None]
+        self.assertRaises(jsonrpc.NefException, instance, *args)
 
-        return TestAdapter()
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefRequest.request')
+    def test___call___get(self, request):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        args = [path, payload]
+        content = {'name': 'snapshot'}
+        response = self.fake_response(method, path, payload, 200, content)
+        request.return_value = response
+        result = instance(*args)
+        params = {'params': payload}
+        request.assert_called_with(method, path, **params)
+        expected = content
+        self.assertEqual(expected, result)
 
-    def test_post(self):
-        random_dict = {'data': uuid.uuid4().hex}
-        rnd_url = 'some/random/url'
-        self.nef.session.mount('{}://{}:{}/{}'.format(
-            'http', HOST, 8080, rnd_url), self.gen_adapter(201, random_dict))
-        self.assertEqual(self.nef.post(rnd_url), random_dict)
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefRequest.request')
+    def test___call___post(self, request):
+        method = 'post'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        args = [path, payload]
+        content = None
+        response = self.fake_response(method, path, payload, 200, content)
+        request.return_value = response
+        result = instance(*args)
+        params = {'data': json.dumps(payload)}
+        request.assert_called_with(method, path, **params)
+        expected = content
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefRequest.request')
+    def test___call___request_error(self, request):
+        method = 'post'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        args = [path, payload]
+        request.side_effect = requests.exceptions.Timeout
+        self.assertRaises(requests.exceptions.Timeout, instance, *args)
+
+    def test_hook_200_empty(self):
+        method = 'delete'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'storage/filesystems'
+        payload = {'force': True}
+        content = None
+        response = self.fake_response(method, path, payload, 200, content)
+        result = instance.hook(response)
+        self.assertEqual(response, result)
+
+    def test_hook_201_empty(self):
+        method = 'post'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'storage/snapshots'
+        payload = {'path': 'parent/child@name'}
+        content = None
+        response = self.fake_response(method, path, payload, 201, content)
+        result = instance.hook(response)
+        self.assertEqual(response, result)
+
+    def test_hook_500_empty(self):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'storage/pools'
+        payload = {'poolName': 'tank'}
+        content = None
+        response = self.fake_response(method, path, payload, 500, content)
+        self.assertRaises(jsonrpc.NefException, instance.hook, response)
+
+    def test_hook_200_bad_content(self):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'storage/volumes'
+        payload = {'name': 'test'}
+        content = None
+        response = self.fake_response(method, path, payload, 200, content)
+        response._content = 'bad_content'
+        self.assertRaises(jsonrpc.NefException, instance.hook, response)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefRequest.auth')
+    def test_hook_403(self, auth):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {'code': 'EAUTH'}
+        response = self.fake_response(method, path, payload, 403, content)
+        auth.return_value = True
+        result = instance.hook(response)
+        self.assertEqual(response, result)
+
+    def test_hook_404_nested(self):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        instance.lock = True
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {'code': 'ENOENT'}
+        response = self.fake_response(method, path, payload, 404, content)
+        result = instance.hook(response)
+        self.assertEqual(response, result)
+
+    def test_hook_404_max_retries(self):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        instance.stat[404] = self.proxy.retries
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {'code': 'ENOENT'}
+        response = self.fake_response(method, path, payload, 404, content)
+        self.assertRaises(jsonrpc.NefException, instance.hook, response)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefRequest.failover')
+    def test_hook_404_failover_error(self, failover):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {'code': 'ENOENT'}
+        response = self.fake_response(method, path, payload, 404, content)
+        failover.return_value = False
+        result = instance.hook(response)
+        self.assertEqual(response, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefRequest.request')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefRequest.failover')
+    def test_hook_404_failover_ok(self, failover, request):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {'code': 'ENOENT'}
+        response = self.fake_response(method, path, payload, 404, content)
+        failover.return_value = True
+        content2 = {'name': 'test'}
+        response2 = self.fake_response(method, path, payload, 200, content2)
+        request.return_value = response2
+        result = instance.hook(response)
+        self.assertEqual(response2, result)
+
+    def test_hook_500_permanent(self):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {'code': 'EINVAL'}
+        response = self.fake_response(method, path, payload, 500, content)
+        self.assertRaises(jsonrpc.NefException, instance.hook, response)
+
+    def test_hook_500_busy_max_retries(self):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        instance.stat[500] = self.proxy.retries
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {'code': 'EBUSY'}
+        response = self.fake_response(method, path, payload, 500, content)
+        self.assertRaises(jsonrpc.NefException, instance.hook, response)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefRequest.request')
+    def test_hook_500_busy_ok(self, request):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {'code': 'EBUSY'}
+        response = self.fake_response(method, path, payload, 500, content)
+        content2 = {'name': 'test'}
+        response2 = self.fake_response(method, path, payload, 200, content2)
+        request.return_value = response2
+        result = instance.hook(response)
+        self.assertEqual(response2, result)
+
+    def test_hook_201_no_monitor(self):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {'monitor': 'unknown'}
+        response = self.fake_response(method, path, payload, 202, content)
+        self.assertRaises(jsonrpc.NefException, instance.hook, response)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefRequest.request')
+    def test_hook_201_ok(self, request):
+        method = 'delete'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {
+            'links': [{
+                'rel': 'monitor',
+                'href': '/jobStatus/jobID'
+            }]
+        }
+        response = self.fake_response(method, path, payload, 202, content)
+        content2 = None
+        response2 = self.fake_response(method, path, payload, 201, content2)
+        request.return_value = response2
+        result = instance.hook(response)
+        self.assertEqual(response2, result)
+
+    def test_200_no_data(self):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {'name': 'test'}
+        response = self.fake_response(method, path, payload, 200, content)
+        result = instance.hook(response)
+        self.assertEqual(response, result)
+
+    def test_200_pagination_end(self):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {'data': 'value'}
+        response = self.fake_response(method, path, payload, 200, content)
+        result = instance.hook(response)
+        self.assertEqual(response, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefRequest.request')
+    def test_200_pagination_next(self, request):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        payload = {'key': 'value'}
+        content = {
+            'data': [{
+                'name': 'test'
+            }],
+            'links': [{
+                'rel': 'next',
+                'href': path
+            }]
+        }
+        response = self.fake_response(method, path, payload, 200, content)
+        response2 = self.fake_response(method, path, payload, 200, content)
+        request.return_value = response2
+        result = instance.hook(response)
+        self.assertEqual(response2, result)
+
+    def test_request(self):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = 'parent/child'
+        url = self.proxy.url(path)
+        payload = {'key': 'value'}
+        result = instance.request(method, path, **payload)
+        self.assertEqual(url, result['url'])
+        self.assertEqual(method, result['method'])
+        for key in payload:
+            self.assertIn(payload[key], result['kwargs'][key])
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefRequest.request')
+    def test_auth(self, request):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        method = 'post'
+        path = 'auth/login'
+        payload = {
+            'data': json.dumps({
+                'username': self.proxy.username,
+                'password': self.proxy.password
+            })
+        }
+        content = {'token': 'test'}
+        response = self.fake_response(method, path, payload, 200, content)
+        request.return_value = response
+        instance.auth()
+        request.assert_called_with(method, path, **payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefRequest.request')
+    def test_failover(self, request):
+        method = 'get'
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        path = self.proxy.root
+        payload = None
+        content = {'path': path}
+        response = self.fake_response(method, path, payload, 200, content)
+        request.return_value = response
+        result = instance.failover()
+        request.assert_called_with(method, path)
+        expected = True
+        self.assertEqual(expected, result)
+
+    def test_getpath(self):
+        method = 'get'
+        rel = 'monitor'
+        href = 'jobStatus/jobID'
+        content = {
+            'links': [{
+                'rel': rel,
+                'href': href
+            }]
+        }
+        instance = jsonrpc.NefRequest(self.proxy, method)
+        result = instance.getpath(content, rel)
+        expected = href
+        self.assertEqual(expected, result)
+
+
+class TestNefCollections(test.TestCase):
+
+    def setUp(self):
+        super(TestNefCollections, self).setUp()
+        self.proxy = FakeNefProxy()
+        self.instance = jsonrpc.NefCollections(self.proxy)
+
+    def test_path(self):
+        path = 'path/to/item name + - & # $ = 0'
+        result = self.instance.path(path)
+        quoted_path = six.moves.urllib.parse.quote_plus(path)
+        expected = posixpath.join(self.instance.root, quoted_path)
+        self.assertEqual(expected, result)
+
+    def test_get(self):
+        name = 'parent/child'
+        args = {'key': 'value'}
+        path = self.instance.path(name)
+        result = self.instance.get(name, args)
+        expected = {
+            'method': 'get',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
+
+    def test_set(self):
+        name = 'parent/child'
+        args = {'key': 'value'}
+        path = self.instance.path(name)
+        result = self.instance.set(name, args)
+        expected = {
+            'method': 'put',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
+
+    def test_list(self):
+        args = {'key': 'value'}
+        path = self.instance.root
+        result = self.instance.list(args)
+        expected = {
+            'method': 'get',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
+
+    def test_create(self):
+        args = {'key': 'value'}
+        path = self.instance.root
+        result = self.instance.create(args)
+        expected = {
+            'method': 'post',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
 
     def test_delete(self):
-        random_dict = {'data': uuid.uuid4().hex}
-        rnd_url = 'some/random/url'
-        self.nef.session.mount('{}://{}:{}/{}'.format(
-            'http', HOST, 8080, rnd_url), self.gen_adapter(201, random_dict))
-        self.assertEqual(self.nef.delete(rnd_url), random_dict)
+        name = 'parent/child'
+        args = {'key': 'value'}
+        path = self.instance.path(name)
+        result = self.instance.delete(name, args)
+        expected = {
+            'method': 'delete',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
 
-    def test_put(self):
-        random_dict = {'data': uuid.uuid4().hex}
-        rnd_url = 'some/random/url'
-        self.nef.session.mount('{}://{}:{}/{}'.format(
-            'http', HOST, 8080, rnd_url), self.gen_adapter(201, random_dict))
-        self.assertEqual(self.nef.put(rnd_url), random_dict)
 
-    def test_get_200(self):
-        random_dict = {'data': uuid.uuid4().hex}
-        rnd_url = 'some/random/url'
-        self.nef.session.mount('{}://{}:{}/{}'.format(
-            'http', HOST, 8080, rnd_url), self.gen_adapter(200, random_dict))
-        self.assertEqual(self.nef.get(rnd_url), random_dict)
+class TestNefSettings(test.TestCase):
 
-    def test_get_201(self):
-        random_dict = {'data': uuid.uuid4().hex}
-        rnd_url = 'some/random/url'
-        self.nef.session.mount('{}://{}:{}/{}'.format(
-            'http', HOST, 8080, rnd_url), self.gen_adapter(201, random_dict))
-        self.assertEqual(self.nef.get(rnd_url), random_dict)
+    def setUp(self):
+        super(TestNefSettings, self).setUp()
+        self.proxy = FakeNefProxy()
+        self.instance = jsonrpc.NefSettings(self.proxy)
 
-    def test_get_500(self):
-        class TestAdapter(adapters.HTTPAdapter):
+    def test_create(self):
+        args = {'key': 'value'}
+        result = self.instance.create(args)
+        expected = NotImplemented
+        self.assertEqual(expected, result)
 
-            def __init__(self):
-                super(TestAdapter, self).__init__()
+    def test_delete(self):
+        name = 'parent/child'
+        args = {'key': 'value'}
+        result = self.instance.delete(name, args)
+        expected = NotImplemented
+        self.assertEqual(expected, result)
 
-            def send(self, request, *args, **kwargs):
-                json = {
-                    'code': 'NEF_ERROR',
-                    'message': 'Some error'
-                }
-                r = gen_response(500, json)
-                r.request = request
-                return r
 
-        adapter = TestAdapter()
-        rnd_url = 'some/random/url'
-        self.nef.session.mount('{}://{}:{}/{}'.format(
-            'http', HOST, 8080, rnd_url), adapter)
-        self.assertRaises(exception.NexentaException, self.nef.get, rnd_url)
+class TestNefDatasets(test.TestCase):
 
-    @patch('cinder.volume.drivers.nexenta.utils.ex2err')
-    def test_get__not_nef_error(self, ex2err):
-        class TestAdapter(adapters.HTTPAdapter):
+    def setUp(self):
+        super(TestNefDatasets, self).setUp()
+        self.proxy = FakeNefProxy()
+        self.instance = jsonrpc.NefDatasets(self.proxy)
 
-            def __init__(self):
-                super(TestAdapter, self).__init__()
+    def test_rename(self):
+        name = 'parent/child'
+        args = {'key': 'value'}
+        path = '%s/%s' % (self.instance.path(name), 'rename')
+        result = self.instance.rename(name, args)
+        expected = {
+            'method': 'post',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
 
-            def send(self, request, *args, **kwargs):
-                r = gen_response(404)
-                r._content = 'Page Not Found'
-                r.request = request
-                return r
 
-        ex2err.return_value = {'code': 404}
-        adapter = TestAdapter()
-        rnd_url = 'some/random/url'
-        self.nef.session.mount('{}://{}:{}/{}'.format(
-            'http', HOST, 8080, rnd_url), adapter)
-        self.assertRaises(exception.NexentaException, self.nef.get,
-                          rnd_url)
+class TestNefSnapshots(test.TestCase):
 
-    @patch('cinder.volume.drivers.nexenta.utils.ex2err')
-    def test_get__not_nef_error_empty_body(self, ex2err):
-        class TestAdapter(adapters.HTTPAdapter):
+    def setUp(self):
+        super(TestNefSnapshots, self).setUp()
+        self.proxy = FakeNefProxy()
+        self.instance = jsonrpc.NefSnapshots(self.proxy)
 
-            def __init__(self):
-                super(TestAdapter, self).__init__()
+    def test_clone(self):
+        name = 'parent/child'
+        args = {'key': 'value'}
+        path = '%s/%s' % (self.instance.path(name), 'clone')
+        result = self.instance.clone(name, args)
+        expected = {
+            'method': 'post',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
 
-            def send(self, request, *args, **kwargs):
-                r = gen_response(404)
-                r.request = request
-                return r
 
-        ex2err.return_value = {'code': 'EEXIST'}
-        adapter = TestAdapter()
-        rnd_url = 'some/random/url'
-        self.nef.session.mount('{}://{}:{}/{}'.format(
-            'http', HOST, 8080, rnd_url), adapter)
-        self.assertRaises(exception.NexentaException, self.nef.get,
-                          rnd_url)
+class TestNefVolumeGroups(test.TestCase):
 
-    def test_202(self):
-        redirect_url = 'redirect/url'
+    def setUp(self):
+        super(TestNefVolumeGroups, self).setUp()
+        self.proxy = FakeNefProxy()
+        self.instance = jsonrpc.NefVolumeGroups(self.proxy)
 
-        class RedirectTestAdapter(adapters.HTTPAdapter):
+    def test_rollback(self):
+        name = 'parent/child'
+        args = {'key': 'value'}
+        path = '%s/%s' % (self.instance.path(name), 'rollback')
+        result = self.instance.rollback(name, args)
+        expected = {
+            'method': 'post',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
 
-            def __init__(self):
-                super(RedirectTestAdapter, self).__init__()
 
-            def send(self, request, *args, **kwargs):
-                json = {
-                    'links': [{'href': redirect_url}]
-                }
-                r = gen_response(202, json)
-                r.request = request
-                return r
+class TestNefVolumes(test.TestCase):
 
-        rnd_url = 'some/random/url'
-        self.nef.session.mount('{}://{}:{}/{}'.format(
-            'http', HOST, 8080, rnd_url), RedirectTestAdapter())
-        self.nef.session.mount('{}://{}:{}/{}'.format(
-            'http', HOST, 8080, redirect_url), self.gen_adapter(201))
-        self.assertIsNone(self.nef.get(rnd_url))
+    def setUp(self):
+        super(TestNefVolumes, self).setUp()
+        self.proxy = FakeNefProxy()
+        self.instance = jsonrpc.NefVolumes(self.proxy)
+
+    def test_promote(self):
+        name = 'parent/child'
+        args = {'key': 'value'}
+        path = '%s/%s' % (self.instance.path(name), 'promote')
+        result = self.instance.promote(name, args)
+        expected = {
+            'method': 'post',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
+
+
+class TestNefFilesystems(test.TestCase):
+
+    def setUp(self):
+        super(TestNefFilesystems, self).setUp()
+        self.proxy = FakeNefProxy()
+        self.instance = jsonrpc.NefFilesystems(self.proxy)
+
+    def test_mount(self):
+        name = 'parent/child'
+        args = {'key': 'value'}
+        path = '%s/%s' % (self.instance.path(name), 'mount')
+        result = self.instance.mount(name, args)
+        expected = {
+            'method': 'post',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
+
+    def test_unmount(self):
+        name = 'parent/child'
+        args = {'key': 'value'}
+        path = '%s/%s' % (self.instance.path(name), 'unmount')
+        result = self.instance.unmount(name, args)
+        expected = {
+            'method': 'post',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
+
+    def test_acl(self):
+        name = 'parent/child'
+        args = {'key': 'value'}
+        path = '%s/%s' % (self.instance.path(name), 'acl')
+        result = self.instance.acl(name, args)
+        expected = {
+            'method': 'post',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
+
+
+class TestNefHpr(test.TestCase):
+
+    def setUp(self):
+        super(TestNefHpr, self).setUp()
+        self.proxy = FakeNefProxy()
+        self.instance = jsonrpc.NefHpr(self.proxy)
+
+    def test_activate(self):
+        args = {'key': 'value'}
+        path = '%s/%s' % (self.instance.root, 'activate')
+        result = self.instance.activate(args)
+        expected = {
+            'method': 'post',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
+
+    def test_start(self):
+        name = 'parent/child'
+        args = {'key': 'value'}
+        path = '%s/%s' % (self.instance.path(name), 'start')
+        result = self.instance.start(name, args)
+        expected = {
+            'method': 'post',
+            'path': path,
+            'payload': args
+        }
+        self.assertEqual(expected, result)
+
+
+class TestNefProxy(test.TestCase):
+
+    def setUp(self):
+        super(TestNefProxy, self).setUp()
+        self.cfg = Mock(spec=conf.Configuration)
+        self.cfg.nexenta_use_https = True
+        self.cfg.driver_ssl_cert_verify = False
+        self.cfg.nexenta_user = 'user'
+        self.cfg.nexenta_password = 'pass'
+        self.cfg.nexenta_rest_address = '1.1.1.1'
+        self.cfg.nexenta_rest_port = 8443
+        self.cfg.nexenta_rest_backoff_factor = 1
+        self.cfg.nexenta_rest_retry_count = 3
+        self.cfg.nexenta_rest_connect_timeout = 1
+        self.cfg.nexenta_rest_read_timeout = 1
+        self.cfg.nas_share_path = 'pool/path/to/share'
+        self.nef_mock = Mock()
+        self.mock_object(jsonrpc, 'NefRequest',
+                         return_value=self.nef_mock)
+
+        self.proto = 'nfs'
+        self.proxy = jsonrpc.NefProxy(self.proto,
+                                      self.cfg.nas_share_path,
+                                      self.cfg)
+
+    def test_delete_bearer(self):
+        self.assertIsNone(self.proxy.delete_bearer())
+        self.assertNotIn('Authorization', self.proxy.session.headers)
+        self.proxy.session.headers['Authorization'] = 'Bearer token'
+        self.assertIsNone(self.proxy.delete_bearer())
+        self.assertNotIn('Authorization', self.proxy.session.headers)
+
+    def test_update_bearer(self):
+        token = 'token'
+        bearer = 'Bearer %s' % token
+        self.assertNotIn('Authorization', self.proxy.session.headers)
+        self.assertIsNone(self.proxy.update_bearer(token))
+        self.assertIn('Authorization', self.proxy.session.headers)
+        self.assertEqual(self.proxy.session.headers['Authorization'], bearer)
+
+    def test_update_token(self):
+        token = 'token'
+        bearer = 'Bearer %s' % token
+        self.assertIsNone(self.proxy.update_token(token))
+        self.assertEqual(self.proxy.tokens[self.proxy.host], token)
+        self.assertEqual(self.proxy.session.headers['Authorization'], bearer)
+
+    def test_update_host(self):
+        token = 'token'
+        bearer = 'Bearer %s' % token
+        host = self.cfg.nexenta_rest_address
+        self.proxy.tokens[host] = token
+        self.assertIsNone(self.proxy.update_host(host))
+        self.assertEqual(self.proxy.session.headers['Authorization'], bearer)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSettings.get')
+    def test_update_lock(self, get_settings):
+        guid = uuid.uuid4().hex
+        settings = {'value': guid}
+        get_settings.return_value = settings
+        self.assertIsNone(self.proxy.update_lock())
+        path = '%s:%s' % (guid, self.proxy.path)
+        if isinstance(path, six.text_type):
+            path = path.encode('utf-8')
+        expected = hashlib.md5(path).hexdigest()
+        self.assertEqual(expected, self.proxy.lock)
+
+    def test_url(self):
+        path = '/path/to/api'
+        result = self.proxy.url(path)
+        expected = '%s://%s:%s%s' % (self.proxy.scheme,
+                                     self.proxy.host,
+                                     self.proxy.port,
+                                     path)
+        self.assertEqual(expected, result)
+
+    @patch('eventlet.greenthread.sleep')
+    def test_delay(self, sleep):
+        sleep.return_value = None
+        for attempt in range(0, 10):
+            expected = int(self.proxy.backoff_factor * (2 ** (attempt - 1)))
+            self.assertIsNone(self.proxy.delay(attempt))
+            sleep.assert_called_with(expected)

--- a/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_nfs.py
+++ b/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_nfs.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -15,62 +15,43 @@
 """
 Unit tests for OpenStack Cinder volume driver
 """
+import hashlib
+import os
 
-from mock import call
 from mock import Mock
 from mock import patch
-from six.moves import urllib
+
+from oslo_utils import units
 
 from cinder import context
 from cinder import db
-from cinder import exception
 from cinder import test
-from cinder.tests.unit.fake_volume import fake_volume_obj
+from cinder.tests.unit import fake_constants as fake
+from cinder.tests.unit.fake_snapshot import fake_snapshot_obj as fake_snapshot
+from cinder.tests.unit.fake_volume import fake_volume_obj as fake_volume
+from cinder.tests.unit.consistencygroup.fake_consistencygroup import (
+    fake_consistencyobject_obj as fake_cgroup)
+from cinder.tests.unit.consistencygroup.fake_cgsnapshot import (
+    fake_cgsnapshot_obj as fake_cgsnapshot)
+from cinder.tests.unit.image import fake as fake_image
 from cinder.volume import configuration as conf
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 from cinder.volume.drivers.nexenta.ns5 import nfs
 
 
 class TestNexentaNfsDriver(test.TestCase):
-    TEST_SHARE = 'host1:/pool/share'
-    TEST_SHARE2_OPTIONS = '-o intr'
-    TEST_FILE_NAME = 'test.txt'
-    TEST_SHARES_CONFIG_FILE = '/etc/cinder/nexenta-shares.conf'
-    TEST_SNAPSHOT_NAME = 'snapshot-1'
-    TEST_VOLUME_NAME = 'volume-1'
-    TEST_VOLUME_NAME2 = 'volume-2'
-
-    TEST_VOLUME = fake_volume_obj(None, **{
-        'name': TEST_VOLUME_NAME,
-        'id': '1',
-        'size': 1,
-        'status': 'available',
-        'provider_location': TEST_SHARE
-    })
-
-    TEST_VOLUME2 = fake_volume_obj(None, **{
-        'name': TEST_VOLUME_NAME2,
-        'size': 2,
-        'id': '2',
-        'status': 'in-use'
-    })
-
-    TEST_SNAPSHOT = {
-        'name': TEST_SNAPSHOT_NAME,
-        'volume_name': TEST_VOLUME_NAME,
-        'volume_size': 1,
-        'volume_id': '1'
-    }
-
-    TEST_SHARE_SVC = 'svc:/network/nfs/server:default'
 
     def setUp(self):
         super(TestNexentaNfsDriver, self).setUp()
         self.ctxt = context.get_admin_context()
         self.cfg = Mock(spec=conf.Configuration)
+        self.cfg.volume_backend_name = 'nexenta_nfs'
+        self.cfg.nexenta_group_snapshot_template = 'group-snapshot-%s'
+        self.cfg.nexenta_origin_snapshot_template = 'origin-snapshot-%s'
         self.cfg.nexenta_dataset_description = ''
         self.cfg.nexenta_mount_point_base = '$state_path/mnt'
         self.cfg.nexenta_sparsed_volumes = True
+        self.cfg.nexenta_qcow2_volumes = False
         self.cfg.nexenta_dataset_compression = 'on'
         self.cfg.nexenta_dataset_dedup = 'off'
         self.cfg.nfs_mount_point_base = '/mnt/test'
@@ -79,195 +60,1080 @@ class TestNexentaNfsDriver(test.TestCase):
         self.cfg.reserved_percentage = 20
         self.cfg.nexenta_use_https = False
         self.cfg.driver_ssl_cert_verify = False
-        self.cfg.nexenta_rest_port = 0
         self.cfg.nexenta_user = 'user'
         self.cfg.nexenta_password = 'pass'
         self.cfg.max_over_subscription_ratio = 20.0
         self.cfg.nas_host = '1.1.1.2'
         self.cfg.nexenta_rest_address = '1.1.1.1'
+        self.cfg.nexenta_rest_port = 8443
+        self.cfg.nexenta_rest_backoff_factor = 1
+        self.cfg.nexenta_rest_retry_count = 3
+        self.cfg.nexenta_rest_connect_timeout = 1
+        self.cfg.nexenta_rest_read_timeout = 1
         self.cfg.nas_share_path = 'pool/share'
-        self.cfg.nfs_mount_options = None
+        self.cfg.nfs_mount_options = '-o vers=4'
+        self.cfg.safe_get = self.fake_safe_get
         self.nef_mock = Mock()
-        self.mock_object(jsonrpc, 'NexentaJSONProxy',
-                         lambda *_, **__: self.nef_mock)
+        self.mock_object(jsonrpc, 'NefRequest',
+                         return_value=self.nef_mock)
         self.drv = nfs.NexentaNfsDriver(configuration=self.cfg)
         self.drv.db = db
         self.drv.do_setup(self.ctxt)
 
-    def _create_volume_db_entry(self):
-        vol = {
-            'id': '1',
-            'size': 1,
-            'status': 'available',
-            'provider_location': self.TEST_SHARE
+    def fake_safe_get(self, key):
+        try:
+            value = getattr(self.cfg, key)
+        except AttributeError:
+            value = None
+        return value
+
+    def test_do_setup(self):
+        self.assertIsNone(self.drv.do_setup(self.ctxt))
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefNfs.get')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefServices.get')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.set')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.get')
+    def test_check_for_setup_error(self, get_filesystem,
+                                   set_filesystem,
+                                   get_service, get_nfs):
+        get_filesystem.return_value = {
+            'mountPoint': '/path/to/volume',
+            'nonBlockingMandatoryMode': False,
+            'isMounted': True
         }
-        return db.volume_create(self.ctxt, vol)['id']
-
-    def test_check_for_setup_error_raise(self):
-        def get_side_effect(*args, **kwargs):
-            if 'storage/pools/' in args[0]:
-                return ''
-            elif 'nas/nfs?filesystem=' in args[0]:
-                return {'data': [{'shareState': 'offline'}]}
-        self.nef_mock.get.side_effect = get_side_effect
-        self.assertRaises(
-            exception.NexentaException,
-            lambda: self.drv.check_for_setup_error())
-
-    def test_check_for_setup_error(self):
-        def get_side_effect(*args, **kwargs):
-            if 'storage/pools/' in args[0]:
-                return ''
-            elif 'nas/nfs?filesystem=' in args[0]:
-                return {'data': [{'shareState': 'online'}]}
-        self.nef_mock.get.side_effect = get_side_effect
+        get_service.return_value = {
+            'state': 'online'
+        }
+        get_nfs.return_value = {
+            'shareState': 'online'
+        }
         self.assertIsNone(self.drv.check_for_setup_error())
-
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._mount_volume')
-    def test_initialize_connection(self, _mount_volume):
-        data = {
-            'export': self.TEST_VOLUME['provider_location'], 'name': 'volume'}
-        self.assertEqual({
-            'driver_volume_type': self.drv.driver_volume_type,
-            'data': data,
-            'mount_point_base': self.drv.nfs_mount_point_base
-        }, self.drv.initialize_connection(self.TEST_VOLUME, None))
-        url = 'hpr/activate'
-        data = {'datasetName': '/'.join(
-            [self.drv.share, self.TEST_VOLUME['name']])}
-        self.nef_mock.post.assert_called_with(url, data)
-
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._mount_volume')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._unmount_volume')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver.local_path')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._create_regular_file')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._create_sparsed_file')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._ensure_share_mounted')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._share_folder')
-    def test_do_create_volume(self, share, ensure, sparsed, local,
-                              regular, _unmount_volume, _mount_volume):
-        local.return_value = 'path'
-        ensure.return_value = True
-        share.return_value = True
-        self.nef_mock.get.return_value = 'on'
-        self.drv._do_create_volume(self.TEST_VOLUME)
-
-        url = 'storage/filesystems'
-        data = {
-            'path': 'pool/share/volume-1',
-            'compressionMode': 'on',
+        get_filesystem.assert_called_with(self.drv.root_path)
+        get_service.assert_called_with('nfs')
+        get_nfs.assert_called_with(self.drv.root_path)
+        get_filesystem.return_value = {
+            'mountPoint': '/path/to/volume',
+            'nonBlockingMandatoryMode': True,
+            'isMounted': True
         }
-        self.nef_mock.post.assert_called_with(url, data)
+        set_filesystem.return_value = {}
+        self.assertIsNone(self.drv.check_for_setup_error())
+        get_filesystem.return_value = {
+            'mountPoint': 'none',
+            'nonBlockingMandatoryMode': False,
+            'isMounted': False
+        }
+        self.assertRaises(jsonrpc.NefException,
+                          self.drv.check_for_setup_error)
+        get_filesystem.return_value = {
+            'mountPoint': '/path/to/volume',
+            'nonBlockingMandatoryMode': False,
+            'isMounted': False
+        }
+        self.assertRaises(jsonrpc.NefException,
+                          self.drv.check_for_setup_error)
+        get_service.return_value = {
+            'state': 'online'
+        }
+        self.assertRaises(jsonrpc.NefException,
+                          self.drv.check_for_setup_error)
+        get_nfs.return_value = {
+            'shareState': 'offline'
+        }
+        self.assertRaises(jsonrpc.NefException,
+                          self.drv.check_for_setup_error)
 
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._unmount_volume')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._ensure_share_mounted')
-    def test_delete_volume(self, ensure, unmount):
-        self._create_volume_db_entry()
-        self.nef_mock.get.return_value = {'data': ['volume']}
-        self.drv.delete_volume(self.TEST_VOLUME)
-        path = '/'.join(['pool/share', self.TEST_VOLUME['name']])
-        url = 'storage/filesystems/%s?%s' % (
-            urllib.parse.quote_plus(path),
-            urllib.parse.urlencode({'force': True, 'snapshots': True}))
-        self.nef_mock.delete.assert_called_with(url)
-
-    def test_create_snapshot(self):
-        self._create_volume_db_entry()
-        self.drv.create_snapshot(self.TEST_SNAPSHOT)
-        vol_path = '/'.join(['pool/share', self.TEST_VOLUME['name']])
-        url = 'storage/snapshots'
-        data = {'path': '%s@snapshot-1' % vol_path}
-        self.nef_mock.post.assert_called_with(url, data)
-
-    def test_delete_snapshot(self):
-        self._create_volume_db_entry()
-        self.nef_mock.get.return_value = {'data': ['volume']}
-        self.drv.delete_snapshot(self.TEST_SNAPSHOT)
-
-        vol_path = '/'.join(['pool/share', self.TEST_VOLUME['name']])
-        snap_path = urllib.parse.quote_plus(('%s@snapshot-1' % vol_path))
-        params = urllib.parse.urlencode({'recursive': False, 'defer': True})
-        url = 'storage/snapshots/%s?%s' % (snap_path, params)
-        self.nef_mock.delete.assert_called_with(url)
-
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver.extend_volume')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver.local_path')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._share_folder')
-    def test_create_volume_from_snapshot(self, share, path, extend):
-        self._create_volume_db_entry()
-        path = '/'.join(['pool/share', self.TEST_VOLUME2['name']])
-        data = {'targetPath': path}
-        self.drv.create_volume_from_snapshot(
-            self.TEST_VOLUME2, self.TEST_SNAPSHOT)
-        source_vol_path = '/'.join(['pool/share', self.TEST_VOLUME['name']])
-        snap_path = '%s@snapshot-1' % urllib.parse.quote_plus(source_vol_path)
-        url_1 = 'storage/snapshots/%s/clone' % snap_path
-        url_2 = 'storage/filesystems/%s/unmount' % urllib.parse.quote_plus(
-            path)
-        url_3 = 'storage/filesystems/%s/mount' % urllib.parse.quote_plus(path)
-        calls = [call(url_1, data), call(url_2), call(url_3)]
-        self.nef_mock.post.assert_has_calls(calls)
-
-        # make sure the volume get extended!
-        extend.assert_called_once_with(self.TEST_VOLUME2, 2)
-
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._unmount_volume')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._mount_volume')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver.local_path')
-    @patch('oslo_concurrency.processutils.execute')
-    def test_extend_volume_sparsed(
-            self, _execute, path, mount, unmount):
-        self._create_volume_db_entry()
-        path.return_value = 'path'
-
-        self.drv.extend_volume(self.TEST_VOLUME, 2)
-
-        _execute.assert_called_with(
-            'truncate', '-s', '2G',
-            'path',
-            root_helper='sudo cinder-rootwrap /etc/cinder/rootwrap.conf',
-            run_as_root=True)
-
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._unmount_volume')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver._mount_volume')
-    @patch('cinder.volume.drivers.nexenta.ns5.nfs.'
-           'NexentaNfsDriver.local_path')
-    @patch('oslo_concurrency.processutils.execute')
-    def test_extend_volume_nonsparsed(
-            self, _execute, path, mount, unmount):
-        self._create_volume_db_entry()
-        path.return_value = 'path'
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._unmount_volume')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.delete')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.set')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._create_regular_file')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._create_sparsed_file')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver.local_path')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._mount_volume')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._set_volume_acl')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.create')
+    def test_create_volume(self, create_volume, set_volume_acl,
+                           mount_volume, get_volume_local_path,
+                           create_sparsed_file, created_regular_file,
+                           set_volume, delete_volume, umount_volume):
+        volume = fake_volume(self.ctxt)
+        local_path = '/local/volume/path'
+        create_volume.return_value = {}
+        set_volume_acl.return_value = {}
+        mount_volume.return_value = True
+        get_volume_local_path.return_value = local_path
+        create_sparsed_file.return_value = True
+        created_regular_file.return_value = True
+        set_volume.return_value = {}
+        delete_volume.return_value = {}
+        umount_volume.return_value = {}
+        with patch.object(self.drv, 'sparsed_volumes', True):
+            self.assertIsNone(self.drv.create_volume(volume))
+            create_sparsed_file.assert_called_with(local_path, volume['size'])
         with patch.object(self.drv, 'sparsed_volumes', False):
-            self.drv.extend_volume(self.TEST_VOLUME, 2)
+            self.assertIsNone(self.drv.create_volume(volume))
+            created_regular_file.assert_called_with(local_path, volume['size'])
+        volume_path = self.drv._get_volume_path(volume)
+        payload = {
+            'path': volume_path,
+            'compressionMode': 'off'
+        }
+        create_volume.assert_called_with(payload)
+        set_volume_acl.assert_called_with(volume)
+        payload = {'compressionMode': self.cfg.nexenta_dataset_compression}
+        set_volume.assert_called_with(volume_path, payload)
+        umount_volume.assert_called_with(volume)
 
-            _execute.assert_called_with(
-                'dd', 'if=/dev/zero', 'seek=1024',
-                'of=path',
-                'bs=1M', 'count=1024',
-                root_helper='sudo cinder-rootwrap /etc/cinder/rootwrap.conf',
-                run_as_root=True)
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._unmount_volume')
+    @patch('cinder.volume.drivers.remotefs.'
+           'RemoteFSDriver.copy_image_to_volume')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._mount_volume')
+    def test_copy_image_to_volume(self, mount_volume,
+                                  copy_image_to_volume,
+                                  unmount_volume):
+        volume = fake_volume(self.ctxt)
+        image_service = fake_image.FakeImageService()
+        image = image_service.images[fake.IMAGE_ID]
+        mount_volume.return_value = True
+        copy_image_to_volume.return_value = True
+        unmount_volume.return_value = True
+        self.drv.copy_image_to_volume(self.ctxt, volume,
+                                      image_service,
+                                      image['id'])
+        mount_volume.assert_called_with(volume)
+        copy_image_to_volume.assert_called_with(self.ctxt, volume,
+                                                image_service,
+                                                image['id'])
+        unmount_volume.assert_called_with(volume)
 
-    def test_get_capacity_info(self):
-        self.nef_mock.get.return_value = {
-            'bytesAvailable': 1000,
-            'bytesUsed': 100}
-        self.assertEqual(
-            (1100, 1000, 100), self.drv._get_capacity_info('pool/share'))
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._unmount_volume')
+    @patch('cinder.volume.drivers.remotefs.'
+           'RemoteFSSnapDriverDistributed.copy_volume_to_image')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._mount_volume')
+    def test_copy_volume_to_image(self, mount_volume,
+                                  copy_volume_to_image,
+                                  unmount_volume):
+        volume = fake_volume(self.ctxt)
+        image_service = fake_image.FakeImageService()
+        image = image_service.images[fake.IMAGE_ID]
+        mount_volume.return_value = True
+        copy_volume_to_image.return_value = True
+        unmount_volume.return_value = True
+        self.drv.copy_volume_to_image(self.ctxt, volume,
+                                      image_service, image)
+        mount_volume.assert_called_with(volume)
+        copy_volume_to_image.assert_called_with(self.ctxt, volume,
+                                                image_service, image)
+        unmount_volume.assert_called_with(volume)
+
+    @patch('os.rmdir')
+    @patch('cinder.privsep.fs.umount')
+    @patch('os_brick.remotefs.remotefs.'
+           'RemoteFsClient._read_mounts')
+    @patch('cinder.volume.drivers.nfs.'
+           'NfsDriver._get_mount_point_for_share')
+    def test__ensure_share_unmounted(self, get_mount_point,
+                                     list_mount_points,
+                                     unmount_filesystem,
+                                     remove_mount_point):
+        mount_point = '/mount/point1'
+        get_mount_point.return_value = mount_point
+        list_mount_points.return_value = [
+            mount_point,
+            '/mount/point2',
+            '/mount/point3'
+        ]
+        unmount_filesystem.return_value = True
+        remove_mount_point.return_value = True
+        share = '1.1.1.1:/path/to/volume'
+        self.assertIsNone(self.drv._ensure_share_unmounted(share))
+        get_mount_point.assert_called_with(share)
+        unmount_filesystem.assert_called_with(mount_point)
+        remove_mount_point.assert_called_with(mount_point)
+
+    @patch('cinder.volume.drivers.nfs.'
+           'NfsDriver._ensure_share_mounted')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.get')
+    def test__mount_volume(self, get_filesystem, mount_share):
+        volume = fake_volume(self.ctxt)
+        mount_point = '/path/to/volume'
+        get_filesystem.return_value = {
+            'mountPoint': mount_point,
+            'isMounted': True
+        }
+        mount_share.return_value = True
+        self.assertIsNone(self.drv._mount_volume(volume))
+        path = self.drv._get_volume_path(volume)
+        payload = {'fields': 'mountPoint,isMounted'}
+        get_filesystem.assert_called_with(path, payload)
+        share = '%s:%s' % (self.drv.nas_host, mount_point)
+        mount_share.assert_called_with(share)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._ensure_share_unmounted')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._get_volume_share')
+    def test__unmount_volume(self, get_share, unmount_share):
+        volume = fake_volume(self.ctxt)
+        mount_point = '/path/to/volume'
+        share = '%s:%s' % (self.drv.nas_host, mount_point)
+        get_share.return_value = share
+        unmount_share.return_value = True
+        self.assertIsNone(self.drv._unmount_volume(volume))
+        get_share.assert_called_with(volume)
+        unmount_share.assert_called_with(share)
+
+    @patch('cinder.volume.drivers.remotefs.'
+           'RemoteFSDriver._create_qcow2_file')
+    @patch('cinder.volume.drivers.remotefs.'
+           'RemoteFSDriver._create_sparsed_file')
+    def test__create_sparsed_file(self, create_sparsed_file,
+                                  create_qcow2_file):
+        create_sparsed_file.return_value = True
+        create_qcow2_file.return_value = True
+        path = '/path/to/file'
+        size = 1
+        with patch.object(self.cfg, 'nexenta_qcow2_volumes', True):
+            self.assertIsNone(self.drv._create_sparsed_file(path, size))
+            create_qcow2_file.assert_called_with(path, size)
+        with patch.object(self.cfg, 'nexenta_qcow2_volumes', False):
+            self.assertIsNone(self.drv._create_sparsed_file(path, size))
+            create_sparsed_file.assert_called_with(path, size)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver.delete_volume')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefHpr.delete')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefHpr.get')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefHpr.start')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefHpr.create')
+    def test_migrate_volume(self, create_service,
+                            start_service, get_service,
+                            delete_service, delete_volume):
+        create_service.return_value = {}
+        start_service.return_value = {}
+        get_service.return_value = {
+            'state': 'disabled'
+        }
+        delete_service.return_value = {}
+        delete_volume.return_value = {}
+        volume = fake_volume(self.ctxt)
+        dst_host = '4.4.4.4'
+        dst_port = 8443
+        dst_path = 'tank/nfs'
+        location_info = 'NexentaNfsDriver:%s:/%s' % (dst_host, dst_path)
+        host = {
+            'host': 'stack@nexenta_nfs#fake_nfs',
+            'capabilities': {
+                'vendor_name': 'Nexenta',
+                'nef_url': dst_host,
+                'nef_port': dst_port,
+                'storage_protocol': 'NFS',
+                'free_capacity_gb': 32,
+                'location_info': location_info
+            }
+        }
+        result = self.drv.migrate_volume(self.ctxt, volume, host)
+        expected = (True, None)
+        svc = 'cinder-migrate-%s' % volume['name']
+        src = self.drv._get_volume_path(volume)
+        dst = '%s/%s' % (dst_path, volume['name'])
+        payload = {
+            'name': svc,
+            'sourceDataset': src,
+            'destinationDataset': dst,
+            'type': 'scheduled',
+            'sendShareNfs': True,
+            'isSource': True,
+            'remoteNode': {
+                'host': dst_host,
+                'port': dst_port
+            }
+        }
+        create_service.assert_called_with(payload)
+        start_service.assert_called_with(svc)
+        get_service.assert_called_with(svc)
+        payload = {
+            'destroySourceSnapshots': True,
+            'destroyDestinationSnapshots': True
+        }
+        delete_service.assert_called_with(svc, payload)
+        delete_volume.assert_called_with(volume)
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._unmount_volume')
+    def test_terminate_connection(self, unmount_volume):
+        unmount_volume.return_value = True
+        volume = fake_volume(self.ctxt)
+        connector = {
+            'initiator': 'iqn:cinder-client',
+            'multipath': True
+        }
+        self.assertIsNone(self.drv.terminate_connection(volume, connector))
+        unmount_volume.assert_called_with(volume)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._get_volume_share')
+    def test_initialize_connection(self, get_share):
+        volume = fake_volume(self.ctxt)
+        path = self.drv._get_volume_path(volume)
+        share = '%s:/%s' % (self.drv.nas_host, path)
+        get_share.return_value = share
+        connector = {
+            'initiator': 'iqn:cinder-client',
+            'multipath': True
+        }
+        result = self.drv.initialize_connection(volume, connector)
+        get_share.assert_called_with(volume)
+        base = self.cfg.nexenta_mount_point_base
+        expected = {
+            'driver_volume_type': 'nfs',
+            'mount_point_base': base,
+            'data': {
+                'export': share,
+                'name': 'volume'
+            }
+        }
+        self.assertEqual(expected, result)
+
+    def test_ensure_export(self):
+        volume = fake_volume(self.ctxt)
+        self.assertIsNone(self.drv.ensure_export(self.ctxt, volume))
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.delete')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._unmount_volume')
+    def test_delete_volume(self, unmount_volume, delete_filesystem):
+        volume = fake_volume(self.ctxt)
+        path = self.drv._get_volume_path(volume)
+        unmount_volume.return_value = {}
+        delete_filesystem.return_value = {}
+        self.assertIsNone(self.drv.delete_volume(volume))
+        unmount_volume.assert_called_with(volume)
+        payload = {'force': True, 'snapshots': True}
+        delete_filesystem.assert_called_with(path, payload)
+
+    @patch('os.rmdir')
+    def test__delete(self, rmdir):
+        rmdir.return_value = True
+        path = '/path/to/volume/mountpoint'
+        self.assertIsNone(self.drv._delete(path))
+        rmdir.assert_called_with(path)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._unmount_volume')
+    @patch('oslo_concurrency.processutils.execute')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver.local_path')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._mount_volume')
+    def test_extend_volume(self, mount_volume, get_volume_local_path,
+                           execute_command, unmount_volume):
+        volume = fake_volume(self.ctxt)
+        root_helper = 'sudo cinder-rootwrap /etc/cinder/rootwrap.conf'
+        local_path = '/path/to/volume/file'
+        new_size = volume['size'] * 2
+        bs = 1 * units.Mi
+        seek = volume['size'] * units.Ki
+        count = (new_size - volume['size']) * units.Ki
+        mount_volume.return_value = True
+        get_volume_local_path.return_value = local_path
+        execute_command.return_value = True
+        unmount_volume.return_value = True
+        with patch.object(self.drv, 'sparsed_volumes', False):
+            self.assertIsNone(self.drv.extend_volume(volume, new_size))
+            execute_command.assert_called_with('dd', 'if=/dev/zero',
+                                               'of=%s' % local_path,
+                                               'bs=%d' % bs,
+                                               'seek=%d' % seek,
+                                               'count=%d' % count,
+                                               run_as_root=True,
+                                               root_helper=root_helper)
+        with patch.object(self.drv, 'sparsed_volumes', True):
+            self.assertIsNone(self.drv.extend_volume(volume, new_size))
+            execute_command.assert_called_with('truncate', '-s',
+                                               '%sG' % new_size,
+                                               local_path,
+                                               run_as_root=True,
+                                               root_helper=root_helper)
+        mount_volume.assert_called_with(volume)
+        unmount_volume.assert_called_with(volume)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.create')
+    def test_create_snapshot(self, create_snapshot):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        create_snapshot.return_value = {}
+        self.assertIsNone(self.drv.create_snapshot(snapshot))
+        path = self.drv._get_snapshot_path(snapshot)
+        payload = {'path': path}
+        create_snapshot.assert_called_with(payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.delete')
+    def test_delete_snapshot(self, delete_snapshot):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        delete_snapshot.return_value = {}
+        self.assertIsNone(self.drv.delete_snapshot(snapshot))
+        path = self.drv._get_snapshot_path(snapshot)
+        payload = {'defer': True}
+        delete_snapshot.assert_called_with(path, payload)
+
+    def test_snapshot_revert_use_temp_snapshot(self):
+        result = self.drv.snapshot_revert_use_temp_snapshot()
+        expected = False
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.rollback')
+    def test_revert_to_snapshot(self, rollback_volume):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        rollback_volume.return_value = {}
+        self.assertIsNone(
+            self.drv.revert_to_snapshot(self.ctxt, volume, snapshot)
+        )
+        path = self.drv._get_volume_path(volume)
+        payload = {'snapshot': snapshot['name']}
+        rollback_volume.assert_called_with(path, payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver.extend_volume')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.mount')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.unmount')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.clone')
+    def test_create_volume_from_snapshot(self, clone_snapshot,
+                                         unmount_filesystem,
+                                         mount_filesystem,
+                                         extend_volume):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        clone_size = 10
+        clone_spec = {
+            'id': fake.VOLUME2_ID,
+            'size': clone_size
+        }
+        clone = fake_volume(self.ctxt, **clone_spec)
+        snapshot_path = self.drv._get_snapshot_path(snapshot)
+        clone_path = self.drv._get_volume_path(clone)
+        clone_snapshot.return_value = {}
+        unmount_filesystem.return_value = {}
+        mount_filesystem.return_value = {}
+        extend_volume.return_value = None
+        self.assertIsNone(
+            self.drv.create_volume_from_snapshot(clone, snapshot)
+        )
+        clone_payload = {'targetPath': clone_path}
+        clone_snapshot.assert_called_with(snapshot_path, clone_payload)
+        unmount_filesystem.assert_called_with(clone_path)
+        mount_filesystem.assert_called_with(clone_path)
+        extend_volume.assert_called_with(clone, clone_size)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver.delete_snapshot')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver.create_volume_from_snapshot')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver.create_snapshot')
+    def test_create_cloned_volume(self, create_snapshot, create_volume,
+                                  delete_snapshot):
+        volume = fake_volume(self.ctxt)
+        clone_spec = {'id': fake.VOLUME2_ID}
+        clone = fake_volume(self.ctxt, **clone_spec)
+        create_snapshot.return_value = {}
+        create_volume.return_value = {}
+        delete_snapshot.return_value = {}
+        self.assertIsNone(self.drv.create_cloned_volume(clone, volume))
+        snapshot = {
+            'name': self.drv.origin_snapshot_template % clone['id'],
+            'volume_id': volume['id'],
+            'volume_name': volume['name'],
+            'volume_size': volume['size']
+        }
+        create_snapshot.assert_called_with(snapshot)
+        create_volume.assert_called_with(clone, snapshot)
+        create_volume.side_effect = jsonrpc.NefException({
+            'message': 'Failed to create volume',
+            'code': 'EBUSY'
+        })
+        self.assertRaises(jsonrpc.NefException,
+                          self.drv.create_cloned_volume,
+                          clone, volume)
+        create_snapshot.side_effect = jsonrpc.NefException({
+            'message': 'Failed to open dataset',
+            'code': 'ENOENT'
+        })
+        self.assertRaises(jsonrpc.NefException,
+                          self.drv.create_cloned_volume,
+                          clone, volume)
+
+    def test_create_consistencygroup(self):
+        cgroup = fake_cgroup(self.ctxt)
+        result = self.drv.create_consistencygroup(self.ctxt, cgroup)
+        expected = {}
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver.delete_volume')
+    def test_delete_consistencygroup(self, delete_volume):
+        cgroup = fake_cgroup(self.ctxt)
+        volume1 = fake_volume(self.ctxt)
+        volume2_spec = {'id': fake.VOLUME2_ID}
+        volume2 = fake_volume(self.ctxt, **volume2_spec)
+        volumes = [volume1, volume2]
+        delete_volume.return_value = {}
+        result = self.drv.delete_consistencygroup(self.ctxt,
+                                                  cgroup,
+                                                  volumes)
+        expected = ({}, [])
+        self.assertEqual(expected, result)
+
+    def test_update_consistencygroup(self):
+        cgroup = fake_cgroup(self.ctxt)
+        volume1 = fake_volume(self.ctxt)
+        volume2_spec = {'id': fake.VOLUME2_ID}
+        volume2 = fake_volume(self.ctxt, **volume2_spec)
+        volume3_spec = {'id': fake.VOLUME3_ID}
+        volume3 = fake_volume(self.ctxt, **volume3_spec)
+        volume4_spec = {'id': fake.VOLUME4_ID}
+        volume4 = fake_volume(self.ctxt, **volume4_spec)
+        add_volumes = [volume1, volume2]
+        remove_volumes = [volume3, volume4]
+        result = self.drv.update_consistencygroup(self.ctxt,
+                                                  cgroup,
+                                                  add_volumes,
+                                                  remove_volumes)
+        expected = ({}, [], [])
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.delete')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.rename')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.create')
+    def test_create_cgsnapshot(self, create_snapshot,
+                               rename_snapshot,
+                               delete_snapshot):
+        cgsnapshot = fake_cgsnapshot(self.ctxt)
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        snapshots = [snapshot]
+        cgsnapshot_name = (
+            self.cfg.nexenta_group_snapshot_template % cgsnapshot['id'])
+        cgsnapshot_path = '%s@%s' % (self.drv.root_path, cgsnapshot_name)
+        snapshot_path = '%s/%s@%s' % (self.drv.root_path,
+                                      snapshot['volume_name'],
+                                      cgsnapshot_name)
+        create_snapshot.return_value = {}
+        rename_snapshot.return_value = {}
+        delete_snapshot.return_value = {}
+        result = self.drv.create_cgsnapshot(self.ctxt,
+                                            cgsnapshot,
+                                            snapshots)
+        create_payload = {'path': cgsnapshot_path, 'recursive': True}
+        create_snapshot.assert_called_with(create_payload)
+        rename_payload = {'newName': snapshot['name']}
+        rename_snapshot.assert_called_with(snapshot_path, rename_payload)
+        delete_payload = {'defer': True, 'recursive': True}
+        delete_snapshot.assert_called_with(cgsnapshot_path, delete_payload)
+        expected = ({}, [])
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver.delete_snapshot')
+    def test_delete_cgsnapshot(self, delete_snapshot):
+        cgsnapshot = fake_cgsnapshot(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        volume = fake_volume(self.ctxt)
+        snapshot.volume = volume
+        snapshots = [snapshot]
+        delete_snapshot.return_value = {}
+        result = self.drv.delete_cgsnapshot(self.ctxt,
+                                            cgsnapshot,
+                                            snapshots)
+        delete_snapshot.assert_called_with(snapshot)
+        expected = ({}, [])
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver.create_volume_from_snapshot')
+    def test_create_consistencygroup_from_src_snapshots(self, create_volume):
+        cgroup = fake_cgroup(self.ctxt)
+        cgsnapshot = fake_cgsnapshot(self.ctxt)
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        snapshots = [snapshot]
+        clone_spec = {'id': fake.VOLUME2_ID}
+        clone = fake_volume(self.ctxt, **clone_spec)
+        clones = [clone]
+        create_volume.return_value = {}
+        result = self.drv.create_consistencygroup_from_src(self.ctxt, cgroup,
+                                                           clones, cgsnapshot,
+                                                           snapshots, None,
+                                                           None)
+        create_volume.assert_called_with(clone, snapshot)
+        expected = ({}, [])
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.delete')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver.create_volume_from_snapshot')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.create')
+    def test_create_consistencygroup_from_src_volumes(self, create_snapshot,
+                                                      create_volume,
+                                                      delete_snapshot):
+        src_cgroup = fake_cgroup(self.ctxt)
+        dst_cgroup_spec = {'id': fake.CONSISTENCY_GROUP2_ID}
+        dst_cgroup = fake_cgroup(self.ctxt, **dst_cgroup_spec)
+        src_volume = fake_volume(self.ctxt)
+        src_volumes = [src_volume]
+        dst_volume_spec = {'id': fake.VOLUME2_ID}
+        dst_volume = fake_volume(self.ctxt, **dst_volume_spec)
+        dst_volumes = [dst_volume]
+        create_snapshot.return_value = {}
+        create_volume.return_value = {}
+        delete_snapshot.return_value = {}
+        result = self.drv.create_consistencygroup_from_src(self.ctxt,
+                                                           dst_cgroup,
+                                                           dst_volumes,
+                                                           None, None,
+                                                           src_cgroup,
+                                                           src_volumes)
+        snapshot_name = (
+            self.cfg.nexenta_origin_snapshot_template % dst_cgroup['id'])
+        snapshot_path = '%s@%s' % (self.drv.root_path, snapshot_name)
+        create_payload = {'path': snapshot_path, 'recursive': True}
+        create_snapshot.assert_called_with(create_payload)
+        snapshot = {
+            'name': snapshot_name,
+            'volume_id': src_volume['id'],
+            'volume_name': src_volume['name'],
+            'volume_size': src_volume['size']
+        }
+        create_volume.assert_called_with(dst_volume, snapshot)
+        delete_payload = {'defer': True, 'recursive': True}
+        delete_snapshot.assert_called_with(snapshot_path, delete_payload)
+        expected = ({}, [])
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._get_volume_share')
+    def test__local_volume_dir(self, get_share):
+        volume = fake_volume(self.ctxt)
+        share = '1.1.1.1:/path/to/share'
+        get_share.return_value = share
+        result = self.drv._local_volume_dir(volume)
+        get_share.assert_called_with(volume)
+        share = share.encode('utf-8')
+        digest = hashlib.md5(share).hexdigest()
+        expected = os.path.join(self.cfg.nexenta_mount_point_base, digest)
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._local_volume_dir')
+    def test_local_path(self, get_local):
+        volume = fake_volume(self.ctxt)
+        local_dir = '/path/to'
+        get_local.return_value = local_dir
+        result = self.drv.local_path(volume)
+        get_local.assert_called_with(volume)
+        expected = os.path.join(local_dir, 'volume')
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.acl')
+    def test__set_volume_acl(self, set_acl):
+        volume = fake_volume(self.ctxt)
+        set_acl.return_value = {}
+        path = self.drv._get_volume_path(volume)
+        payload = {
+            'type': 'allow',
+            'principal': 'everyone@',
+            'permissions': ['full_set'],
+            'flags': ['file_inherit', 'dir_inherit']
+        }
+        self.assertIsNone(self.drv._set_volume_acl(volume))
+        set_acl.assert_called_with(path, payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.get')
+    def test__get_volume_share(self, get_filesystem):
+        volume = fake_volume(self.ctxt)
+        path = self.drv._get_volume_path(volume)
+        mount_point = '/path/to'
+        get_filesystem.return_value = {'mountPoint': mount_point}
+        result = self.drv._get_volume_share(volume)
+        payload = {'fields': 'mountPoint'}
+        get_filesystem.assert_called_with(path, payload)
+        expected = '%s:%s' % (self.drv.nas_host, mount_point)
+        self.assertEqual(expected, result)
+
+    def test__get_volume_path(self):
+        volume = fake_volume(self.ctxt)
+        result = self.drv._get_volume_path(volume)
+        expected = '%s/%s' % (self.drv.root_path, volume['name'])
+        self.assertEqual(expected, result)
+
+    def test__get_snapshot_path(self):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        result = self.drv._get_snapshot_path(snapshot)
+        expected = '%s/%s@%s' % (self.drv.root_path,
+                                 snapshot['volume_name'],
+                                 snapshot['name'])
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.get')
+    def test_get_volume_stats(self, get_filesystem):
+        available = 100
+        used = 75
+        get_filesystem.return_value = {
+            'mountPoint': '/path/to',
+            'bytesAvailable': available * units.Gi,
+            'bytesUsed': used * units.Gi
+        }
+        result = self.drv.get_volume_stats(True)
+        payload = {'fields': 'mountPoint,bytesAvailable,bytesUsed'}
+        get_filesystem.assert_called_with(self.drv.root_path, payload)
+        self.assertEqual(self.drv._stats, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.get')
+    def test_update_volume_stats(self, get_filesystem):
+        available = 8
+        used = 2
+        share = '%s:/%s' % (self.drv.nas_host, self.drv.root_path)
+        get_filesystem.return_value = {
+            'mountPoint': '/%s' % self.drv.root_path,
+            'bytesAvailable': available * units.Gi,
+            'bytesUsed': used * units.Gi
+        }
+        location_info = '%(driver)s:%(share)s' % {
+            'driver': self.drv.__class__.__name__,
+            'share': share
+        }
+        expected = {
+            'vendor_name': 'Nexenta',
+            'dedup': self.cfg.nexenta_dataset_dedup,
+            'compression': self.cfg.nexenta_dataset_compression,
+            'description': self.cfg.nexenta_dataset_description,
+            'nef_url': self.cfg.nexenta_rest_address,
+            'nef_port': self.cfg.nexenta_rest_port,
+            'driver_version': self.drv.VERSION,
+            'storage_protocol': 'NFS',
+            'sparsed_volumes': self.cfg.nexenta_sparsed_volumes,
+            'total_capacity_gb': used + available,
+            'free_capacity_gb': available,
+            'reserved_percentage': self.cfg.reserved_percentage,
+            'QoS_support': False,
+            'multiattach': True,
+            'consistencygroup_support': True,
+            'consistent_group_snapshot_enabled': True,
+            'volume_backend_name': self.cfg.volume_backend_name,
+            'location_info': location_info,
+            'nfs_mount_point_base': self.cfg.nexenta_mount_point_base
+        }
+        self.assertIsNone(self.drv._update_volume_stats())
+        self.assertEqual(expected, self.drv._stats)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.list')
+    def test__get_existing_volume(self, list_filesystems):
+        volume = fake_volume(self.ctxt)
+        parent = self.drv.root_path
+        name = volume['name']
+        path = self.drv._get_volume_path(volume)
+        list_filesystems.return_value = [{
+            'name': name,
+            'path': path
+        }]
+        result = self.drv._get_existing_volume({'source-name': name})
+        payload = {
+            'path': path,
+            'parent': parent,
+            'fields': 'path',
+            'recursive': False
+        }
+        list_filesystems.assert_called_with(payload)
+        expected = {
+            'name': name,
+            'path': path
+        }
+        self.assertEqual(expected, result)
+
+    def test__check_already_managed_snapshot(self):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        result = self.drv._check_already_managed_snapshot(snapshot)
+        expected = False
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.list')
+    def test__get_existing_snapshot(self, list_snapshots):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        name = snapshot['name']
+        path = self.drv._get_snapshot_path(snapshot)
+        parent = self.drv._get_volume_path(volume)
+        list_snapshots.return_value = [{
+            'name': name,
+            'path': path
+        }]
+        payload = {'source-name': name}
+        result = self.drv._get_existing_snapshot(snapshot, payload)
+        payload = {
+            'parent': parent,
+            'fields': 'name,path',
+            'recursive': False,
+            'name': name
+        }
+        list_snapshots.assert_called_with(payload)
+        expected = {
+            'name': name,
+            'path': path,
+            'volume_name': volume['name'],
+            'volume_size': volume['size']
+        }
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.rename')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._get_existing_volume')
+    def test_manage_existing(self, get_existing_volume, rename_volume):
+        existing_volume = fake_volume(self.ctxt)
+        manage_volume_spec = {'id': fake.VOLUME2_ID}
+        manage_volume = fake_volume(self.ctxt, **manage_volume_spec)
+        existing_name = existing_volume['name']
+        existing_path = self.drv._get_volume_path(existing_volume)
+        manage_path = self.drv._get_volume_path(manage_volume)
+        get_existing_volume.return_value = {
+            'name': existing_name,
+            'path': existing_path
+        }
+        rename_volume.return_value = {}
+        payload = {'source-name': existing_name}
+        self.assertIsNone(self.drv.manage_existing(manage_volume, payload))
+        get_existing_volume.assert_called_with(payload)
+        payload = {'newPath': manage_path}
+        rename_volume.assert_called_with(existing_path, payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._unmount_volume')
+    @patch('os.path.getsize')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver.local_path')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._mount_volume')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._set_volume_acl')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._get_existing_volume')
+    def test_manage_existing_get_size(self, get_volume, set_acl,
+                                      mount_volume, get_local,
+                                      get_size, unmount_volume):
+        volume = fake_volume(self.ctxt)
+        name = volume['name']
+        size = volume['size']
+        path = self.drv._get_volume_path(volume)
+        get_volume.return_value = {
+            'name': name,
+            'path': path
+        }
+        set_acl.return_value = {}
+        mount_volume.return_value = True
+        get_local.return_value = '/path/to/volume/file'
+        get_size.return_value = size * units.Gi
+        unmount_volume.return_value = True
+        payload = {'source-name': name}
+        result = self.drv.manage_existing_get_size(volume, payload)
+        expected = size
+        self.assertEqual(expected, result)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefFilesystems.list')
+    def test_get_manageable_volumes(self, list_filesystems):
+        volume = fake_volume(self.ctxt)
+        volumes = [volume]
+        size = volume['size']
+        path = self.drv._get_volume_path(volume)
+        guid = 12345
+        parent = self.drv.root_path
+        list_filesystems.return_value = [{
+            'guid': guid,
+            'parent': parent,
+            'path': path,
+            'bytesUsed': size * units.Gi
+        }]
+        result = self.drv.get_manageable_volumes(volumes, None, 1,
+                                                 0, 'size', 'asc')
+        payload = {
+            'parent': parent,
+            'fields': 'guid,parent,path,bytesUsed',
+            'recursive': False
+        }
+        list_filesystems.assert_called_with(payload)
+        expected = [{
+            'cinder_id': volume['id'],
+            'extra_info': None,
+            'reason_not_safe': 'Volume already managed',
+            'reference': {
+                'source-guid': guid,
+                'source-name': volume['name']
+            },
+            'safe_to_manage': False,
+            'size': volume['size']
+        }]
+        self.assertEqual(expected, result)
+
+    def test_unmanage(self):
+        volume = fake_volume(self.ctxt)
+        self.assertIsNone(self.drv.unmanage(volume))
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.rename')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._get_existing_snapshot')
+    def test_manage_existing_snapshot(self, get_existing_snapshot,
+                                      rename_snapshot):
+        volume = fake_volume(self.ctxt)
+        existing_snapshot = fake_snapshot(self.ctxt)
+        existing_snapshot.volume = volume
+        manage_snapshot_spec = {'id': fake.SNAPSHOT2_ID}
+        manage_snapshot = fake_snapshot(self.ctxt, **manage_snapshot_spec)
+        manage_snapshot.volume = volume
+        existing_name = existing_snapshot['name']
+        manage_name = manage_snapshot['name']
+        volume_name = volume['name']
+        volume_size = volume['size']
+        existing_path = self.drv._get_snapshot_path(existing_snapshot)
+        get_existing_snapshot.return_value = {
+            'name': existing_name,
+            'path': existing_path,
+            'volume_name': volume_name,
+            'volume_size': volume_size
+        }
+        rename_snapshot.return_value = {}
+        payload = {'source-name': existing_name}
+        self.assertIsNone(
+            self.drv.manage_existing_snapshot(manage_snapshot, payload)
+        )
+        get_existing_snapshot.assert_called_with(manage_snapshot, payload)
+        payload = {'newName': manage_name}
+        rename_snapshot.assert_called_with(existing_path, payload)
+
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'nfs.NexentaNfsDriver._get_existing_snapshot')
+    def test_manage_existing_snapshot_get_size(self, get_snapshot):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        snapshot_name = snapshot['name']
+        volume_name = volume['name']
+        volume_size = volume['size']
+        snapshot_path = self.drv._get_snapshot_path(snapshot)
+        get_snapshot.return_value = {
+            'name': snapshot_name,
+            'path': snapshot_path,
+            'volume_name': volume_name,
+            'volume_size': volume_size
+        }
+        payload = {'source-name': snapshot_name}
+        result = self.drv.manage_existing_snapshot_get_size(volume, payload)
+        expected = volume['size']
+        self.assertEqual(expected, result)
+
+    @patch('cinder.objects.VolumeList.get_all_by_host')
+    @patch('cinder.volume.drivers.nexenta.ns5.'
+           'jsonrpc.NefSnapshots.list')
+    def test_get_manageable_snapshots(self, list_snapshots, list_volumes):
+        volume = fake_volume(self.ctxt)
+        volumes = [volume]
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        snapshots = [snapshot]
+        guid = 12345
+        name = snapshot['name']
+        path = self.drv._get_snapshot_path(snapshot)
+        parent = self.drv._get_volume_path(volume)
+        list_snapshots.return_value = [{
+            'name': name,
+            'path': path,
+            'guid': guid,
+            'parent': parent,
+            'hprService': '',
+            'snaplistId': ''
+        }]
+        list_volumes.return_value = volumes
+        result = self.drv.get_manageable_snapshots(snapshots, None, 1,
+                                                   0, 'size', 'asc')
+        payload = {
+            'parent': self.drv.root_path,
+            'fields': 'name,guid,path,parent,hprService,snaplistId',
+            'recursive': True
+        }
+        list_snapshots.assert_called_with(payload)
+        expected = [{
+            'cinder_id': snapshot['id'],
+            'extra_info': None,
+            'reason_not_safe': 'Snapshot already managed',
+            'source_reference': {
+                'name': volume['name']
+            },
+            'reference': {
+                'source-guid': guid,
+                'source-name': snapshot['name']
+            },
+            'safe_to_manage': False,
+            'size': volume['size']
+        }]
+        self.assertEqual(expected, result)
+
+    def test_unmanage_snapshot(self):
+        volume = fake_volume(self.ctxt)
+        snapshot = fake_snapshot(self.ctxt)
+        snapshot.volume = volume
+        self.assertIsNone(self.drv.unmanage_snapshot(snapshot))

--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -14,6 +14,7 @@
 #    under the License.
 
 import ipaddress
+import posixpath
 import random
 import uuid
 import six
@@ -21,10 +22,13 @@ import six
 from oslo_log import log as logging
 from oslo_utils import units
 
+from cinder import context
 from cinder import coordination
 from cinder import interface
+from cinder import objects
 from cinder.i18n import _
 from cinder.volume import driver
+from cinder.volume import utils
 from cinder.volume.drivers.nexenta import options
 from cinder.volume.drivers.nexenta.ns5.jsonrpc import NefProxy
 from cinder.volume.drivers.nexenta.ns5.jsonrpc import NefException
@@ -65,23 +69,25 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
               - Fixed HTTP authentication.
               - Added coordination for dataset operations.
         1.4.1 - Support for NexentaStor tenants.
+        1.4.2 - Added manage/unmanage/manageable-list volume/snapshot support.
     """
 
-    VERSION = '1.4.1'
-
-    # ThirdPartySystems wiki page
+    VERSION = '1.4.2'
     CI_WIKI_NAME = "Nexenta_CI"
 
+    vendor_name = 'Nexenta'
+    product_name = 'NexentaStor5'
     storage_protocol = 'iSCSI'
     driver_volume_type = 'iscsi'
-    volume_backend_name = 'NexentaStor5_iSCSI'
 
     def __init__(self, *args, **kwargs):
         super(NexentaISCSIDriver, self).__init__(*args, **kwargs)
         if not self.configuration:
-            message = (_('%(name)s backend configuration not found')
-                       % {'name': self.volume_backend_name})
-            raise NefException({'code': 'ENODATA', 'message': message})
+            message = (_('%(product_name)s %(storage_protocol)s '
+                         'backend configuration not found')
+                       % {'product_name': self.product_name,
+                          'storage_protocol': self.storage_protocol})
+            raise NefException(code='ENODATA', message=message)
         self.configuration.append_config_values(
             options.NEXENTA_CONNECTION_OPTS)
         self.configuration.append_config_values(
@@ -89,6 +95,9 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         self.configuration.append_config_values(
             options.NEXENTA_DATASET_OPTS)
         self.nef = None
+        self.volume_backend_name = (
+            self.configuration.safe_get('volume_backend_name') or
+            '%s_%s' % (self.product_name, self.storage_protocol))
         self.target_prefix = self.configuration.nexenta_target_prefix
         self.target_group_prefix = (
             self.configuration.nexenta_target_group_prefix)
@@ -101,23 +110,30 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         self.volume_group = self.configuration.nexenta_volume_group
         self.portal_port = self.configuration.nexenta_iscsi_target_portal_port
         self.portals = self.configuration.nexenta_iscsi_target_portals
-        self.dataset_sparsed = self.configuration.nexenta_sparse
-        self.dataset_deduplication = self.configuration.nexenta_dataset_dedup
-        self.dataset_compression = (
+        self.sparsed_volumes = self.configuration.nexenta_sparse
+        self.deduplicated_volumes = self.configuration.nexenta_dataset_dedup
+        self.compressed_volumes = (
             self.configuration.nexenta_dataset_compression)
         self.dataset_description = (
             self.configuration.nexenta_dataset_description)
         self.iscsi_target_portal_port = (
             self.configuration.nexenta_iscsi_target_portal_port)
-        self.root_path = '%s/%s' % (self.pool, self.volume_group)
+        self.root_path = posixpath.join(self.pool, self.volume_group)
         self.dataset_blocksize = self.configuration.nexenta_ns5_blocksize
         if not self.configuration.nexenta_ns5_blocksize > 128:
             self.dataset_blocksize *= units.Ki
+        self.group_snapshot_template = (
+            self.configuration.nexenta_group_snapshot_template)
+        self.origin_snapshot_template = (
+            self.configuration.nexenta_origin_snapshot_template)
 
     def do_setup(self, context):
         self.nef = NefProxy(self.driver_volume_type,
                             self.root_path,
                             self.configuration)
+
+    def check_for_setup_error(self):
+        """Check root volume group and iSCSI target service."""
         try:
             self.nef.volumegroups.get(self.root_path)
         except NefException as error:
@@ -126,15 +142,11 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             payload = {'path': self.root_path,
                        'volumeBlockSize': self.dataset_blocksize}
             self.nef.volumegroups.create(payload)
-
-    def check_for_setup_error(self):
-        """Check ZFS pool, volume group and iSCSI target service."""
-        self.nef.volumegroups.get(self.root_path)
         service = self.nef.services.get('iscsit')
         if service['state'] != 'online':
             message = (_('iSCSI target service is not online: %(state)s')
                        % {'state': service['state']})
-            raise NefException({'code': 'ESRCH', 'message': message})
+            raise NefException(code='ESRCH', message=message)
 
     def create_volume(self, volume):
         """Create a zfs volume on appliance.
@@ -146,7 +158,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             'path': self._get_volume_path(volume),
             'volumeSize': volume['size'] * units.Gi,
             'volumeBlockSize': self.dataset_blocksize,
-            'sparseVolume': self.dataset_sparsed
+            'compressionMode': self.compressed_volumes,
+            'sparseVolume': self.sparsed_volumes
         }
         self.nef.volumes.create(payload)
 
@@ -196,13 +209,15 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         payload = {'path': snapshot_path}
         self.nef.snapshots.create(payload)
 
+    @coordination.synchronized('{self.nef.lock}')
     def delete_snapshot(self, snapshot):
         """Deletes a snapshot.
 
         :param snapshot: snapshot reference
         """
         snapshot_path = self._get_snapshot_path(snapshot)
-        self._delete_snapshot(snapshot_path)
+        payload = {'defer': True}
+        self.nef.snapshots.delete(snapshot_path, payload)
 
     def snapshot_revert_use_temp_snapshot(self):
         # Considering that NexentaStor based drivers use COW images
@@ -237,32 +252,31 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: new volume reference
         :param src_vref: source volume reference
         """
-        snapshot_name = self._get_clone_snapshot_name(volume)
-        snapshot = {'name': snapshot_name,
-                    'volume_id': src_vref['id'],
-                    'volume_name': src_vref['name'],
-                    'volume_size': src_vref['size']}
+        snapshot = {
+            'name': self.origin_snapshot_template % volume['id'],
+            'volume_id': src_vref['id'],
+            'volume_name': src_vref['name'],
+            'volume_size': src_vref['size']
+        }
         self.create_snapshot(snapshot)
         try:
             self.create_volume_from_snapshot(volume, snapshot)
-        except NefException as volume_error:
-            LOG.debug('Failed to create cloned volume: '
-                      '%(error)s. Delete temporary snapshot '
-                      '%(volume)s@%(snapshot)s',
-                      {'error': volume_error,
-                       'volume': snapshot['volume_name'],
-                       'snapshot': snapshot['name']})
+        except NefException as error:
+            LOG.debug('Failed to create clone %(clone)s '
+                      'from volume %(volume)s: %(error)s',
+                      {'clone': volume['name'],
+                       'volume': src_vref['name'],
+                       'error': error})
+            raise error
+        finally:
             try:
                 self.delete_snapshot(snapshot)
-            except NefException as snapshot_error:
+            except NefException as error:
                 LOG.debug('Failed to delete temporary snapshot '
                           '%(volume)s@%(snapshot)s: %(error)s',
-                          {'volume': snapshot['volume_name'],
+                          {'volume': src_vref['name'],
                            'snapshot': snapshot['name'],
-                           'error': snapshot_error})
-            raise volume_error
-        snapshot_path = self._get_snapshot_path(snapshot)
-        self._delete_snapshot(snapshot_path)
+                           'error': error})
 
     def create_export(self, context, volume, connector):
         """Export a volume."""
@@ -289,7 +303,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         volume_path = self._get_volume_path(volume)
         if isinstance(connector, dict) and 'initiator' in connector:
             connectors = []
-            for attachment in volume.volume_attachment:
+            for attachment in volume['volume_attachment']:
                 connectors.append(attachment.get('connector'))
             if connectors.count(connector) > 1:
                 LOG.debug('Detected multiple connections on host '
@@ -347,14 +361,13 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
 
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor appliance."""
-        LOG.debug('Updating volume stats')
+        LOG.debug('Updating volume backend %(volume_backend_name)s stats',
+                  {'volume_backend_name': self.volume_backend_name})
         payload = {'fields': 'bytesAvailable,bytesUsed'}
-        stats = self.nef.volumegroups.get(self.root_path, payload)
-        volume_backend_name = (
-            self.configuration.safe_get('volume_backend_name') or
-            self.volume_backend_name)
-        free = stats['bytesAvailable'] // units.Gi
-        allocated = stats['bytesUsed'] // units.Gi
+        dataset = self.nef.volumegroups.get(self.root_path, payload)
+        free = dataset['bytesAvailable'] // units.Gi
+        used = dataset['bytesUsed'] // units.Gi
+        total = free + used
         location_info = '%(driver)s:%(host)s:%(pool)s/%(group)s' % {
             'driver': self.__class__.__name__,
             'host': self.iscsi_host,
@@ -362,50 +375,37 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             'group': self.volume_group,
         }
         self._stats = {
-            'vendor_name': 'Nexenta',
-            'dedup': self.dataset_deduplication,
-            'compression': self.dataset_compression,
+            'vendor_name': self.vendor_name,
+            'dedup': self.deduplicated_volumes,
+            'compression': self.compressed_volumes,
             'description': self.dataset_description,
+            'nef_url': self.nef.host,
+            'nef_port': self.nef.port,
             'driver_version': self.VERSION,
             'storage_protocol': self.storage_protocol,
-            'sparsed_volumes': self.dataset_sparsed,
-            'total_capacity_gb': free + allocated,
+            'sparsed_volumes': self.sparsed_volumes,
+            'total_capacity_gb': total,
             'free_capacity_gb': free,
             'reserved_percentage': self.configuration.reserved_percentage,
             'QoS_support': False,
             'multiattach': True,
             'consistencygroup_support': True,
             'consistent_group_snapshot_enabled': True,
-            'volume_backend_name': volume_backend_name,
             'location_info': location_info,
-            'iscsi_target_portal_port': self.iscsi_target_portal_port,
-            'nef_url': self.nef.host,
-            'nef_port': self.nef.port
+            'volume_backend_name': self.volume_backend_name,
+            'iscsi_target_portal_port': self.iscsi_target_portal_port
         }
 
     def _get_volume_path(self, volume):
         """Return ZFS datset path for the volume."""
-        return '%s/%s' % (self.root_path, volume['name'])
+        return posixpath.join(self.root_path, volume['name'])
 
     def _get_snapshot_path(self, snapshot):
         """Return ZFS snapshot path for the snapshot."""
-        return '%s/%s@%s' % (self.root_path, snapshot['volume_name'],
-                             snapshot['name'])
-
-    def _get_cgsnapshot_path(self, cgsnapshot):
-        """Return ZFS snapshot path for the consistency group snapshot."""
-        name = self._get_cgsnapshot_name(cgsnapshot)
-        return '%s@%s' % (self.root_path, name)
-
-    @staticmethod
-    def _get_clone_snapshot_name(volume):
-        """Return snapshot name that will be used to clone the volume."""
-        return 'cinder-clone-snapshot-%s' % volume['id']
-
-    @staticmethod
-    def _get_cgsnapshot_name(cgsnapshot):
-        """Return cgsnapshot name for the consistency group snapshot."""
-        return 'cgsnapshot-%s' % cgsnapshot['id']
+        volume_name = snapshot['volume_name']
+        snapshot_name = snapshot['name']
+        volume_path = posixpath.join(self.root_path, volume_name)
+        return '%s@%s' % (volume_path, snapshot_name)
 
     def _get_target_group_name(self, target_name):
         """Return Nexenta iSCSI target group name for volume."""
@@ -662,7 +662,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         if not mapping:
             message = (_('Failed to get LUN number for %(volume)s')
                        % {'volume': volume_path})
-            raise NefException({'code': 'ENOTBLK', 'message': message})
+            raise NefException(code='ENOTBLK', message=message)
         lun = mapping[0]['lun']
         props_luns = [lun] * len(props_iqns)
 
@@ -829,13 +829,6 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         remove_volumes_update = []
         return group_model_update, add_volumes_update, remove_volumes_update
 
-    @coordination.synchronized('{self.nef.lock}')
-    def _rename_cgsnapshot(self, cgsnapshot, snapshot):
-        path = '%s/%s@%s' % (self.root_path, snapshot['volume_name'],
-                             self._get_cgsnapshot_name(cgsnapshot))
-        payload = {'newName': snapshot['name']}
-        self.nef.snapshots.rename(path, payload)
-
     def create_cgsnapshot(self, context, cgsnapshot, snapshots):
         """Creates a consistency group snapshot.
 
@@ -846,12 +839,19 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         """
         group_model_update = {}
         snapshots_model_update = []
-        path = self._get_cgsnapshot_path(cgsnapshot)
-        payload = {'path': path, 'recursive': True}
-        self.nef.snapshots.create(payload)
+        cgsnapshot_name = self.group_snapshot_template % cgsnapshot['id']
+        cgsnapshot_path = '%s@%s' % (self.root_path, cgsnapshot_name)
+        create_payload = {'path': cgsnapshot_path, 'recursive': True}
+        self.nef.snapshots.create(create_payload)
         for snapshot in snapshots:
-            self._rename_cgsnapshot(cgsnapshot, snapshot)
-        self._delete_snapshot(path, True)
+            volume_name = snapshot['volume_name']
+            volume_path = posixpath.join(self.root_path, volume_name)
+            snapshot_name = snapshot['name']
+            snapshot_path = '%s@%s' % (volume_path, cgsnapshot_name)
+            rename_payload = {'newName': snapshot_name}
+            self.nef.snapshots.rename(snapshot_path, rename_payload)
+        delete_payload = {'defer': True, 'recursive': True}
+        self.nef.snapshots.delete(cgsnapshot_path, delete_payload)
         return group_model_update, snapshots_model_update
 
     def delete_cgsnapshot(self, context, cgsnapshot, snapshots):
@@ -888,16 +888,483 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             for volume, snapshot in zip(volumes, snapshots):
                 self.create_volume_from_snapshot(volume, snapshot)
         elif source_cg and source_vols:
-            path = self._get_cgsnapshot_path(group)
-            payload = {'path': path, 'recursive': True}
-            self.nef.snapshots.create(payload)
+            snapshot_name = self.origin_snapshot_template % group['id']
+            snapshot_path = '%s@%s' % (self.root_path, snapshot_name)
+            create_payload = {'path': snapshot_path, 'recursive': True}
+            self.nef.snapshots.create(create_payload)
             for volume, source_vol in zip(volumes, source_vols):
-                snapshot_name = self._get_clone_snapshot_name(volume)
-                snapshot = {'name': snapshot_name,
-                            'volume_id': source_vol['id'],
-                            'volume_name': source_vol['name'],
-                            'volume_size': source_vol['size']}
-                self._rename_cgsnapshot(group, snapshot)
+                snapshot = {
+                    'name': snapshot_name,
+                    'volume_id': source_vol['id'],
+                    'volume_name': source_vol['name'],
+                    'volume_size': source_vol['size']
+                }
                 self.create_volume_from_snapshot(volume, snapshot)
-            self._delete_snapshot(path, True)
+            delete_payload = {'defer': True, 'recursive': True}
+            self.nef.snapshots.delete(snapshot_path, delete_payload)
         return group_model_update, volumes_model_update
+
+    def _get_existing_volume(self, existing_ref):
+        types = {
+            'source-name': 'name',
+            'source-guid': 'guid'
+        }
+        if not any(key in types for key in existing_ref):
+            keys = ', '.join(types.keys())
+            message = (_('Manage existing volume failed '
+                         'due to invalid backend reference. '
+                         'Volume reference must contain '
+                         'at least one valid key: %(keys)s')
+                       % {'keys': keys})
+            raise NefException(code='EINVAL', message=message)
+        payload = {
+            'parent': self.root_path,
+            'fields': 'name,path,volumeSize'
+        }
+        for key, value in types.items():
+            if key in existing_ref:
+                payload[value] = existing_ref[key]
+        existing_volumes = self.nef.volumes.list(payload)
+        if len(existing_volumes) == 1:
+            volume_path = existing_volumes[0]['path']
+            volume_name = existing_volumes[0]['name']
+            volume_size = existing_volumes[0]['volumeSize'] // units.Gi
+            existing_volume = {
+                'name': volume_name,
+                'path': volume_path,
+                'size': volume_size
+            }
+            vid = utils.extract_id_from_volume_name(volume_name)
+            if utils.check_already_managed_volume(vid):
+                message = (_('Volume %(name)s already managed')
+                           % {'name': volume_name})
+                raise NefException(code='EBUSY', message=message)
+            return existing_volume
+        elif not existing_volumes:
+            code = 'ENOENT'
+            reason = _('no matching volumes were found')
+        else:
+            code = 'EINVAL'
+            reason = _('too many volumes were found')
+        message = (_('Unable to manage existing volume by '
+                     'reference %(reference)s: %(reason)s')
+                   % {'reference': existing_ref, 'reason': reason})
+        raise NefException(code=code, message=message)
+
+    def _check_already_managed_snapshot(self, snapshot_id):
+        """Check cinder database for already managed snapshot.
+
+        :param snapshot_id: snapshot id parameter
+        :returns: return True, if database entry with specified
+                  snapshot id exists, otherwise return False
+        """
+        if not isinstance(snapshot_id, six.string_types):
+            return False
+        try:
+            uuid.UUID(snapshot_id, version=4)
+        except ValueError:
+            return False
+        ctxt = context.get_admin_context()
+        return objects.Snapshot.exists(ctxt, snapshot_id)
+
+    def _get_existing_snapshot(self, snapshot, existing_ref):
+        types = {
+            'source-name': 'name',
+            'source-guid': 'guid'
+        }
+        if not any(key in types for key in existing_ref):
+            keys = ', '.join(types.keys())
+            message = (_('Manage existing snapshot failed '
+                         'due to invalid backend reference. '
+                         'Snapshot reference must contain '
+                         'at least one valid key: %(keys)s')
+                       % {'keys': keys})
+            raise NefException(code='EINVAL', message=message)
+        volume_name = snapshot['volume_name']
+        volume_size = snapshot['volume_size']
+        volume = {'name': volume_name}
+        volume_path = self._get_volume_path(volume)
+        payload = {
+            'parent': volume_path,
+            'fields': 'name,path',
+            'recursive': False
+        }
+        for key, value in types.items():
+            if key in existing_ref:
+                payload[value] = existing_ref[key]
+        existing_snapshots = self.nef.snapshots.list(payload)
+        if len(existing_snapshots) == 1:
+            name = existing_snapshots[0]['name']
+            path = existing_snapshots[0]['path']
+            existing_snapshot = {
+                'name': name,
+                'path': path,
+                'volume_name': volume_name,
+                'volume_size': volume_size
+            }
+            sid = utils.extract_id_from_snapshot_name(name)
+            if self._check_already_managed_snapshot(sid):
+                message = (_('Snapshot %(name)s already managed')
+                           % {'name': name})
+                raise NefException(code='EBUSY', message=message)
+            return existing_snapshot
+        elif not existing_snapshots:
+            code = 'ENOENT'
+            reason = _('no matching snapshots were found')
+        else:
+            code = 'EINVAL'
+            reason = _('too many snapshots were found')
+        message = (_('Unable to manage existing snapshot by '
+                     'reference %(reference)s: %(reason)s')
+                   % {'reference': existing_ref, 'reason': reason})
+        raise NefException(code=code, message=message)
+
+    @coordination.synchronized('{self.nef.lock}')
+    def manage_existing(self, volume, existing_ref):
+        """Brings an existing backend storage object under Cinder management.
+
+        existing_ref is passed straight through from the API request's
+        manage_existing_ref value, and it is up to the driver how this should
+        be interpreted.  It should be sufficient to identify a storage object
+        that the driver should somehow associate with the newly-created cinder
+        volume structure.
+
+        There are two ways to do this:
+
+        1. Rename the backend storage object so that it matches the,
+           volume['name'] which is how drivers traditionally map between a
+           cinder volume and the associated backend storage object.
+
+        2. Place some metadata on the volume, or somewhere in the backend, that
+           allows other driver requests (e.g. delete, clone, attach, detach...)
+           to locate the backend storage object when required.
+
+        If the existing_ref doesn't make sense, or doesn't refer to an existing
+        backend storage object, raise a ManageExistingInvalidReference
+        exception.
+
+        The volume may have a volume_type, and the driver can inspect that and
+        compare against the properties of the referenced backend storage
+        object.  If they are incompatible, raise a
+        ManageExistingVolumeTypeMismatch, specifying a reason for the failure.
+
+        :param volume:       Cinder volume to manage
+        :param existing_ref: Driver-specific information used to identify a
+                             volume
+        """
+        existing_volume = self._get_existing_volume(existing_ref)
+        existing_volume_path = existing_volume['path']
+        payload = {'volume': existing_volume_path}
+        mappings = self.nef.mappings.list(payload)
+        if mappings:
+            message = (_('Failed to manage existing volume %(path)s '
+                         'due to existing LUN mappings: %(mappings)s')
+                       % {'path': existing_volume_path,
+                          'mappings': mappings})
+            raise NefException(code='EEXIST', message=message)
+        if existing_volume['name'] != volume['name']:
+            volume_path = self._get_volume_path(volume)
+            payload = {'newPath': volume_path}
+            self.nef.volumes.rename(existing_volume_path, payload)
+
+    def manage_existing_get_size(self, volume, existing_ref):
+        """Return size of volume to be managed by manage_existing.
+
+        When calculating the size, round up to the next GB.
+
+        :param volume:       Cinder volume to manage
+        :param existing_ref: Driver-specific information used to identify a
+                             volume
+        :returns size:       Volume size in GiB (integer)
+        """
+        existing_volume = self._get_existing_volume(existing_ref)
+        return existing_volume['size']
+
+    def get_manageable_volumes(self, cinder_volumes, marker, limit, offset,
+                               sort_keys, sort_dirs):
+        """List volumes on the backend available for management by Cinder.
+
+        Returns a list of dictionaries, each specifying a volume in the host,
+        with the following keys:
+        - reference (dictionary): The reference for a volume, which can be
+          passed to "manage_existing".
+        - size (int): The size of the volume according to the storage
+          backend, rounded up to the nearest GB.
+        - safe_to_manage (boolean): Whether or not this volume is safe to
+          manage according to the storage backend. For example, is the volume
+          in use or invalid for any reason.
+        - reason_not_safe (string): If safe_to_manage is False, the reason why.
+        - cinder_id (string): If already managed, provide the Cinder ID.
+        - extra_info (string): Any extra information to return to the user
+
+        :param cinder_volumes: A list of volumes in this host that Cinder
+                               currently manages, used to determine if
+                               a volume is manageable or not.
+        :param marker:    The last item of the previous page; we return the
+                          next results after this value (after sorting)
+        :param limit:     Maximum number of items to return
+        :param offset:    Number of items to skip after marker
+        :param sort_keys: List of keys to sort results by (valid keys are
+                          'identifier' and 'size')
+        :param sort_dirs: List of directions to sort by, corresponding to
+                          sort_keys (valid directions are 'asc' and 'desc')
+        """
+        manageable_volumes = []
+        cinder_volume_names = {}
+        for cinder_volume in cinder_volumes:
+            key = cinder_volume['name']
+            value = cinder_volume['id']
+            cinder_volume_names[key] = value
+        payload = {
+            'parent': self.root_path,
+            'fields': 'name,guid,path,volumeSize',
+            'recursive': False
+        }
+        volumes = self.nef.volumes.list(payload)
+        for volume in volumes:
+            safe_to_manage = True
+            reason_not_safe = None
+            cinder_id = None
+            extra_info = None
+            path = volume['path']
+            guid = volume['guid']
+            size = volume['volumeSize'] // units.Gi
+            name = volume['name']
+            if name in cinder_volume_names:
+                cinder_id = cinder_volume_names[name]
+                safe_to_manage = False
+                reason_not_safe = _('Volume already managed')
+            else:
+                payload = {
+                    'volume': path,
+                    'fields': 'hostGroup'
+                }
+                mappings = self.nef.mappings.list(payload)
+                members = []
+                for mapping in mappings:
+                    hostgroup = mapping['hostGroup']
+                    if hostgroup == options.DEFAULT_HOST_GROUP:
+                        members.append(hostgroup)
+                    else:
+                        group = self.nef.hostgroups.get(hostgroup)
+                        members += group['members']
+                if members:
+                    safe_to_manage = False
+                    hosts = ', '.join(members)
+                    reason_not_safe = (_('Volume is connected '
+                                         'to host(s) %(hosts)s')
+                                       % {'hosts': hosts})
+            reference = {
+                'source-name': name,
+                'source-guid': guid
+            }
+            manageable_volumes.append({
+                'reference': reference,
+                'size': size,
+                'safe_to_manage': safe_to_manage,
+                'reason_not_safe': reason_not_safe,
+                'cinder_id': cinder_id,
+                'extra_info': extra_info
+            })
+        return utils.paginate_entries_list(manageable_volumes,
+                                           marker, limit, offset,
+                                           sort_keys, sort_dirs)
+
+    def unmanage(self, volume):
+        """Removes the specified volume from Cinder management.
+
+        Does not delete the underlying backend storage object.
+
+        For most drivers, this will not need to do anything.  However, some
+        drivers might use this call as an opportunity to clean up any
+        Cinder-specific configuration that they have associated with the
+        backend storage object.
+
+        :param volume: Cinder volume to unmanage
+        """
+        pass
+
+    @coordination.synchronized('{self.nef.lock}')
+    def manage_existing_snapshot(self, snapshot, existing_ref):
+        """Brings an existing backend storage object under Cinder management.
+
+        existing_ref is passed straight through from the API request's
+        manage_existing_ref value, and it is up to the driver how this should
+        be interpreted.  It should be sufficient to identify a storage object
+        that the driver should somehow associate with the newly-created cinder
+        snapshot structure.
+
+        There are two ways to do this:
+
+        1. Rename the backend storage object so that it matches the
+           snapshot['name'] which is how drivers traditionally map between a
+           cinder snapshot and the associated backend storage object.
+
+        2. Place some metadata on the snapshot, or somewhere in the backend,
+           that allows other driver requests (e.g. delete) to locate the
+           backend storage object when required.
+
+        If the existing_ref doesn't make sense, or doesn't refer to an existing
+        backend storage object, raise a ManageExistingInvalidReference
+        exception.
+
+        :param snapshot:     Cinder volume snapshot to manage
+        :param existing_ref: Driver-specific information used to identify a
+                             volume snapshot
+        """
+        existing_snapshot = self._get_existing_snapshot(snapshot, existing_ref)
+        existing_snapshot_path = existing_snapshot['path']
+        if existing_snapshot['name'] != snapshot['name']:
+            payload = {'newName': snapshot['name']}
+            self.nef.snapshots.rename(existing_snapshot_path, payload)
+
+    def manage_existing_snapshot_get_size(self, snapshot, existing_ref):
+        """Return size of snapshot to be managed by manage_existing.
+
+        When calculating the size, round up to the next GB.
+
+        :param snapshot:     Cinder volume snapshot to manage
+        :param existing_ref: Driver-specific information used to identify a
+                             volume snapshot
+        :returns size:       Volume snapshot size in GiB (integer)
+        """
+        existing_snapshot = self._get_existing_snapshot(snapshot, existing_ref)
+        return existing_snapshot['volume_size']
+
+    def get_manageable_snapshots(self, cinder_snapshots, marker, limit, offset,
+                                 sort_keys, sort_dirs):
+        """List snapshots on the backend available for management by Cinder.
+
+        Returns a list of dictionaries, each specifying a snapshot in the host,
+        with the following keys:
+        - reference (dictionary): The reference for a snapshot, which can be
+          passed to "manage_existing_snapshot".
+        - size (int): The size of the snapshot according to the storage
+          backend, rounded up to the nearest GB.
+        - safe_to_manage (boolean): Whether or not this snapshot is safe to
+          manage according to the storage backend. For example, is the snapshot
+          in use or invalid for any reason.
+        - reason_not_safe (string): If safe_to_manage is False, the reason why.
+        - cinder_id (string): If already managed, provide the Cinder ID.
+        - extra_info (string): Any extra information to return to the user
+        - source_reference (string): Similar to "reference", but for the
+          snapshot's source volume.
+
+        :param cinder_snapshots: A list of snapshots in this host that Cinder
+                                 currently manages, used to determine if
+                                 a snapshot is manageable or not.
+        :param marker:    The last item of the previous page; we return the
+                          next results after this value (after sorting)
+        :param limit:     Maximum number of items to return
+        :param offset:    Number of items to skip after marker
+        :param sort_keys: List of keys to sort results by (valid keys are
+                          'identifier' and 'size')
+        :param sort_dirs: List of directions to sort by, corresponding to
+                          sort_keys (valid directions are 'asc' and 'desc')
+
+        """
+        manageable_snapshots = []
+        cinder_volume_names = {}
+        cinder_snapshot_names = {}
+        ctxt = context.get_admin_context()
+        cinder_volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        for cinder_volume in cinder_volumes:
+            key = self._get_volume_path(cinder_volume)
+            value = {
+                'name': cinder_volume['name'],
+                'size': cinder_volume['size']
+            }
+            cinder_volume_names[key] = value
+        for cinder_snapshot in cinder_snapshots:
+            key = cinder_snapshot['name']
+            value = {
+                'id': cinder_snapshot['id'],
+                'size': cinder_snapshot['volume_size'],
+                'parent': cinder_snapshot['volume_name']
+            }
+            cinder_snapshot_names[key] = value
+        payload = {
+            'parent': self.root_path,
+            'fields': 'name,guid,path,parent,hprService,snaplistId',
+            'recursive': True
+        }
+        snapshots = self.nef.snapshots.list(payload)
+        for snapshot in snapshots:
+            safe_to_manage = True
+            reason_not_safe = None
+            cinder_id = None
+            extra_info = None
+            name = snapshot['name']
+            guid = snapshot['guid']
+            path = snapshot['path']
+            parent = snapshot['parent']
+            if parent not in cinder_volume_names:
+                LOG.debug('Skip snapshot %(path)s: parent '
+                          'volume %(parent)s is unmanaged',
+                          {'path': path, 'parent': parent})
+                continue
+            if name.startswith(self.origin_snapshot_template):
+                LOG.debug('Skip temporary origin snapshot %(path)s',
+                          {'path': path})
+                continue
+            if name.startswith(self.group_snapshot_template):
+                LOG.debug('Skip temporary group snapshot %(path)s',
+                          {'path': path})
+                continue
+            if snapshot['hprService'] or snapshot['snaplistId']:
+                LOG.debug('Skip HPR/snapping snapshot %(path)s',
+                          {'path': path})
+                continue
+            if name in cinder_snapshot_names:
+                size = cinder_snapshot_names[name]['size']
+                cinder_id = cinder_snapshot_names[name]['id']
+                safe_to_manage = False
+                reason_not_safe = _('Snapshot already managed')
+            else:
+                size = cinder_volume_names[parent]['size']
+                payload = {'fields': 'clones'}
+                props = self.nef.snapshots.get(path)
+                clones = props['clones']
+                unmanaged_clones = []
+                for clone in clones:
+                    if not clone in cinder_volume_names:
+                        unmanaged_clones.append(clone)
+                if unmanaged_clones:
+                    safe_to_manage = False
+                    dependent_clones = ', '.join(unmanaged_clones)
+                    reason_not_safe = (_('Snapshot has unmanaged '
+                                         'dependent clone(s) %(clones)s')
+                                       % {'clones': dependent_clones})
+            reference = {
+                'source-name': name,
+                'source-guid': guid
+            }
+            source_reference = {
+                'name': cinder_volume_names[parent]['name']
+            }
+            manageable_snapshots.append({
+                'reference': reference,
+                'size': size,
+                'safe_to_manage': safe_to_manage,
+                'reason_not_safe': reason_not_safe,
+                'cinder_id': cinder_id,
+                'extra_info': extra_info,
+                'source_reference': source_reference
+            })
+        return utils.paginate_entries_list(manageable_snapshots,
+                                           marker, limit, offset,
+                                           sort_keys, sort_dirs)
+
+    def unmanage_snapshot(self, snapshot):
+        """Removes the specified snapshot from Cinder management.
+
+        Does not delete the underlying backend storage object.
+
+        For most drivers, this will not need to do anything. However, some
+        drivers might use this call as an opportunity to clean up any
+        Cinder-specific configuration that they have associated with the
+        backend storage object.
+
+        :param snapshot: Cinder volume snapshot to unmanage
+        """
+        pass

--- a/cinder/volume/drivers/nexenta/options.py
+++ b/cinder/volume/drivers/nexenta/options.py
@@ -213,6 +213,12 @@ NEXENTA_DATASET_OPTS = [
     cfg.BoolOpt('nexenta_sparse',
                 default=False,
                 help='Enables or disables the creation of sparse datasets'),
+    cfg.StrOpt('nexenta_origin_snapshot_template',
+               default='origin-snapshot-%s',
+               help='Template string to generate origin name of clone'),
+    cfg.StrOpt('nexenta_group_snapshot_template',
+               default='group-snapshot-%s',
+               help='Template string to generate group snapshot name')
 ]
 
 NEXENTA_RRMGR_OPTS = [


### PR DESCRIPTION
**NEX-19807 Nexenta Cinder driver: support for manage/unmanage volumes**

**Pep8**
```
$ tox -e pep8
pep8 develop-inst-noop: /opt/stack/cinder
pep8 installed: alabaster==0.7.12,alembic==1.0.6,amqp==2.4.0,appdirs==1.4.3,asn1crypto==0.24.0,automaton==1.15.0,Babel==2.6.0,bandit==1.5.1,bcrypt==3.1.6,cachetools==3.0.0,castellan==1.1.0,certifi==2018.11.29,cffi==1.11.5,chardet==3.0.4,-e git://git.openstack.org/openstack/cinder.git@c8976b726a9a19c3860e49ba249738b50e652f14#egg=cinder,cliff==2.14.0,cmd2==0.8.9,contextlib2==0.5.5,coverage==4.5.2,cryptography==2.4.2,cursive==0.2.2,ddt==1.2.0,debtcollector==1.20.0,decorator==4.3.0,defusedxml==0.5.0,dnspython==1.16.0,docutils==0.14,dogpile.cache==0.6.8,dulwich==0.19.10,enum34==1.1.6,eventlet==0.24.1,extras==1.0.0,fasteners==0.14.1,fixtures==3.0.0,flake8==2.5.5,funcsigs==1.0.2,functools32==3.2.3.post2,future==0.17.1,futures==3.2.0,futurist==1.8.0,gitdb2==2.0.5,GitPython==2.1.11,google-api-python-client==1.7.7,google-auth==1.6.2,google-auth-httplib2==0.0.3,greenlet==0.4.15,grpcio==1.15.0,hacking==0.12.0,httplib2==0.12.0,idna==2.8,imagesize==1.1.0,ipaddress==1.0.22,iso8601==0.1.12,Jinja2==2.10,jmespath==0.9.3,jsonpatch==1.23,jsonpointer==2.0,jsonschema==2.6.0,keystoneauth1==3.11.2,keystonemiddleware==5.3.0,kombu==4.2.2.post1,linecache2==1.0.0,lxml==4.3.0,Mako==1.0.7,MarkupSafe==1.1.0,mccabe==0.2.1,mock==2.0.0,monotonic==1.5,mox3==0.26.0,msgpack==0.6.0,munch==2.3.2,netaddr==0.7.19,netifaces==0.10.9,networkx==2.2,oauth2client==4.1.3,openstackdocstheme==1.28.1,openstacksdk==0.23.0,os-api-ref==1.6.0,os-brick==2.7.0,os-client-config==1.31.2,os-service-types==1.4.0,os-win==4.2.0,oslo.cache==1.32.0,oslo.concurrency==3.29.0,oslo.config==6.8.0,oslo.context==2.22.0,oslo.db==4.43.0,oslo.i18n==3.23.0,oslo.log==3.42.2,oslo.messaging==9.3.1,oslo.middleware==3.37.0,oslo.policy==2.0.0,oslo.privsep==1.31.1,oslo.reports==1.29.1,oslo.rootwrap==5.15.1,oslo.serialization==2.28.1,oslo.service==1.34.0,oslo.upgradecheck==0.1.1,oslo.utils==3.40.1,oslo.versionedobjects==1.34.1,oslo.vmware==2.32.1,oslotest==3.7.0,osprofiler==2.5.2,packaging==18.0,paramiko==2.4.2,Paste==3.0.6,PasteDeploy==2.0.1,pbr==5.1.1,pep8==1.5.7,prettytable==0.7.2,psutil==5.4.8,psycopg2==2.7.6.1,pyasn1==0.4.5,pyasn1-modules==0.2.3,pycadf==2.8.0,pycparser==2.19,pydot==1.4.1,pyflakes==0.8.1,Pygments==2.3.1,pyinotify==0.9.6,PyMySQL==0.9.3,PyNaCl==1.3.0,pyOpenSSL==19.0.0,pyparsing==2.3.1,pyperclip==1.7.0,python-barbicanclient==4.8.1,python-dateutil==2.7.5,python-editor==1.0.3,python-glanceclient==2.15.0,python-keystoneclient==3.18.0,python-mimeparse==1.6.0,python-novaclient==11.1.0,python-subunit==1.3.0,python-swiftclient==3.6.0,pytz==2018.9,pyudev==0.21.0,PyYAML==3.13,reno==2.11.2,repoze.lru==0.7,requests==2.21.0,requestsexceptions==1.4.0,retrying==1.3.3,rfc3986==1.2.0,Routes==2.4.1,rsa==4.0,rtslib-fb==2.1.66,simplejson==3.16.0,six==1.12.0,smmap2==2.0.5,snowballstemmer==1.2.1,Sphinx==1.8.3,sphinxcontrib-websupport==1.1.0,SQLAlchemy==1.2.16,sqlalchemy-migrate==0.11.0,sqlparse==0.2.4,statsd==3.3.0,stestr==2.2.0,stevedore==1.30.0,subprocess32==3.5.3,suds-jurko==0.6,taskflow==3.4.0,Tempita==0.5.2,tenacity==5.0.2,testresources==2.0.1,testscenarios==0.5.0,testtools==2.3.0,tooz==1.64.0,traceback2==1.4.0,typing==3.6.6,unicodecsv==0.14.1,unittest2==1.1.0,uritemplate==3.0.0,urllib3==1.24.1,vine==1.2.0,voluptuous==0.11.5,warlock==1.3.0,wcwidth==0.1.7,WebOb==1.8.5,wrapt==1.11.1
pep8 run-test-pre: PYTHONHASHSEED='2955484570'
pep8 runtests: commands[0] | flake8 .
pep8 runtests: commands[1] | /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 runtests: commands[2] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder /opt/stack/cinder/doc/source/ /opt/stack/cinder/releasenotes/notes
_____________________________________________________________________________________________________________________ summary _____________________________________________________________________________________________________________________
  pep8: commands succeeded
  congratulations :)
```

**Tempest iSCSI**
```
======
Totals
======
Ran: 273 tests in 4242.0000 sec.
 - Passed: 269
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3359.7528 sec.
```

**Tempest NFS**
```
======
Totals
======
Ran: 273 tests in 7634.0000 sec.
 - Passed: 268
 - Skipped: 5
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 6182.6790 sec.
```

**Unit tests for iSCSI / python2**
```
======
Totals
======
Ran: 51 tests in 2.0000 sec.
 - Passed: 51
 - Skipped: 0
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 7.1122 sec.
```

**Unit tests for iSCSI / python3**
```
======
Totals
======
Ran: 51 tests in 2.5023 sec.
 - Passed: 51
 - Skipped: 0
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 7.8328 sec.
```

**Unit tests for NFS / python2**
```
======
Totals
======
Ran: 48 tests in 2.0000 sec.
 - Passed: 48
 - Skipped: 0
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 7.2764 sec.
```

**Unit tests for NFS / python3**
```
======
Totals
======
Ran: 48 tests in 2.4294 sec.
 - Passed: 48
 - Skipped: 0
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 7.2372 sec.
```
