### PR TITLE
NEX-20387 Our provided openstack driver does not deal gracefully with a slow pool

### DIFF
--- a/cinder/volume/drivers/nexenta/nfs.py
+++ b/cinder/volume/drivers/nexenta/nfs.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -13,32 +13,34 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import datetime
+import difflib
 import hashlib
+import ipaddress
 import os
-import re
-import six
+import posixpath
 
 from eventlet import greenthread
 from oslo_log import log as logging
+from oslo_utils import strutils
+from oslo_utils import timeutils
 from oslo_utils import units
+import six
 
 from cinder import context
-from cinder import db
-from cinder import exception
 from cinder.i18n import _
 from cinder import interface
+from cinder import objects
+from cinder.privsep import fs
 from cinder.volume.drivers.nexenta import jsonrpc
 from cinder.volume.drivers.nexenta import options
-from cinder.volume.drivers.nexenta import utils
 from cinder.volume.drivers import nfs
 
-VERSION = '1.3.2'
 LOG = logging.getLogger(__name__)
-BLOCK_SIZE_MB = 1
 
 
 @interface.volumedriver
-class NexentaNfsDriver(nfs.NfsDriver):  # pylint: disable=R0921
+class NexentaNfsDriver(nfs.NfsDriver):
     """Executes volume driver commands on Nexenta Appliance.
 
     Version history:
@@ -57,427 +59,158 @@ class NexentaNfsDriver(nfs.NfsDriver):  # pylint: disable=R0921
         1.3.1 - Cache capacity info and check shared folders on setup.
         1.3.2 - Pass mount_point_base in init_conn to support host-based
                 migration.
+        1.4.0 - Refactored NFS driver.
+              - Improved storage assisted volume migration.
+              - Added revert to snapshot support.
+              - Added volume multi-attach.
+              - Fixed automatic mode for nexenta_rest_protocol.
+              - Added deferred deletion for snapshots.
+              - Added synchronization for NMS REST API calls.
+              - Added configuration parameters for REST API connect/read
+                timeouts, connection retries and backoff factor.
+              - Disabled non-blocking mandatory locks.
+              - Added informative exception messages for REST API.
+              - Improved collection of backend statistics.
     """
 
-    driver_prefix = 'nexenta'
-    volume_backend_name = 'NexentaNfsDriver'
-    VERSION = VERSION
-    VOLUME_FILE_NAME = 'volume'
+    VERSION = '1.4.0'
+    CI_WIKI_NAME = 'Nexenta_CI'
 
-    # ThirdPartySystems wiki page
-    CI_WIKI_NAME = "Nexenta_CI"
+    vendor_name = 'Nexenta'
+    product_name = 'NexentaStor4'
+    storage_protocol = 'NFS'
+    driver_volume_type = 'nfs'
 
     def __init__(self, *args, **kwargs):
         super(NexentaNfsDriver, self).__init__(*args, **kwargs)
-        if self.configuration:
-            self.configuration.append_config_values(
-                options.NEXENTA_CONNECTION_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_NFS_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_DATASET_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_RRMGR_OPTS)
-
-        self.verify_ssl = self.configuration.driver_ssl_cert_verify
-        self.nms_cache_volroot = self.configuration.nexenta_nms_cache_volroot
-        self.rrmgr_compression = self.configuration.nexenta_rrmgr_compression
-        self.rrmgr_tcp_buf_size = self.configuration.nexenta_rrmgr_tcp_buf_size
-        self.rrmgr_connections = self.configuration.nexenta_rrmgr_connections
-        self.nfs_mount_point_base = self.configuration.nexenta_mount_point_base
+        if not self.configuration:
+            message = (_('%(product_name)s %(storage_protocol)s '
+                         'backend configuration not found')
+                       % {'product_name': self.product_name,
+                          'storage_protocol': self.storage_protocol})
+            raise jsonrpc.NmsException(code='ENODATA', message=message)
+        self.configuration.append_config_values(
+            options.NEXENTA_CONNECTION_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_NFS_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_DATASET_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_RRMGR_OPTS)
+        self.nms = None
+        self.driver_name = self.__class__.__name__
+        self.nas_host = self.configuration.nas_host
+        self.root_path = self.configuration.nas_share_path
+        self.mount_point_base = self.configuration.nexenta_mount_point_base
         self.volume_compression = (
             self.configuration.nexenta_dataset_compression)
-        self.volume_deduplication = self.configuration.nexenta_dataset_dedup
-        self.volume_description = (
-            self.configuration.nexenta_dataset_description)
         self.sparsed_volumes = self.configuration.nexenta_sparsed_volumes
-        self._nms2volroot = {}
-        self.share2nms = {}
-        self.nfs_versions = {}
-        self.shares_with_capacities = {}
+        self.origin_snapshot_template = (
+            self.configuration.nexenta_origin_snapshot_template)
+        self.migration_snapshot_prefix = (
+            self.configuration.nexenta_migration_snapshot_prefix)
+        self.migration_service_prefix = (
+            self.configuration.nexenta_migration_service_prefix)
+        self.migration_throttle = (
+            self.configuration.nexenta_migration_throttle)
 
-    @property
-    def backend_name(self):
-        backend_name = None
-        if self.configuration:
-            backend_name = self.configuration.safe_get('volume_backend_name')
-        if not backend_name:
-            backend_name = self.__class__.__name__
-        return backend_name
+    @staticmethod
+    def get_driver_options():
+        return (
+            options.NEXENTA_CONNECTION_OPTS +
+            options.NEXENTA_NFS_OPTS +
+            options.NEXENTA_DATASET_OPTS +
+            options.NEXENTA_RRMGR_OPTS
+        )
 
     def do_setup(self, context):
-        shares_config = getattr(self.configuration, self.driver_prefix +
-                                '_shares_config')
-        if shares_config:
-            self.configuration.nfs_shares_config = shares_config
-        super(NexentaNfsDriver, self).do_setup(context)
-        self._load_shares_config(shares_config)
-        self._mount_subfolders()
+        self.nms = jsonrpc.NmsProxy(self.driver_volume_type,
+                                    self.root_path,
+                                    self.configuration)
 
     def check_for_setup_error(self):
-        """Verify that the volume for our folder exists.
+        """Check root filesystem, NFS service and NFS share."""
+        if not self.nms.folder.object_exists(self.root_path):
+            message = (_('NFS root filesystem %(path)s not found')
+                       % {'path': self.root_path})
+            raise jsonrpc.NmsException(code='ENOENT', message=message)
+        filesystem = self.nms.folder.get_child_props(self.root_path, '')
+        if filesystem['mountpoint'] == 'none':
+            message = (_('NFS root filesystem %(path)s is not writable')
+                       % {'path': self.root_path})
+            raise jsonrpc.NefException(code='ENOENT', message=message)
+        if filesystem['mounted'] == 'no':
+            message = (_('NFS root filesystem %(path)s is not mounted')
+                       % {'path': self.root_path})
+            raise jsonrpc.NefException(code='ENOTDIR', message=message)
+        if filesystem['nbmand'] == 'on':
+            self.nms.folder.set_child_prop(self.root_path, 'nbmand', 'off')
+        fmri = 'svc:/network/nfs/server:default'
+        state = self.nms.netsvc.get_state(fmri)
+        if state != 'online':
+            message = (_('NFS service is not online: %(state)s')
+                       % {'state': state})
+            raise jsonrpc.NmsException(code='ESRCH', message=message)
+        shared = self.nms.netstorsvc.is_folder_shared(fmri, self.root_path)
+        if not shared:
+            message = (_('NFS root filesystem %(path)s is not shared')
+                       % {'path': self.root_path})
+            raise jsonrpc.NmsException(code='ENOENT', message=message)
 
-        :raise: :py:exc:`LookupError`
-        """
-        if self.share2nms:
-            for nfs_share in self.share2nms:
-                nms = self.share2nms[nfs_share]
-                volume_name, dataset = self._get_share_datasets(nfs_share)
-                if not nms.volume.object_exists(volume_name):
-                    raise LookupError(_("Volume %s does not exist in Nexenta "
-                                        "Store appliance"), volume_name)
-                folder = '%s/%s' % (volume_name, dataset)
-                if not nms.folder.object_exists(folder):
-                    raise LookupError(_("Folder %s does not exist in Nexenta "
-                                        "Store appliance"), folder)
-                if (folder not in nms.netstorsvc.get_shared_folders(
-                        'svc:/network/nfs/server:default', '')):
-                    self._share_folder(nms, volume_name, dataset)
-                self._get_capacity_info(nfs_share)
-
-    def migrate_volume(self, ctxt, volume, host):
-        """Migrate if volume and host are managed by Nexenta appliance.
-
-        :param ctxt: context
-        :param volume: a dictionary describing the volume to migrate
-        :param host: a dictionary describing the host to migrate to
-        """
-        LOG.debug('Enter: migrate_volume: id=%(id)s, host=%(host)s',
-                  {'id': volume['id'], 'host': host})
-
-        false_ret = (False, None)
-
-        if volume['status'] not in ('available', 'retyping'):
-            LOG.warning("Volume status must be 'available' or 'retyping'."
-                        " Current volume status: %s", volume['status'])
-            return false_ret
-
-        if 'capabilities' not in host:
-            LOG.warning("Unsupported host. No capabilities found")
-            return false_ret
-
-        capabilities = host['capabilities']
-        ns_shares = capabilities['ns_shares']
-        dst_parts = capabilities['location_info'].split(':')
-        dst_host, dst_volume = dst_parts[1:]
-
-        if (capabilities.get('vendor_name') != 'Nexenta' or
-                dst_parts[0] != self.__class__.__name__ or
-                capabilities['free_capacity_gb'] < volume['size']):
-            return false_ret
-
-        nms = self.share2nms[volume['provider_location']]
-        ssh_bindings = nms.appliance.ssh_list_bindings()
-        shares = []
-        for bind in ssh_bindings:
-            for share in ns_shares:
-                if (share.startswith(bind.split('@')[1].split(':')[0]) and
-                        ns_shares[share] >= volume['size']):
-                    shares.append(share)
-        if len(shares) == 0:
-            LOG.warning("Remote NexentaStor appliance at %s should be "
-                        "SSH-bound.", share)
-            return false_ret
-        share = sorted(shares, key=ns_shares.get, reverse=True)[0]
-        snapshot = {
-            'volume_name': volume['name'],
-            'volume_id': volume['id'],
-            'name': utils.get_migrate_snapshot_name(volume)
-        }
-        self.create_snapshot(snapshot)
-        location = volume['provider_location']
-        src = '%(share)s/%(volume)s@%(snapshot)s' % {
-            'share': location.split(':')[1].split('volumes/')[1],
-            'volume': volume['name'],
-            'snapshot': snapshot['name']
-        }
-        dst = ':'.join([dst_host, dst_volume.split('/volumes/')[1]])
-        try:
-            nms.appliance.execute(self._get_zfs_send_recv_cmd(src, dst))
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot send source snapshot %(src)s to "
-                        "destination %(dst)s. Reason: %(exc)s",
-                        {'src': src, 'dst': dst, 'exc': exc})
-            return false_ret
-        finally:
-            try:
-                self.delete_snapshot(snapshot)
-            except exception.NexentaException as exc:
-                LOG.warning("Cannot delete temporary source snapshot "
-                            "%(src)s on NexentaStor Appliance: %(exc)s",
-                            {'src': src, 'exc': exc})
-        try:
-            self.delete_volume(volume)
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot delete source volume %(volume)s on "
-                        "NexentaStor Appliance: %(exc)s",
-                        {'volume': volume['name'], 'exc': exc})
-
-        dst_nms = self._get_nms_for_url(capabilities['nms_url'])
-        dst_snapshot = '%s/%s@%s' % (dst_volume.split('volumes/')[1],
-                                     volume['name'], snapshot['name'])
-        try:
-            dst_nms.snapshot.destroy(dst_snapshot, '')
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot delete temporary destination snapshot "
-                        "%(dst)s on NexentaStor Appliance: %(exc)s",
-                        {'dst': dst_snapshot, 'exc': exc})
-        return True, {'provider_location': share}
-
-    def _get_zfs_send_recv_cmd(self, src, dst):
-        """Returns rrmgr command for source and destination."""
-        return utils.get_rrmgr_cmd(src, dst,
-                                   compression=self.rrmgr_compression,
-                                   tcp_buf_size=self.rrmgr_tcp_buf_size,
-                                   connections=self.rrmgr_connections)
-
-    def initialize_connection(self, volume, connector):
-        """Allow connection to connector and return connection info.
+    def create_volume(self, volume):
+        """Creates a volume.
 
         :param volume: volume reference
-        :param connector: connector reference
+        :return: model update dict for volume reference
         """
-        export = '%s/%s' % (volume['provider_location'], volume['name'])
-        data = {'export': export, 'name': 'volume'}
-        if volume['provider_location'] in self.shares:
-            data['options'] = self.shares[volume['provider_location']]
-        return {
-            'driver_volume_type': self.driver_volume_type,
-            'data': data,
-            'mount_point_base': self.nfs_mount_point_base
+        volume_path = self._get_volume_path(volume)
+        volume_options = {
+            'compression': self.volume_compression
         }
-
-    def retype(self, context, volume, new_type, diff, host):
-        """Convert the volume to be of the new type.
-
-        :param ctxt: Context
-        :param volume: A dictionary describing the volume to migrate
-        :param new_type: A dictionary describing the volume type to convert to
-        :param diff: A dictionary with the difference between the two types
-        :param host: A dictionary describing the host to migrate to, where
-                     host['host'] is its name, and host['capabilities'] is a
-                     dictionary of its reported capabilities.
-        """
-        LOG.debug('Retype volume request %(vol)s to be %(type)s '
-                  '(host: %(host)s), diff %(diff)s.',
-                  {'vol': volume['name'],
-                   'type': new_type,
-                   'host': host,
-                   'diff': diff})
-
-        options = dict(
-            compression='compression',
-            dedup='dedup',
-            description='nms:description'
-        )
-
-        retyped = False
-        migrated = False
-        model_update = None
-
-        src_backend = self.__class__.__name__
-        dst_backend = host['capabilities']['location_info'].split(':')[0]
-        if src_backend != dst_backend:
-            LOG.warning('Cannot retype from %(src_backend)s to '
-                        '%(dst_backend)s.',
-                        {
-                            'src_backend': src_backend,
-                            'dst_backend': dst_backend
-                        })
-            return False
-
-        hosts = (volume['host'], host['host'])
-        old, new = hosts
-        if old != new:
-            migrated, provider_location = self.migrate_volume(
-                context, volume, host)
-
-        if not migrated:
-            provider_location = volume['provider_location']
-            nms = self.share2nms[provider_location]
-        else:
-            nms_url = host['capabilities']['nms_url']
-            nms = self._get_nms_for_url(nms_url)
-            model_update = provider_location
-            provider_location = provider_location['provider_location']
-
-        share = provider_location.split(':')[1].split('volumes/')[1]
-        folder = '%(share)s/%(volume)s' % {
-            'share': share,
-            'volume': volume['name']
-        }
-
-        for opt in options:
-            old, new = diff.get('extra_specs').get(opt, (False, False))
-            if old != new:
-                LOG.debug('Changing %(opt)s from %(old)s to %(new)s.',
-                          {'opt': opt, 'old': old, 'new': new})
-                try:
-                    nms.folder.set_child_prop(
-                        folder, options[opt], new)
-                    retyped = True
-                except exception.NexentaException:
-                    LOG.error('Error trying to change %(opt)s'
-                              ' from %(old)s to %(new)s',
-                              {'opt': opt, 'old': old, 'new': new})
-                    return False, None
-        return retyped or migrated, model_update
-
-    def _do_create_volume(self, volume):
-        nfs_share = volume['provider_location']
-        nms = self.share2nms[nfs_share]
-
-        vol, dataset = self._get_share_datasets(nfs_share)
-        folder = '%s/%s' % (dataset, volume['name'])
-        LOG.debug('Creating folder on Nexenta Store %s', folder)
-        nms.folder.create_with_props(
-            vol, folder,
-            {'compression': self.configuration.nexenta_dataset_compression}
-        )
-
-        volume_path = self.remote_path(volume)
-        volume_size = volume['size']
+        self.nms.folder.create_with_props(self.root_path,
+                                          volume['name'],
+                                          volume_options)
         try:
-            self._share_folder(nms, vol, folder)
-
-            if getattr(self.configuration,
-                       self.driver_prefix + '_sparsed_volumes'):
-                self._create_sparsed_file(nms, volume_path, volume_size)
+            self._set_volume_acl(volume)
+            self._mount_volume(volume)
+            volume_file = self.local_path(volume)
+            volume_size = volume['size']
+            if self.sparsed_volumes:
+                self._create_sparsed_file(volume_file, volume_size)
             else:
-                folder_path = '%s/%s' % (vol, folder)
-                compression = nms.folder.get_child_prop(
-                    folder_path, 'compression')
+                compression = self.nms.folder.get_child_prop(volume_path,
+                                                             'compression')
                 if compression != 'off':
-                    # Disable compression, because otherwise will not use space
-                    # on disk.
-                    nms.folder.set_child_prop(
-                        folder_path, 'compression', 'off')
-                try:
-                    self._create_regular_file(nms, volume_path, volume_size)
-                finally:
-                    if compression != 'off':
-                        # Backup default compression value if it was changed.
-                        nms.folder.set_child_prop(
-                            folder_path, 'compression', compression)
-
-            self._set_rw_permissions_for_all(nms, volume_path)
-
-            if self._get_nfs_server_version(nfs_share) < 4:
-                sub_share, mnt_path = self._get_subshare_mount_point(nfs_share,
-                                                                     volume)
-                self._ensure_share_mounted(sub_share, mnt_path)
-            self._get_capacity_info(nfs_share)
-        except exception.NexentaException as exc:
+                    self.nms.folder.set_child_prop(volume_file,
+                                                   'compression',
+                                                   'off')
+                self._create_regular_file(volume_file, volume_size)
+                if compression != 'off':
+                    self.nms.folder.set_child_prop(volume_path,
+                                                   'compression',
+                                                   compression)
+        except jsonrpc.NmsException as create_error:
             try:
-                nms.folder.destroy('%s/%s' % (vol, folder))
-            except exception.NexentaException:
-                LOG.warning("Cannot destroy created folder: "
-                            "%(vol)s/%(folder)s",
-                            {'vol': vol, 'folder': folder})
-            raise exc
+                self.nms.folder.destroy(volume_path, '-rf')
+            except jsonrpc.NmsException as delete_error:
+                LOG.debug('Failed to delete volume %(path)s: %(error)s',
+                          {'path': volume_path, 'error': delete_error})
+            raise create_error
+        finally:
+            self._unmount_volume(volume)
 
-    def create_volume_from_snapshot(self, volume, snapshot):
-        """Create new volume from other's snapshot on appliance.
+    def copy_image_to_volume(self, context, volume, image_service, image_id):
+        LOG.debug('Copy image %(image)s to volume %(volume)s',
+                  {'image': image_id, 'volume': volume['name']})
+        self._mount_volume(volume)
+        super(NexentaNfsDriver, self).copy_image_to_volume(
+            context, volume, image_service, image_id)
+        self._unmount_volume(volume)
 
-        :param volume: reference of volume to be created
-        :param snapshot: reference of source snapshot
-        """
-        self._ensure_shares_mounted()
-
-        snapshot_vol = self._get_snapshot_volume(snapshot)
-        nfs_share = snapshot_vol['provider_location']
-        volume['provider_location'] = nfs_share
-        nms = self.share2nms[nfs_share]
-
-        vol, dataset = self._get_share_datasets(nfs_share)
-        snapshot_name = '%s/%s/%s@%s' % (vol, dataset, snapshot['volume_name'],
-                                         snapshot['name'])
-        folder = '%s/%s' % (dataset, volume['name'])
-        nms.folder.clone(snapshot_name, '%s/%s' % (vol, folder))
-
-        try:
-            self._share_folder(nms, vol, folder)
-        except exception.NexentaException as exc:
-            try:
-                nms.folder.destroy('%s/%s' % (vol, folder), '')
-            except exception.NexentaException:
-                LOG.warning("Cannot destroy cloned folder: "
-                            "%(vol)s/%(folder)s",
-                            {'vol': vol, 'folder': folder})
-            raise exc
-
-        if self._get_nfs_server_version(nfs_share) < 4:
-            sub_share, mnt_path = self._get_subshare_mount_point(nfs_share,
-                                                                 volume)
-            self._ensure_share_mounted(sub_share, mnt_path)
-
-        if (('size' in volume) and (
-                volume['size'] > snapshot['volume_size'])):
-            self.extend_volume(volume, volume['size'])
-
-        return {'provider_location': volume['provider_location']}
-
-    def create_cloned_volume(self, volume, src_vref):
-        """Creates a clone of the specified volume.
-
-        :param volume: new volume reference
-        :param src_vref: source volume reference
-        """
-        LOG.info('Creating clone of volume: %s', src_vref['id'])
-        snapshot = {'volume_name': src_vref['name'],
-                    'volume_id': src_vref['id'],
-                    'volume_size': src_vref['size'],
-                    'name': self._get_clone_snapshot_name(volume)}
-        # We don't delete this snapshot, because this snapshot will be origin
-        # of new volume. This snapshot will be automatically promoted by NMS
-        # when user will delete its origin.
-        self.create_snapshot(snapshot)
-        try:
-            return self.create_volume_from_snapshot(volume, snapshot)
-        except exception.NexentaException as exc:
-            LOG.error('Volume creation failed, deleting created snapshot '
-                      '%(volume_name)s@%(name)s', snapshot)
-            try:
-                self.delete_snapshot(snapshot)
-            except (exception.NexentaException, exception.SnapshotIsBusy):
-                LOG.warning('Failed to delete zfs snapshot '
-                            '%(volume_name)s@%(name)s', snapshot)
-            raise exc
-
-    def delete_volume(self, volume):
-        """Deletes a logical volume.
-
-        :param volume: volume reference
-        """
-        nfs_share = volume.get('provider_location')
-        if nfs_share:
-            nms = self.share2nms[nfs_share]
-            vol, parent_folder = self._get_share_datasets(nfs_share)
-            folder = '%s/%s/%s' % (vol, parent_folder, volume['name'])
-            mount_path = self.remote_path(volume).strip(
-                '/%s' % self.VOLUME_FILE_NAME)
-            if mount_path in self._remotefsclient._read_mounts():
-                self._execute('umount', mount_path, run_as_root=True)
-            try:
-                props = nms.folder.get_child_props(folder, 'origin') or {}
-                nms.folder.destroy(folder, '-r')
-            except exception.NexentaException as exc:
-                if 'does not exist' in exc.args[0]:
-                    LOG.info('Folder %s does not exist, it was '
-                             'already deleted.', folder)
-                    return
-                raise
-            self._get_capacity_info(nfs_share)
-            origin = props.get('origin')
-            if origin and self._is_clone_snapshot_name(origin):
-                try:
-                    nms.snapshot.destroy(origin, '')
-                except exception.NexentaException as exc:
-                    if 'does not exist' in exc.args[0]:
-                        LOG.info('Snapshot %s does not exist, it was '
-                                 'already deleted.', origin)
-                        return
-                    raise
+    def copy_volume_to_image(self, context, volume, image_service, image_meta):
+        LOG.debug('Copy volume %(volume)s to image %(image)s',
+                  {'volume': volume['name'], 'image': image_meta['id']})
+        self._mount_volume(volume)
+        super(NexentaNfsDriver, self).copy_volume_to_image(
+            context, volume, image_service, image_meta)
+        self._unmount_volume(volume)
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -485,352 +218,897 @@ class NexentaNfsDriver(nfs.NfsDriver):  # pylint: disable=R0921
         :param volume: volume reference
         :param new_size: volume new size in GB
         """
-        LOG.info('Extending volume: %(id)s New size: %(size)s GB',
-                 {'id': volume['id'], 'size': new_size})
-        nfs_share = volume['provider_location']
-        nms = self.share2nms[nfs_share]
-        volume_path = self.remote_path(volume)
-        if getattr(self.configuration,
-                   self.driver_prefix + '_sparsed_volumes'):
-            self._create_sparsed_file(nms, volume_path, new_size)
+        LOG.debug('Extend volume %(volume)s, new size: %(size)sGB',
+                  {'volume': volume['name'], 'size': new_size})
+        self._mount_volume(volume)
+        volume_file = self.local_path(volume)
+        if self.sparsed_volumes:
+            self._execute('truncate', '-s',
+                          '%dG' % new_size,
+                          volume_file,
+                          run_as_root=True)
         else:
-            block_count = ((new_size - volume['size']) * units.Gi /
-                           (BLOCK_SIZE_MB * units.Mi))
+            seek = volume['size'] * units.Ki
+            count = (new_size - volume['size']) * units.Ki
+            self._execute('dd',
+                          'if=/dev/zero',
+                          'of=%s' % volume_file,
+                          'bs=%d' % units.Mi,
+                          'seek=%d' % seek,
+                          'count=%d' % count,
+                          run_as_root=True)
+        self._unmount_volume(volume)
 
-            nms.appliance.execute(
-                'dd if=/dev/zero seek=%(seek)d of=%(path)s'
-                ' bs=%(bs)dM count=%(count)d' % {
-                    'seek': volume['size'] * units.Gi / (
-                        BLOCK_SIZE_MB * units.Mi),
-                    'path': volume_path,
-                    'bs': BLOCK_SIZE_MB,
-                    'count': block_count
-                }
-            )
+    def delete_volume(self, volume):
+        """Deletes a logical volume.
+
+        :param volume: volume reference
+        """
+        volume_path = self._get_volume_path(volume)
+        try:
+            origin = self.nms.folder.get_child_prop(volume_path, 'origin')
+        except jsonrpc.NmsException as error:
+            if error.code == 'ENOENT':
+                return
+            raise
+        self.nms.folder.destroy(volume_path, '-rf')
+        if not origin:
+            return
+        template = self.origin_snapshot_template
+        parent_path, snapshot_name = origin.split('@')
+        if not self._match_template(template, snapshot_name):
+            return
+        try:
+            self.nms.snapshot.destroy(origin, '-d')
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to delete origin snapshot %(origin)s '
+                      'of volume %(volume)s: %(error)s',
+                      {'origin': origin,
+                       'volume': volume['name'],
+                       'error': error})
+
+    def create_volume_from_snapshot(self, volume, snapshot):
+        """Create new volume from other's snapshot on appliance.
+
+        :param volume: reference of volume to be created
+        :param snapshot: reference of source snapshot
+        """
+        LOG.debug('Create volume %(volume)s from snapshot %(snapshot)s',
+                  {'volume': volume['name'], 'snapshot': snapshot['name']})
+        snapshot_path = self._get_snapshot_path(snapshot)
+        clone_path = self._get_volume_path(volume)
+        self.nms.folder.clone(snapshot_path, clone_path)
+        if volume['size'] > snapshot['volume_size']:
+            new_size = volume['size']
+            volume['size'] = snapshot['volume_size']
+            self.extend_volume(volume, new_size)
+            volume['size'] = new_size
+
+    def create_cloned_volume(self, volume, src_vref):
+        """Creates a clone of the specified volume.
+
+        :param volume: new volume reference
+        :param src_vref: source volume reference
+        """
+        snapshot = {
+            'name': self.origin_snapshot_template % volume['id'],
+            'volume_id': src_vref['id'],
+            'volume_name': src_vref['name'],
+            'volume_size': src_vref['size']
+        }
+        self.create_snapshot(snapshot)
+        try:
+            self.create_volume_from_snapshot(volume, snapshot)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to create clone %(clone)s '
+                      'from volume %(volume)s: %(error)s',
+                      {'clone': volume['name'],
+                       'volume': src_vref['name'],
+                       'error': error})
+            raise
+        finally:
+            try:
+                self.delete_snapshot(snapshot)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to delete temporary snapshot '
+                          '%(volume)s@%(snapshot)s: %(error)s',
+                          {'volume': src_vref['name'],
+                           'snapshot': snapshot['name'],
+                           'error': error})
+
+    def _ensure_share_unmounted(self, share):
+        """Ensure that NFS share is unmounted on the host.
+
+        :param share: share path
+        """
+        attempts = max(1, self.configuration.nfs_mount_attempts)
+        path = self._get_mount_point_for_share(share)
+        if path not in self._remotefsclient._read_mounts():
+            LOG.debug('NFS share %(share)s is not mounted at %(path)s',
+                      {'share': share, 'path': path})
+            return
+        for attempt in range(attempts):
+            try:
+                fs.umount(path)
+                LOG.debug('NFS share %(share)s has been unmounted at %(path)s',
+                          {'share': share, 'path': path})
+                break
+            except Exception as error:
+                if attempt == (attempts - 1):
+                    LOG.error('Failed to unmount NFS share %(share)s '
+                              'after %(attempts)s attempts',
+                              {'share': share, 'attempts': attempts})
+                    raise
+                LOG.debug('Unmount attempt %(attempt)s failed: %(error)s, '
+                          'retrying unmount %(share)s from %(path)s',
+                          {'attempt': attempt, 'error': error,
+                           'share': share, 'path': path})
+                greenthread.sleep(1)
+        self._delete(path)
+
+    def _delete(self, path):
+        """Override parent method for safe remove mountpoint."""
+        try:
+            os.rmdir(path)
+            LOG.debug('The mountpoint %(path)s has been successfully removed',
+                      {'path': path})
+        except OSError as error:
+            LOG.debug('Failed to remove mountpoint %(path)s: %(error)s',
+                      {'path': path, 'error': error.strerror})
+
+    def _mount_volume(self, volume):
+        """Ensure that volume is activated and mounted on the host."""
+        share = self._get_volume_share(volume)
+        self._ensure_share_mounted(share)
+
+    def _unmount_volume(self, volume):
+        """Ensure that volume is unmounted on the host."""
+        try:
+            share = self._get_volume_share(volume)
+        except jsonrpc.NmsException as error:
+            if error.code == 'ENOENT':
+                return
+        self._ensure_share_unmounted(share)
+
+    def create_export(self, context, volume, connector):
+        """Driver entry point to get the export info for a new volume."""
+        pass
+
+    def ensure_export(self, context, volume):
+        """Driver entry point to get the export info for an existing volume."""
+        pass
+
+    def remove_export(self, context, volume):
+        """Driver entry point to remove an export for a volume."""
+        pass
+
+    def terminate_connection(self, volume, connector, **kwargs):
+        """Terminate a connection to a volume.
+
+        :param volume: a volume object
+        :param connector: a connector object
+        :returns: dictionary of connection information
+        """
+        LOG.debug('Terminate volume connection for %(volume)s',
+                  {'volume': volume['name']})
+        self._unmount_volume(volume)
+
+    def initialize_connection(self, volume, connector):
+        """Allow connection to connector and return connection info.
+
+        :param volume: volume reference
+        :param connector: connector reference
+        :returns: dictionary of connection information
+        """
+        LOG.debug('Initialize volume connection for %(volume)s',
+                  {'volume': volume['name']})
+        share = self._get_volume_share(volume)
+        data = {
+            'export': share,
+            'name': 'volume'
+        }
+        nfs_options = self.configuration.safe_get('nfs_mount_options')
+        nas_options = self.configuration.safe_get('nas_mount_options')
+        if nfs_options and nas_options:
+            LOG.debug('Overriding NFS mount options for volume %(volume)s: '
+                      'nfs_mount_options = "%(nfs_options)s" with '
+                      'nas_mount_options = "%(nas_options)s"',
+                      {'volume': volume['name'],
+                       'nfs_options': nfs_options,
+                       'nas_options': nas_options})
+        if nas_options:
+            data['options'] = '-o %s' % nas_options
+        elif nfs_options:
+            data['options'] = '-o %s' % nfs_options
+        info = {
+            'driver_volume_type': self.driver_volume_type,
+            'mount_point_base': self.mount_point_base,
+            'data': data
+        }
+        return info
+
+    def _get_bound_host(self, host):
+        """Get user@host:port from SSH bindings."""
+        try:
+            bindings = self.nms.appliance.ssh_list_bindings()
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get SSH bindings: %(error)s',
+                      {'error': error})
+            return None
+        for user_host_port in bindings:
+            binding = bindings[user_host_port]
+            if not (isinstance(binding, list) and len(binding) == 4):
+                LOG.warning('Skip incompatible SSH binding: %(binding)s',
+                            {'binding': binding})
+                continue
+            data = binding[2]
+            items = data.split(',')
+            for item in items:
+                if host == item.strip():
+                    return user_host_port
+        return None
+
+    def _svc_state(self, fmri, state):
+        retries = 10
+        delay = 30
+        while retries:
+            greenthread.sleep(delay)
+            retries -= 1
+            try:
+                status = self.nms.autosvc.get_state(fmri)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to get state of migration '
+                          'service %(fmri)s: %(error)s',
+                          {'fmri': fmri, 'error': error})
+                continue
+            if status == 'uninitialized':
+                continue
+            elif status == state:
+                return True
+            if state == 'online':
+                method = getattr(self.nms.autosvc, 'enable')
+            elif state == 'disabled':
+                method = getattr(self.nms.autosvc, 'disable')
+            else:
+                LOG.error('Request unknown service state: %(state)s',
+                          {'state': state})
+                return False
+            try:
+                method(fmri)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to change state of migration service '
+                          '%(fmri)s to %(state)s: %(error)s',
+                          {'fmri': fmri, 'state': state, 'error': error})
+        LOG.error('Unable to change state of migration service %(fmri)s '
+                  'to %(state)s: maximum retries exceeded',
+                  {'fmri': fmri, 'state': state})
+        return False
+
+    def _svc_progress(self, fmri):
+        """Get progress for SMF service."""
+        progress = 0
+        try:
+            estimations = self.nms.autosync.get_estimations(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get estimations for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return progress
+        size = estimations.get('curt_siz')
+        sent = estimations.get('curt_sen')
+        try:
+            size = float(size)
+            sent = float(sent)
+            if size > 0:
+                progress = int(100 * sent / size)
+        except (TypeError, ValueError) as error:
+            LOG.error('Failed to parse estimations statistics '
+                      '%(estimations)s for migration service '
+                      '%(fmri)s: %(error)s',
+                      {'estimations': estimations,
+                       'fmri': fmri, 'error': error})
+        return progress
+
+    def _svc_result(self, fmri):
+        try:
+            props = self.nms.autosvc.get_child_props(fmri, '')
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get properties of migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return False
+        history = props.get('zfs/run_history')
+        if not history:
+            LOG.error('Failed to get history of migration service '
+                      '%(fmri)s: %(props)s',
+                      {'fmri': fmri, 'props': props})
+            return False
+        results = history.split()
+        if len(results) > 1:
+            LOG.warning('Found unexpected replication sessions for '
+                        'migration service %(fmri)s: %(history)s',
+                        {'fmri': fmri, 'history': history})
+        latest = results.pop()
+        start, stop, code = latest.split('::')
+        try:
+            start = int(start)
+            stop = int(stop)
+            code = int(code)
+        except (TypeError, ValueError) as error:
+            LOG.error('Failed to parse history %(history)s for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'history': history, 'fmri': fmri, 'error': error})
+            return False
+        delta = stop - start
+        if code != 1:
+            LOG.error('Migration service %(fmri)s failed after %(delta)s '
+                      'seconds, please check the service log below',
+                      {'fmri': fmri, 'delta': delta})
+            return False
+        LOG.info('Migration service %(fmri)s successfully finished in '
+                 '%(delta)s seconds',
+                 {'fmri': fmri, 'delta': delta})
+        return True
+
+    def _svc_cleanup(self, fmri, migrated=False):
+        props = None
+        flags = {
+            'src_properties': '1',
+            'dst_properties': '1',
+            'src_snapshots': '1',
+            'dst_snapshots': '1'
+        }
+        if not migrated:
+            flags['dst_datasets'] = '1'
+        try:
+            props = self.nms.autosvc.get_child_props(fmri, '')
+            props['zfs/sync-recursive'] = '1'
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get properties of migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        try:
+            self.nms.autosvc.unschedule(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to unschedule migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        self._svc_state(fmri, 'disabled')
+        try:
+            self.nms.autosvc.destroy(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to destroy migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        if not props:
+            return
+        try:
+            src_pid, dst_pid = self.nms.autosync.cleanup(props, flags)
+        except jsonrpc.NmsException as error:
+            src_pid = dst_pid = 0
+            LOG.error('Failed to cleanup migration service %(fmri)s: '
+                      '%(error)s',
+                      {'fmri': fmri, 'error': error})
+        for pid in [src_pid, dst_pid]:
+            while pid:
+                try:
+                    self.nms.job.get_jobparams(pid)
+                except jsonrpc.NmsException as error:
+                    if error.code == 'ENOENT':
+                        break
+                greenthread.sleep(30)
+        if migrated:
+            return
+        path = props.get('restarter/logfile')
+        if not path:
+            return
+        try:
+            content = self.nms.logviewer.get_tail(path, units.Mi)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get log file content for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return
+        log = '\n'.join(content)
+        LOG.error('Migration service %(fmri)s log: %(log)s',
+                  {'fmri': fmri, 'log': log})
+
+    def _migrate_volume(self, volume, host, path):
+        delay = 30
+        retries = 10
+        src_path = self._get_volume_path(volume)
+        dst_path = posixpath.join(path, volume['name'])
+        hosts = self._get_host_addresses()
+        if host in hosts:
+            dst_host = 'localhost'
+            service_direction = '0'
+            service_proto = 'zfs'
+            if src_path == dst_path:
+                LOG.info('Skip local to local replication: source '
+                         'volume %(src_path)s and destination volume '
+                         '%(dst_path)s are the same local volume',
+                         {'src_path': src_path, 'dst_path': dst_path})
+                return True
+        else:
+            service_direction = '1'
+            service_proto = 'zfs+rr'
+            dst_host = self._get_bound_host(host)
+            if not dst_host:
+                LOG.error('Storage assisted volume migration is '
+                          'unavailable: the destination host '
+                          '%(host)s should be SSH bound',
+                          {'host': host})
+                return False
+        service_name = '%(prefix)s-%(volume)s' % {
+            'prefix': self.migration_service_prefix,
+            'volume': volume['name']
+        }
+        comment = 'Migrate %(src)s to %(host)s:%(dst)s' % {
+            'src': src_path,
+            'host': dst_host,
+            'dst': dst_path
+        }
+        yesterday = timeutils.utcnow() - datetime.timedelta(days=1)
+        dst_path = path
+        rate_limit = 0
+        if self.migration_throttle:
+            rate_limit = self.migration_throttle * units.Ki
+        payload = {
+            'comment': comment,
+            'custom_name': service_name,
+            'from-fs': src_path,
+            'to-host': dst_host,
+            'to-fs': dst_path,
+            'direction': service_direction,
+            'marker_name': self.migration_snapshot_prefix,
+            'proto': service_proto,
+            'day': six.text_type(yesterday.day),
+            'rate_limit': six.text_type(rate_limit),
+            '_unique': 'type from-host from-fs to-host to-fs',
+            'method': 'sync',
+            'from-host': 'localhost',
+            'period_multiplier': '1',
+            'keep_src': '1',
+            'keep_dst': '1',
+            'trace_level': '30',
+            'type': 'monthly',
+            'nconn': '2',
+            'period': '12',
+            'mbuffer_size': '16',
+            'minute': '0',
+            'hour': '0',
+            'flags': '0',
+            'estimations': '0',
+            'force': '0',
+            'reverse_capable': '0',
+            'sync-recursive': '0',
+            'auto-clone': '0',
+            'flip_options': '0',
+            'direction_flipped': '0',
+            'retry': '0',
+            'success_counter': '0',
+            'dircontent': '0',
+            'zip_level': '0',
+            'auto-mount': '0',
+            'marker': '',
+            'exclude': '',
+            'run_history': '',
+            'progress-marker': '',
+            'from-snapshot': '',
+            'latest-suffix': '',
+            'trunk': '',
+            'options': ''
+        }
+        try:
+            fmri = self.nms.autosvc.fmri_create('auto-sync', comment,
+                                                src_path, 0, payload)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to create migration service '
+                      'with payload %(payload)s: %(error)s',
+                      {'payload': payload, 'error': error})
+            return False
+        if not self._svc_state(fmri, 'online'):
+            self._svc_cleanup(fmri)
+            return False
+        service_running = False
+        try:
+            self.nms.autosvc.execute(fmri)
+            service_running = True
+            LOG.info('Migration service %(fmri)s successfully started',
+                     {'fmri': fmri})
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to start migration service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        if not service_running:
+            LOG.error('Migration service %(fmri)s is offline',
+                      {'fmri': fmri})
+            self._svc_cleanup(fmri)
+            return False
+        service_history = None
+        service_retries = retries
+        service_progress = 0
+        while service_retries and not service_history:
+            greenthread.sleep(delay)
+            service_retries -= 1
+            try:
+                service_props = self.nms.autosvc.get_child_props(fmri, '')
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to get properties of migration service '
+                          '%(fmri)s: %(error)s',
+                          {'fmri': fmri, 'error': error})
+                continue
+            service_history = service_props.get('zfs/run_history')
+            service_started = service_props.get('zfs/time_started')
+            if service_started == 'N/A':
+                continue
+            progress = self._svc_progress(fmri)
+            if progress > service_progress:
+                service_progress = progress
+                service_retries = retries
+            LOG.info('Migration service %(fmri)s replication progress: '
+                     '%(service_progress)s%%',
+                     {'fmri': fmri, 'service_progress': service_progress})
+        if not service_history:
+            self._svc_cleanup(fmri)
+            return False
+        volume_migrated = self._svc_result(fmri)
+        self._svc_cleanup(fmri, volume_migrated)
+        if volume_migrated:
+            try:
+                self.delete_volume(volume)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to delete source volume %(volume)s '
+                          'after successful migration: %(error)s',
+                          {'volume': volume['name'], 'error': error})
+        return volume_migrated
+
+    def migrate_volume(self, context, volume, host):
+        """Migrate the volume to the specified host.
+
+        Returns a boolean indicating whether the migration occurred,
+        as well as model_update.
+
+        :param context: Security context
+        :param volume: A dictionary describing the volume to migrate
+        :param host: A dictionary describing the host to migrate to, where
+                     host['host'] is its name, and host['capabilities'] is a
+                     dictionary of its reported capabilities.
+        """
+        LOG.info('Start storage assisted volume migration '
+                 'for volume %(volume)s to host %(host)s',
+                 {'volume': volume['name'],
+                  'host': host['host']})
+        false_ret = (False, None)
+        if 'capabilities' not in host:
+            LOG.error('No host capabilities found for '
+                      'the destination host %(host)s',
+                      {'host': host['host']})
+            return false_ret
+        capabilities = host['capabilities']
+        required_capabilities = [
+            'vendor_name',
+            'location_info',
+            'storage_protocol',
+            'free_capacity_gb'
+        ]
+        for capability in required_capabilities:
+            if capability not in capabilities:
+                LOG.error('Required host capability %(capability)s not '
+                          'found for the destination host %(host)s',
+                          {'capability': capability, 'host': host['host']})
+                return false_ret
+        vendor = capabilities['vendor_name']
+        if vendor != self.vendor_name:
+            LOG.error('Unsupported vendor %(vendor)s found '
+                      'for the destination host %(host)s',
+                      {'vendor': vendor, 'host': host['host']})
+            return false_ret
+        location = capabilities['location_info']
+        try:
+            driver, nas_host, nas_path = location.split(':')
+        except ValueError as error:
+            LOG.error('Failed to parse location info %(location)s '
+                      'for the destination host %(host)s: %(error)s',
+                      {'location': location, 'host': host['host'],
+                       'error': error})
+            return false_ret
+        if not (driver and nas_host and nas_path):
+            LOG.error('Incomplete location info %(location)s '
+                      'found for the destination host %(host)s',
+                      {'location': location, 'host': host['host']})
+            return false_ret
+        if driver != self.driver_name:
+            LOG.error('Unsupported storage driver %(driver)s '
+                      'found for the destination host %(host)s',
+                      {'driver': driver, 'host': host['host']})
+            return false_ret
+        storage_protocol = capabilities['storage_protocol']
+        if storage_protocol != self.storage_protocol:
+            LOG.error('Unsupported storage protocol %(protocol)s '
+                      'found for the destination host %(host)s',
+                      {'protocol': storage_protocol,
+                       'host': host['host']})
+            return false_ret
+        free_capacity_gb = capabilities['free_capacity_gb']
+        if free_capacity_gb < volume['size']:
+            LOG.error('There is not enough space available on the '
+                      'destination host %(host)s to migrate volume '
+                      '%(volume)s, available space: %(free)sG, '
+                      'required space: %(required)sG',
+                      {'host': host['host'], 'volume': volume['name'],
+                       'free': free_capacity_gb,
+                       'required': volume['size']})
+            return false_ret
+        if self._migrate_volume(volume, nas_host, nas_path):
+            return (True, None)
+        return false_ret
+
+    def update_migrated_volume(self, context, volume, new_volume,
+                               original_volume_status):
+        """Return model update for migrated volume.
+
+        This method should rename the back-end volume name on the
+        destination host back to its original name on the source host.
+
+        :param context: The context of the caller
+        :param volume: The original volume that was migrated to this backend
+        :param new_volume: The migration volume object that was created on
+                           this backend as part of the migration process
+        :param original_volume_status: The status of the original volume
+        :returns: model_update to update DB with any needed changes
+        """
+        name_id = None
+        volume_path = self._get_volume_path(volume)
+        new_volume_path = self._get_volume_path(new_volume)
+        try:
+            self.terminate_connection(new_volume, None)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to terminate all connections '
+                      'to migrated volume %(volume)s before '
+                      'renaming: %(error)s',
+                      {'volume': new_volume['name'],
+                       'error': error})
+        cmd = 'zfs rename %(new_volume)s %(volume)s' % {
+            'new_volume': new_volume_path,
+            'volume': volume_path
+        }
+        try:
+            self.nms.appliance.execute(cmd)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to rename volume %(new_volume)s '
+                      'to %(volume)s after migration: %(error)s',
+                      {'new_volume': new_volume['name'],
+                       'volume': volume['name'],
+                       'error': error})
+            name_id = new_volume._name_id or new_volume.id
+        model_update = {'_name_id': name_id}
+        return model_update
+
+    def retype(self, context, volume, new_type, diff, host):
+        """Convert the volume to be of the new type."""
+        pass
 
     def create_snapshot(self, snapshot):
         """Creates a snapshot.
 
         :param snapshot: snapshot reference
         """
-        volume = self._get_snapshot_volume(snapshot)
-        nfs_share = volume['provider_location']
-        nms = self.share2nms[nfs_share]
-        vol, dataset = self._get_share_datasets(nfs_share)
-        folder = '%s/%s/%s' % (vol, dataset, volume['name'])
-        nms.folder.create_snapshot(folder, snapshot['name'], '-r')
+        snapshot_path = self._get_snapshot_path(snapshot)
+        volume_path, snapshot_name = snapshot_path.split('@')
+        self.nms.folder.create_snapshot(volume_path, snapshot_name, '')
 
     def delete_snapshot(self, snapshot):
         """Deletes a snapshot.
 
         :param snapshot: snapshot reference
         """
-        volume = self._get_snapshot_volume(snapshot)
-        nfs_share = volume['provider_location']
-        nms = self.share2nms[nfs_share]
-        vol, dataset = self._get_share_datasets(nfs_share)
-        folder = '%s/%s/%s' % (vol, dataset, volume['name'])
-        try:
-            nms.snapshot.destroy('%s@%s' % (folder, snapshot['name']), '')
-        except exception.NexentaException as exc:
-            if 'does not exist' in exc.args[0]:
-                LOG.info('Snapshot %(folder)s@%(snapshot)s does not '
-                         'exist, it was already deleted.',
-                         {
-                             'folder': folder,
-                             'snapshot': snapshot,
-                         })
-                return
-            elif 'has dependent clones' in exc.args[0]:
-                LOG.info('Snapshot %(folder)s@%(snapshot)s has dependent '
-                         'clones, it will be deleted later.',
-                         {
-                             'folder': folder,
-                             'snapshot': snapshot,
-                         })
-                return
+        snapshot_path = self._get_snapshot_path(snapshot)
+        self.nms.snapshot.destroy(snapshot_path, '-d')
 
-    def _create_sparsed_file(self, nms, path, size):
-        """Creates file with 0 disk usage.
+    def snapshot_revert_use_temp_snapshot(self):
+        # Considering that NexentaStor based drivers use COW images
+        # for storing snapshots, having chains of such images,
+        # creating a backup snapshot when reverting one is not
+        # actually helpful.
+        return False
 
-        :param nms: nms object
-        :param path: path to new file
-        :param size: size of file
+    def revert_to_snapshot(self, context, volume, snapshot):
+        """Revert volume to snapshot."""
+        snapshot_path = self._get_snapshot_path(snapshot)
+        self.nms.snapshot.rollback(snapshot_path, '')
+
+    def _set_volume_acl(self, volume):
+        volume_path = self._get_volume_path(volume)
+        group = 'everyone@'
+        acl = {
+            'allow': [
+                'full_set',
+                'dir_inherit',
+                'file_inherit'
+            ]
+        }
+        self.nms.folder.set_group_acl(volume_path, group, acl)
+
+    def _get_volume_share(self, volume):
+        """Return NFS share path for the volume."""
+        volume_path = self._get_volume_path(volume)
+        filesystem = self.nms.folder.get_child_props(volume_path, '')
+        if filesystem['mountpoint'] == 'none':
+            self.nms.folder.inherit_prop(volume_path, 'mountpoint', 0)
+            filesystem = self.nms.folder.get_child_props(volume_path, '')
+        if filesystem['mounted'] != 'yes':
+            self.nms.folder.mount(volume_path, 0)
+        share = '%s:%s' % (self.nas_host, filesystem['mountpoint'])
+        return share
+
+    def _local_volume_dir(self, volume):
+        """Get volume dir (mounted locally fs path) for given volume.
+
+        :param volume: volume reference
         """
-        nms.appliance.execute(
-            'truncate --size %(size)dG %(path)s' % {
-                'path': path,
-                'size': size
-            }
-        )
-
-    def _create_regular_file(self, nms, path, size):
-        """Creates regular file of given size.
-
-        Takes a lot of time for large files.
-
-        :param nms: nms object
-        :param path: path to new file
-        :param size: size of file
-        """
-        block_count = size * units.Gi / (BLOCK_SIZE_MB * units.Mi)
-
-        LOG.info('Creating regular file: %s.'
-                 'This may take some time.', path)
-
-        nms.appliance.execute(
-            'dd if=/dev/zero of=%(path)s bs=%(bs)dM count=%(count)d' % {
-                'path': path,
-                'bs': BLOCK_SIZE_MB,
-                'count': block_count
-            }
-        )
-
-        LOG.info('Regular file: %s created.', path)
-
-    def _set_rw_permissions_for_all(self, nms, path):
-        """Sets 666 permissions for the path.
-
-        :param nms: nms object
-        :param path: path to file
-        """
-        nms.appliance.execute('chmod ugo+rw %s' % path)
+        share = self._get_volume_share(volume)
+        if isinstance(share, six.text_type):
+            share = share.encode('utf-8')
+        path = hashlib.md5(share).hexdigest()
+        return os.path.join(self.mount_point_base, path)
 
     def local_path(self, volume):
         """Get volume path (mounted locally fs path) for given volume.
 
         :param volume: volume reference
         """
-        nfs_share = volume['provider_location']
-        return os.path.join(self._get_mount_point_for_share(nfs_share),
-                            volume['name'], 'volume')
+        volume_dir = self._local_volume_dir(volume)
+        return os.path.join(volume_dir, 'volume')
 
-    def _get_mount_point_for_share(self, nfs_share):
-        """Returns path to mount point NFS share.
+    def get_volume_stats(self, refresh=False):
+        """Get volume stats.
 
-        :param nfs_share: example 172.18.194.100:/var/nfs
+        If 'refresh' is True, update the stats first.
         """
-        nfs_share = nfs_share.encode('utf-8')
-        return os.path.join(self.configuration.nexenta_mount_point_base,
-                            hashlib.md5(nfs_share).hexdigest())
+        if refresh or not self._stats:
+            self._update_volume_stats()
 
-    def remote_path(self, volume):
-        """Get volume path (mounted remotely fs path) for given volume.
-
-        :param volume: volume reference
-        """
-        nfs_share = volume['provider_location']
-        share = nfs_share.split(':')[1].rstrip('/')
-        return '%s/%s/volume' % (share, volume['name'])
-
-    def _share_folder(self, nms, volume, folder):
-        """Share NFS folder on NexentaStor Appliance.
-
-        :param nms: nms object
-        :param volume: volume name
-        :param folder: folder name
-        """
-        path = '%s/%s' % (volume, folder.lstrip('/'))
-        share_opts = {
-            'read_write': '*',
-            'read_only': '',
-            'root': 'nobody',
-            'extra_options': 'anon=0',
-            'recursive': 'true',
-            'anonymous_rw': 'true',
-        }
-        LOG.debug('Sharing folder %s on Nexenta Store', folder)
-        nms.netstorsvc.share_folder('svc:/network/nfs/server:default', path,
-                                    share_opts)
-
-    def _load_shares_config(self, share_file):
-        self.shares = {}
-        self.share2nms = {}
-
-        for share in self._read_config_file(share_file):
-            # A configuration line may be either:
-            # host:/share_name  http://user:pass@host:[port]/
-            # or
-            # host:/share_name  http://user:pass@host:[port]/
-            #    -o options=123,rw --other
-            if not share.strip():
-                continue
-            if share.startswith('#'):
-                continue
-
-            share_info = re.split(r'\s+', share, 2)
-
-            share_address = share_info[0].strip()
-            nms_url = share_info[1].strip()
-            share_opts = share_info[2].strip() if len(share_info) > 2 else None
-
-            if not re.match(r'.+:/.+', share_address):
-                LOG.warning("Share %s ignored due to invalid format. "
-                            "Must be of form address:/export.",
-                            share_address)
-                continue
-
-            self.shares[share_address] = share_opts
-            self.share2nms[share_address] = self._get_nms_for_url(nms_url)
-
-        LOG.debug('Shares loaded: %s', self.shares)
-
-    def _get_subshare_mount_point(self, nfs_share, volume):
-        mnt_path = '%s/%s' % (
-            self._get_mount_point_for_share(nfs_share), volume['name'])
-        sub_share = '%s/%s' % (nfs_share, volume['name'])
-        return sub_share, mnt_path
-
-    def _ensure_share_mounted(self, nfs_share, mount_path=None):
-        """Ensure that NFS share is mounted on the host.
-
-        Unlike the parent method this one accepts mount_path as an optional
-        parameter and uses it as a mount point if provided.
-
-        :param nfs_share: NFS share name
-        :param mount_path: mount path on the host
-        """
-        mnt_flags = []
-        if self.shares.get(nfs_share) is not None:
-            mnt_flags = self.shares[nfs_share].split()
-        num_attempts = max(1, self.configuration.nfs_mount_attempts)
-        for attempt in range(num_attempts):
-            try:
-                if mount_path is None:
-                    self._remotefsclient.mount(nfs_share, mnt_flags)
-                else:
-                    if mount_path in self._remotefsclient._read_mounts():
-                        LOG.info('Already mounted: %s', mount_path)
-                        return
-
-                    self._execute('mkdir', '-p', mount_path,
-                                  check_exit_code=False)
-                    self._remotefsclient._mount_nfs(nfs_share, mount_path,
-                                                    mnt_flags)
-                return
-            except Exception as e:
-                if attempt == (num_attempts - 1):
-                    LOG.error('Mount failure for %(share)s after '
-                              '%(count)d attempts.', {
-                                  'share': nfs_share,
-                                  'count': num_attempts})
-                    raise exception.NfsException(six.text_type(e))
-                LOG.warning(
-                    'Mount attempt %(attempt)d failed: %(error)s. '
-                    'Retrying mount ...', {
-                        'attempt': attempt,
-                        'error': e})
-                greenthread.sleep(1)
-
-    def _mount_subfolders(self):
-        ctxt = context.get_admin_context()
-        vol_entries = self.db.volume_get_all_by_host(ctxt, self.host)
-        for vol in vol_entries:
-            nfs_share = vol['provider_location']
-            if ((nfs_share in self.shares) and
-                    (self._get_nfs_server_version(nfs_share) < 4)):
-                sub_share, mnt_path = self._get_subshare_mount_point(
-                    nfs_share, vol)
-                self._ensure_share_mounted(sub_share, mnt_path)
-
-    def _get_nfs_server_version(self, share):
-        if not self.nfs_versions.get(share):
-            nms = self.share2nms[share]
-            nfs_opts = nms.netsvc.get_confopts(
-                'svc:/network/nfs/server:default', 'configure')
-            try:
-                self.nfs_versions[share] = int(
-                    nfs_opts['nfs_server_versmax']['current'])
-            except KeyError:
-                self.nfs_versions[share] = int(
-                    nfs_opts['server_versmax']['current'])
-        return self.nfs_versions[share]
-
-    def _get_capacity_info(self, nfs_share):
-        """Calculate available space on the NFS share.
-
-        :param nfs_share: example 172.18.194.100:/var/nfs
-        """
-        nms = self.share2nms[nfs_share]
-        ns_volume, ns_folder = self._get_share_datasets(nfs_share)
-        folder_props = nms.folder.get_child_props('%s/%s' % (ns_volume,
-                                                             ns_folder),
-                                                  'used|available')
-        free = utils.str2size(folder_props['available'])
-        allocated = utils.str2size(folder_props['used'])
-        self.shares_with_capacities[nfs_share] = {
-            'free': utils.str2gib_size(free),
-            'total': utils.str2gib_size(free + allocated)}
-        return free + allocated, free, allocated
-
-    def _get_nms_for_url(self, url):
-        """Returns initialized nms object for url."""
-        auto, scheme, user, password, host, port, path = (
-            utils.parse_nms_url(url))
-        return jsonrpc.NexentaJSONProxy(scheme, host, port, path, user,
-                                        password, auto=auto,
-                                        verify=self.verify_ssl)
-
-    def _get_snapshot_volume(self, snapshot):
-        ctxt = context.get_admin_context()
-        return db.volume_get(ctxt, snapshot['volume_id'])
-
-    def _get_volroot(self, nms):
-        """Returns volroot property value from NexentaStor appliance."""
-        if not self.nms_cache_volroot:
-            return nms.server.get_prop('volroot')
-        if nms not in self._nms2volroot:
-            self._nms2volroot[nms] = nms.server.get_prop('volroot')
-        return self._nms2volroot[nms]
-
-    def _get_share_datasets(self, nfs_share):
-        nms = self.share2nms[nfs_share]
-        volroot = self._get_volroot(nms)
-        path = nfs_share.split(':')[1][len(volroot):].strip('/')
-        volume_name = path.split('/')[0]
-        folder_name = '/'.join(path.split('/')[1:])
-        return volume_name, folder_name
-
-    def _get_clone_snapshot_name(self, volume):
-        """Return name for snapshot that will be used to clone the volume."""
-        return 'cinder-clone-snapshot-%(id)s' % volume
-
-    def _is_clone_snapshot_name(self, snapshot):
-        """Check if snapshot is created for cloning."""
-        name = snapshot.split('@')[-1]
-        return name.startswith('cinder-clone-snapshot-')
+        return self._stats
 
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor appliance."""
-        LOG.debug('Updating volume stats')
-        total_space = 0
-        free_space = 0
-        share = None
-        for _share in self._mounted_shares:
-            if self.shares_with_capacities[_share]['free'] > free_space:
-                free_space = self.shares_with_capacities[_share]['free']
-                total_space = self.shares_with_capacities[_share]['total']
-                share = _share
-
-        location_info = '%(driver)s:%(share)s' % {
-            'driver': self.__class__.__name__,
-            'share': share
+        pool_name = self.root_path.split('/')[0]
+        stats = {'available': None, 'used': None}
+        payload = '|'.join(stats.keys())
+        props = self.nms.folder.get_child_props(self.root_path, payload)
+        for key in stats:
+            if not props.get(key):
+                LOG.error('Unable to get %(key)s statistics for %(path)s '
+                          'from properties %(props)s',
+                          {'path': self.root_path, 'props': props})
+                continue
+            text = '%sB' % props[key]
+            try:
+                value = strutils.string_to_bytes(text, return_int=True)
+                stats[key] = value
+            except ValueError as error:
+                LOG.error('Failed to convert text value %(text)s to '
+                          'bytes for the %(key)s property: %(error)s',
+                          {'text': text, 'key': key, 'error': error})
+        if None in stats.values():
+            allocated_capacity_gb = 'unknown'
+            free_capacity_gb = 'unknown'
+            total_capacity_gb = 'unknown'
+        else:
+            free_capacity_gb = stats['available'] // units.Gi
+            allocated_capacity_gb = stats['used'] // units.Gi
+            total_capacity_gb = free_capacity_gb + allocated_capacity_gb
+        provisioned_capacity_gb = total_volumes = 0
+        ctxt = context.get_admin_context()
+        volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        for volume in volumes:
+            provisioned_capacity_gb += volume['size']
+            total_volumes += 1
+        volume_backend_name = (
+            self.configuration.safe_get('volume_backend_name'))
+        if not volume_backend_name:
+            LOG.error('Failed to get configured volume backend name')
+            volume_backend_name = '%(product)s_%(protocol)s' % {
+                'product': self.product_name,
+                'protocol': self.storage_protocol
+            }
+        description = (
+            self.configuration.safe_get('nexenta_dataset_description'))
+        if not description:
+            description = '%(product)s %(host)s:%(path)s' % {
+                'product': self.product_name,
+                'host': self.configuration.nas_host,
+                'path': self.configuration.nas_share_path
+            }
+        max_over_subscription_ratio = (
+            self.configuration.safe_get('max_over_subscription_ratio'))
+        reserved_percentage = (
+            self.configuration.safe_get('reserved_percentage'))
+        if reserved_percentage is None:
+            reserved_percentage = 0
+        location_info = '%(driver)s:%(host)s:%(path)s' % {
+            'driver': self.driver_name,
+            'host': self.configuration.nas_host,
+            'path': self.configuration.nas_share_path
         }
-        nms_url = self.share2nms[share].url
+        display_name = 'Capabilities of %(product)s %(protocol)s driver' % {
+            'product': self.product_name,
+            'protocol': self.storage_protocol
+        }
+        visibility = 'public'
         self._stats = {
-            'vendor_name': 'Nexenta',
-            'dedup': self.volume_deduplication,
-            'compression': self.volume_compression,
-            'description': self.volume_description,
-            'nms_url': nms_url,
-            'ns_shares': self.shares_with_capacities,
             'driver_version': self.VERSION,
-            'storage_protocol': 'NFS',
-            'total_capacity_gb': total_space,
-            'free_capacity_gb': free_space,
-            'reserved_percentage': self.configuration.reserved_percentage,
-            'QoS_support': False,
+            'vendor_name': self.vendor_name,
+            'storage_protocol': self.storage_protocol,
+            'volume_backend_name': volume_backend_name,
             'location_info': location_info,
-            'volume_backend_name': self.backend_name,
-            'nfs_mount_point_base': self.nfs_mount_point_base
+            'description': description,
+            'display_name': display_name,
+            'pool_name': pool_name,
+            'multiattach': True,
+            'QoS_support': False,
+            'consistencygroup_support': False,
+            'consistent_group_snapshot_enabled': False,
+            'online_extend_support': True,
+            'sparse_copy_volume': True,
+            'thin_provisioning_support': True,
+            'thick_provisioning_support': True,
+            'total_capacity_gb': total_capacity_gb,
+            'allocated_capacity_gb': allocated_capacity_gb,
+            'free_capacity_gb': free_capacity_gb,
+            'provisioned_capacity_gb': provisioned_capacity_gb,
+            'total_volumes': total_volumes,
+            'max_over_subscription_ratio': max_over_subscription_ratio,
+            'reserved_percentage': reserved_percentage,
+            'visibility': visibility,
+            'dedup': self.configuration.nexenta_dataset_dedup,
+            'compression': self.configuration.nexenta_dataset_compression,
+            'nms_url': self.nms.url
         }
+        LOG.debug('Updated volume backend statistics for host %(host)s '
+                  'and volume backend %(volume_backend_name)s: %(stats)s',
+                  {'host': self.host,
+                   'volume_backend_name': volume_backend_name,
+                   'stats': self._stats})
+
+    def _get_volume_path(self, volume):
+        """Return ZFS datset path for the volume."""
+        return posixpath.join(self.root_path, volume['name'])
+
+    def _get_snapshot_path(self, snapshot):
+        """Return ZFS snapshot path for the snapshot."""
+        volume_name = snapshot['volume_name']
+        snapshot_name = snapshot['name']
+        volume_path = posixpath.join(self.root_path, volume_name)
+        return '%s@%s' % (volume_path, snapshot_name)
+
+    def _get_host_addresses(self):
+        """Return NexentaStor IP addresses list."""
+        addresses = []
+        items = self.nms.appliance.execute('ipadm show-addr -p -o addr')
+        for item in items:
+            cidr = six.text_type(item)
+            addr, mask = cidr.split('/')
+            obj = ipaddress.ip_address(addr)
+            if not obj.is_loopback:
+                addresses.append(obj.exploded)
+        LOG.debug('Configured IP addresses: %(addresses)s',
+                  {'addresses': addresses})
+        return addresses
+
+    @staticmethod
+    def _match_template(template, name):
+        sequence = difflib.SequenceMatcher(None, name, template)
+        added = deleted = result = ''
+        for tag, a1, a2, b1, b2 in sequence.get_opcodes():
+            if tag == 'equal':
+                result += ''.join(sequence.a[a1:a2])
+            elif tag == 'delete':
+                deleted += ''.join(sequence.a[a1:a2])
+            elif tag == 'insert':
+                added += ''.join(sequence.b[b1:b2])
+            elif tag == 'replace':
+                result += ''.join(sequence.b[b1:b2])
+        if result == template and not (added or deleted):
+            return True
+        return False

--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -314,17 +314,24 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         volume_path = self._get_volume_path(volume)
         if isinstance(connector, dict) and 'initiator' in connector:
             connectors = []
-            for attachment in volume['volume_attachment']:
-                connectors.append(attachment.get('connector'))
+            if 'volume_attachment' in volume:
+                if isinstance(volume['volume_attachment'], list):
+                    for attachment in volume['volume_attachment']:
+                        if not isinstance(attachment, dict):
+                            continue
+                        if 'connector' not in attachment:
+                            continue
+                        connectors.append(attachment['connector'])
             if connectors.count(connector) > 1:
-                LOG.debug('Detected multiple connections on host '
-                          '%(host_name)s [%(host_ip)s] for volume '
-                          '%(volume)s, skip terminate volume connection',
-                          {'host_name': connector.get('host', 'unknown'),
+                LOG.debug('Detected %(count)s connections from host '
+                          '%(host_name)s (IP:%(host_ip)s) to volume '
+                          '%(volume)s, skip terminating connection',
+                          {'count': connectors.count(connector),
+                           'host_name': connector.get('host', 'unknown'),
                            'host_ip': connector.get('ip', 'unknown'),
                            'volume': volume['name']})
                 return True
-            host_iqn = connector.get('initiator')
+            host_iqn = connector['initiator']
             host_groups.append(options.DEFAULT_HOST_GROUP)
             host_group = self._get_host_group(host_iqn)
             if host_group is not None:
@@ -645,7 +652,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 props['target_iqns'] = props_iqns
                 props['target_luns'] = props_luns
             else:
-                index = random.randrange(0, len(props_luns))
+                index = random.randrange(len(props_luns))
                 props['target_portal'] = props_portals[index]
                 props['target_iqn'] = props_iqns[index]
                 props['target_lun'] = props_luns[index]
@@ -710,7 +717,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                    'hostGroup': host_group}
         self.nef.mappings.create(payload)
         mapping = {}
-        for attempt in range(0, self.nef.retries):
+        for attempt in range(self.nef.retries):
             mapping = self.nef.mappings.list(payload)
             if mapping:
                 break
@@ -727,7 +734,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             props['target_iqns'] = props_iqns
             props['target_luns'] = props_luns
         else:
-            index = random.randrange(0, len(props_luns))
+            index = random.randrange(len(props_luns))
             props['target_portal'] = props_portals[index]
             props['target_iqn'] = props_iqns[index]
             props['target_lun'] = props_luns[index]

--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -237,7 +237,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
             LOG.debug('NFS share %(share)s is not mounted at %(path)s',
                       {'share': share, 'path': path})
             return
-        for attempt in range(0, attempts):
+        for attempt in range(attempts):
             try:
                 fs.umount(path)
                 LOG.debug('NFS share %(share)s has been unmounted at %(path)s',


### PR DESCRIPTION
**NEX-20387 Our provided openstack driver does not deal gracefully with a slow pool**
```
+        1.4.0 - Refactored NFS driver.
+              - Revert to snapshot support.
+              - Fixed automatic mode for nexenta_rest_protocol.
+              - Added deferred deletion for snapshots.
+              - Added synchronization for NMS REST API calls.
+              - Added configuration parameters for REST API connect/read
+                timeouts, connection retries and backoff factor.
+              - Disabled non-blocking mandatory locks.
+              - Added informative exception messages for REST API.
+              - Improved collection of backend statistics.
```

*Pep8 tests*
```
pep8 run-test: commands[0] | flake8 .
pep8 run-test: commands[1] | /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 run-test: commands[2] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder /opt/stack/cinder/doc/source/ /opt/stack/cinder/releasenotes
/notes
___________________________________ summary ____________________________________
  pep8: commands succeeded
  congratulations :)
```

*Tempest tests*
```
======
Totals
======
Ran: 267 tests in 4137.0000 sec.
 - Passed: 256
 - Skipped: 11
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3340.1426 sec.
```