### PR TITLE
NEX-20320 Cinder NFS generic migration error: mount.nfs: Protocol not supported

### DIFF
--- a/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_nfs.py
+++ b/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_nfs.py
@@ -515,10 +515,12 @@ class TestNexentaNfsDriver(test.TestCase):
         result = self.drv.initialize_connection(volume, connector)
         get_share.assert_called_with(volume)
         base = self.cfg.nexenta_mount_point_base
+        options = '-o %s' % self.cfg.nas_mount_options
         expected = {
             'driver_volume_type': 'nfs',
             'mount_point_base': base,
             'data': {
+                'options': options,
                 'export': share,
                 'name': 'volume'
             }


### PR DESCRIPTION
**Fixed NFS protocol version for generic volume migration**

**Code style tests**
```
pep8 start: run-test-pre 
pep8 run-test-pre: PYTHONHASHSEED='837511469'
pep8 finish: run-test-pre  after 0.00 seconds
pep8 start: runtests 
pep8 runtests: commands[0] | flake8 .
pep8 finish: runtests  after 167.44 seconds
pep8 start: run-test-post 
pep8 finish: run-test-post  after 0.00 seconds
___________________________________________________________________ summary ___________________________________________________________________
  pep8: commands succeeded
  congratulations :)
```

**Unit tests**
```
======
Totals
======
Ran: 196 tests in 4.2176 sec.
 - Passed: 196
 - Skipped: 0
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 14.4848 sec.
```

**Functional tests**
```
======
Totals
======
Ran: 273 tests in 4621.0000 sec.
 - Passed: 268
 - Skipped: 5
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3731.3524  sec.
```