### PR TITLE
Stein: NEX-20387 and NEX-18892 

### DIFF
--- a/cinder/volume/drivers/nexenta/iscsi.py
+++ b/cinder/volume/drivers/nexenta/iscsi.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Nexenta Systems, Inc. All Rights Reserved.
+# Copyright 2019 Nexenta Systems, Inc. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -12,23 +12,28 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import hashlib
-import json
+import datetime
+import difflib
+import ipaddress
+import posixpath
+import random
+import uuid
+
+from eventlet import greenthread
+from oslo_log import log as logging
+from oslo_utils import strutils
+from oslo_utils import timeutils
+from oslo_utils import units
 import six
 
-from oslo_log import log as logging
-from oslo_utils import excutils
-
-from cinder import coordination
-from cinder import exception
+from cinder import context
 from cinder.i18n import _
 from cinder import interface
+from cinder import objects
 from cinder.volume import driver
 from cinder.volume.drivers.nexenta import jsonrpc
 from cinder.volume.drivers.nexenta import options
-from cinder.volume.drivers.nexenta import utils
 
-VERSION = '1.3.3'
 LOG = logging.getLogger(__name__)
 
 
@@ -57,217 +62,151 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         1.3.1 - Added ZFS cleanup.
         1.3.2 - Added support for target_portal_group and zvol folder.
         1.3.3 - Added synchronization for Comstar API calls.
+        1.4.0 - Fixed automatic mode for nexenta_rest_protocol.
+              - Fixed compatibility with initial driver version.
+              - Fixed deletion of temporary snapshots.
+              - Fixed creation of volumes with enabled compression option.
+              - Refactored LUN creation, use host group for LUN mappings.
+              - Refactored storage assisted volume migration.
+              - Added deferred deletion for snapshots.
+              - Added revert to snapshot support.
+              - Added volume multi-attach.
+              - Added report discard support.
+              - Added informative exception messages for REST API.
+              - Added configuration parameters for REST API connect/read.
+                timeouts, connection retries and backoff factor.
+              - Added configuration parameter for LUN writeback cache.
+              - Improved collection of backend statistics.
     """
 
-    VERSION = VERSION
-
-    # ThirdPartySystems wiki page
+    VERSION = '1.4.0'
     CI_WIKI_NAME = "Nexenta_CI"
+
+    vendor_name = 'Nexenta'
+    product_name = 'NexentaStor4'
+    storage_protocol = 'iSCSI'
+    driver_volume_type = 'iscsi'
 
     def __init__(self, *args, **kwargs):
         super(NexentaISCSIDriver, self).__init__(*args, **kwargs)
+        if not self.configuration:
+            message = (_('%(product_name)s %(storage_protocol)s '
+                         'backend configuration not found')
+                       % {'product_name': self.product_name,
+                          'storage_protocol': self.storage_protocol})
+            raise jsonrpc.NmsException(code='ENODATA', message=message)
+        self.configuration.append_config_values(
+            options.NEXENTA_CONNECTION_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_ISCSI_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_DATASET_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_RRMGR_OPTS)
         self.nms = None
-        self.targets = {}
-        if self.configuration:
-            self.configuration.append_config_values(
-                options.NEXENTA_CONNECTION_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_ISCSI_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_DATASET_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_RRMGR_OPTS)
-        self.verify_ssl = self.configuration.driver_ssl_cert_verify
-        self.nms_protocol = self.configuration.nexenta_rest_protocol
-        self.nms_host = self.configuration.nexenta_host
-        self.nms_port = self.configuration.nexenta_rest_port
-        self.nms_user = self.configuration.nexenta_user
-        self.nms_password = self.configuration.nexenta_password
+        self.mappings = {}
+        self.driver_name = self.__class__.__name__
+        self.san_host = self.configuration.nexenta_host
         self.volume = self.configuration.nexenta_volume
         self.folder = self.configuration.nexenta_folder
-        self.tpgs = self.configuration.nexenta_iscsi_target_portal_groups
         self.volume_compression = (
             self.configuration.nexenta_dataset_compression)
-        self.volume_deduplication = self.configuration.nexenta_dataset_dedup
-        self.volume_description = (
-            self.configuration.nexenta_dataset_description)
-        self.rrmgr_compression = self.configuration.nexenta_rrmgr_compression
-        self.rrmgr_tcp_buf_size = self.configuration.nexenta_rrmgr_tcp_buf_size
-        self.rrmgr_connections = self.configuration.nexenta_rrmgr_connections
-        self.iscsi_target_portal_port = (
-            self.configuration.nexenta_iscsi_target_portal_port)
+        self.volume_blocksize = self.configuration.nexenta_blocksize
+        self.volume_sparse = self.configuration.nexenta_sparse
+        self.tpgs = self.configuration.nexenta_iscsi_target_portal_groups
+        self.target_prefix = self.configuration.nexenta_target_prefix
+        self.target_group_prefix = (
+            self.configuration.nexenta_target_group_prefix)
+        self.host_group_prefix = self.configuration.nexenta_host_group_prefix
+        self.lpt = self.configuration.nexenta_luns_per_target
+        self.portal_port = self.configuration.nexenta_iscsi_target_portal_port
+        self.origin_snapshot_template = (
+            self.configuration.nexenta_origin_snapshot_template)
+        self.migration_snapshot_prefix = (
+            self.configuration.nexenta_migration_snapshot_prefix)
+        self.migration_service_prefix = (
+            self.configuration.nexenta_migration_service_prefix)
+        self.migration_throttle = (
+            self.configuration.nexenta_migration_throttle)
+        if self.folder:
+            self.root_path = posixpath.join(self.volume, self.folder)
+        else:
+            self.root_path = self.volume
 
-    @property
-    def backend_name(self):
-        backend_name = None
-        if self.configuration:
-            backend_name = self.configuration.safe_get('volume_backend_name')
-        if not backend_name:
-            backend_name = self.__class__.__name__
-        return backend_name
+    @staticmethod
+    def get_driver_options():
+        return (
+            options.NEXENTA_CONNECTION_OPTS +
+            options.NEXENTA_ISCSI_OPTS +
+            options.NEXENTA_DATASET_OPTS +
+            options.NEXENTA_RRMGR_OPTS
+        )
 
     def do_setup(self, context):
-        if self.nms_protocol == 'auto':
-            protocol, auto = 'http', True
-        else:
-            protocol, auto = self.nms_protocol, False
-
-        self.nms = jsonrpc.NexentaJSONProxy(
-            protocol, self.nms_host, self.nms_port, '/rest/nms', self.nms_user,
-            self.nms_password, self.verify_ssl, auto=auto)
-
-        license = self.nms.appliance.get_license_info()
-        signature = license.get('machine_sig')
-        LOG.debug('NexentaStor Host Signature: %(signature)s',
-                  {'signature': signature})
-
-        plugin = 'nms-rsf-cluster'
-        plugins = self.nms.plugin.get_names('')
-        if isinstance(plugins, list) and plugin in plugins:
-            names = self.nms.rsf_plugin.get_names('')
-            if isinstance(names, list) and len(names) == 1:
-                name = names[0]
-                prop = 'machinesigs'
-                props = self.nms.rsf_plugin.get_child_props(name, '')
-                if isinstance(props, dict) and prop in props:
-                    signatures = json.loads(props.get(prop))
-                    if isinstance(signatures, dict) and \
-                       signature in signatures.values():
-                        signature = ':'.join(sorted(signatures.values()))
-                        LOG.debug('NexentaStor HA Cluster Signature: '
-                                  '%(signature)s',
-                                  {'signature': signature})
-                    else:
-                        LOG.debug('HA Cluster plugin %(plugin)s is not '
-                                  'configured for NexentaStor Host '
-                                  '%(signature)s: %(signatures)s',
-                                  {'plugin': plugin,
-                                   'signature': signature,
-                                   'signatures': signatures})
-                else:
-                    LOG.debug('HA Cluster plugin %(plugin)s is misconfigured',
-                              {'plugin': plugin})
-            else:
-                LOG.debug('HA Cluster plugin %(plugin)s is not configured '
-                          'or is misconfigured',
-                          {'plugin': plugin})
-        else:
-            LOG.debug('HA Cluster plugin %(plugin)s is not installed',
-                      {'plugin': plugin})
-
-        self.lock = hashlib.md5(signature).hexdigest()
-        LOG.debug('NMS coordination lock: %(lock)s',
-                  {'lock': self.lock})
+        self.nms = jsonrpc.NmsProxy(self.driver_volume_type,
+                                    self.root_path,
+                                    self.configuration)
 
     def check_for_setup_error(self):
-        """Verify that the volume for our zvols exists.
-
-        :raise: :py:exc:`LookupError`
-        """
+        """Verify that the volume, folder and tpgs exists."""
         if not self.nms.volume.object_exists(self.volume):
-            raise LookupError(_("Volume %s does not exist in Nexenta SA") %
-                              self.volume)
-        if self.folder:
-            folder = '%s/%s' % (self.volume, self.folder)
-            if not self.nms.folder.object_exists(folder):
-                raise LookupError(_("Folder %s does not exist in NexentaStor "
-                                    "appliance"), folder)
+            message = (_('Volume %(volume)s not found')
+                       % {'volume': self.volume})
+            raise jsonrpc.NmsException(code='ENOENT', message=message)
+        if not self.nms.folder.object_exists(self.root_path):
+            message = (_('Folder %(folder)s not found')
+                       % {'folder': self.root_path})
+            raise jsonrpc.NmsException(code='ENOENT', message=message)
+        host_tpgs = self.nms.iscsitarget.list_tpg()
+        for tpg in self.tpgs:
+            if tpg in host_tpgs:
+                continue
+            message = (_('Target portal group %(tpg)s not found')
+                       % {'tpg': tpg})
+            raise jsonrpc.NmsException(code='ENOENT', message=message)
 
-    def _get_zvol_name(self, volume_name):
-        """Return zvol name that corresponds given volume name."""
-        if self.folder:
-            path = '%s/%s' % (self.volume, self.folder)
-        else:
-            path = self.volume
-        return '%s/%s' % (path, volume_name)
+    def _get_volume_path(self, volume):
+        """Return ZFS datset path for the volume."""
+        return posixpath.join(self.root_path, volume['name'])
 
-    def _create_target(self, target_idx):
-        target_name = '%s-%s-%i' % (
-            self.configuration.nexenta_target_prefix,
-            self.nms_host,
-            target_idx
-        )
-        target_group_name = self._get_target_group_name(target_name)
-
-        if not self._target_exists(target_name):
-            try:
-                self.nms.iscsitarget.create_target({
-                    'target_name': target_name,
-                    'tpgs': self.tpgs})
-            except exception.NexentaException as exc:
-                if 'already' in exc.args[0]:
-                    LOG.info('Ignored target creation error %s while '
-                             'ensuring export.',
-                             exc)
-                else:
-                    raise
-        if not self._target_group_exists(target_group_name):
-            try:
-                self.nms.stmf.create_targetgroup(target_group_name)
-            except exception.NexentaException as exc:
-                if ('already' in exc.args[0]):
-                    LOG.info('Ignored target group creation error %s '
-                             'while ensuring export.',
-                             exc)
-                else:
-                    raise
-        if not self._target_member_in_target_group(target_group_name,
-                                                   target_name):
-            try:
-                self.nms.stmf.add_targetgroup_member(target_group_name,
-                                                     target_name)
-            except exception.NexentaException as exc:
-                if ('already' in exc.args[0]):
-                    LOG.info('Ignored target group member addition error '
-                             '%s while ensuring export.', exc)
-                else:
-                    raise
-
-        self.targets[target_name] = []
-        return target_name
-
-    def _get_target_name(self, volume):
-        """Return iSCSI target name with least LUs."""
-        provider_location = volume.get('provider_location')
-        target_names = self.targets.keys()
-        if provider_location:
-            target_name = provider_location.split(',1 ')[1].split(' ')[0]
-            if not(self.targets.get(target_name)):
-                self.targets[target_name] = []
-            if not(volume['name'] in self.targets[target_name]):
-                self.targets[target_name].append(volume['name'])
-        elif not(target_names):
-            # create first target and target group
-            target_name = self._create_target(0)
-            self.targets[target_name].append(volume['name'])
-        else:
-            target_name = target_names[0]
-            for target in target_names:
-                if len(self.targets[target]) < len(self.targets[target_name]):
-                    target_name = target
-            if len(self.targets[target_name]) >= 20:
-                # create new target and target group
-                target_name = self._create_target(len(target_names))
-            if not(volume['name'] in self.targets[target_name]):
-                self.targets[target_name].append(volume['name'])
-        return target_name
-
-    def _get_target_group_name(self, target_name):
-        """Return Nexenta iSCSI target group name for volume."""
-        return target_name.replace(
-            self.configuration.nexenta_target_prefix,
-            self.configuration.nexenta_target_group_prefix
-        )
+    def _get_snapshot_path(self, snapshot):
+        """Return ZFS snapshot path for the snapshot."""
+        volume_name = snapshot['volume_name']
+        snapshot_name = snapshot['name']
+        volume_path = posixpath.join(self.root_path, volume_name)
+        return '%s@%s' % (volume_path, snapshot_name)
 
     @staticmethod
-    def _get_clone_snapshot_name(volume):
-        """Return name for snapshot that will be used to clone the volume."""
-        return 'cinder-clone-snapshot-%(id)s' % volume
+    def _match_template(template, name):
+        sequence = difflib.SequenceMatcher(None, name, template)
+        added = deleted = result = ''
+        for tag, a1, a2, b1, b2 in sequence.get_opcodes():
+            if tag == 'equal':
+                result += ''.join(sequence.a[a1:a2])
+            elif tag == 'delete':
+                deleted += ''.join(sequence.a[a1:a2])
+            elif tag == 'insert':
+                added += ''.join(sequence.b[b1:b2])
+            elif tag == 'replace':
+                result += ''.join(sequence.b[b1:b2])
+        if result == template and not (added or deleted):
+            return True
+        return False
 
-    @staticmethod
-    def _is_clone_snapshot_name(snapshot):
-        """Check if snapshot is created for cloning."""
-        return snapshot.startswith('cinder-clone-snapshot-')
+    def _create_target_group(self, group, target):
+        """Create a new target group with target member.
+
+        :param group: group name
+        :param target: group member
+        """
+        if not self._target_exists(target):
+            tpgs = ','.join(self.tpgs)
+            payload = {
+                'target_name': target,
+                'tpgs': tpgs
+            }
+            self.nms.iscsitarget.create_target(payload)
+        if not self._target_group_exists(group):
+            self.nms.stmf.create_targetgroup(group)
+        if not self._target_member_in_target_group(group, target):
+            self.nms.stmf.add_targetgroup_member(group, target)
 
     def create_volume(self, volume):
         """Create a zvol on appliance.
@@ -275,16 +214,15 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: volume reference
         :return: model update dict for volume reference
         """
-        try:
-            self.nms.zvol.create(
-                self._get_zvol_name(volume['name']),
-                '%sG' % (volume['size'],),
-                six.text_type(self.configuration.nexenta_blocksize),
-                self.configuration.nexenta_sparse)
-        except exception.NexentaException as exc:
-            if 'already exists' in exc.args[0]:
-                return
-            raise
+        volume_path = self._get_volume_path(volume)
+        volume_size = '%sG' % volume['size']
+        volume_blocksize = six.text_type(self.volume_blocksize)
+        volume_sparsed = self.volume_sparse
+        volume_options = {'compression': self.volume_compression}
+        self.nms.zvol.create_with_props(volume_path, volume_size,
+                                        volume_blocksize,
+                                        volume_sparsed,
+                                        volume_options)
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -292,39 +230,37 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: volume reference
         :param new_size: volume new size in GB
         """
-        LOG.info('Extending volume: %(id)s New size: %(size)s GB',
-                 {'id': volume['id'], 'size': new_size})
-        self.nms.zvol.set_child_prop(self._get_zvol_name(volume['name']),
-                                     'volsize', '%sG' % new_size)
+        volume_path = self._get_volume_path(volume)
+        volume_size = '%sG' % new_size
+        self.nms.zvol.set_child_prop(volume_path, 'volsize', volume_size)
 
     def delete_volume(self, volume):
-        """Destroy a zvol on appliance.
+        """Deletes a logical volume.
 
         :param volume: volume reference
         """
-        volume_name = self._get_zvol_name(volume['name'])
+        volume_path = self._get_volume_path(volume)
         try:
-            origin = self.nms.zvol.get_child_props(
-                volume_name, 'origin').get('origin')
-            self.nms.zvol.destroy(volume_name, '-r')
-        except exception.NexentaException as exc:
-            if 'does not exist' in exc.args[0]:
-                LOG.info('Volume %s does not exist, it '
-                         'seems it was already deleted.', volume_name)
-                return
-            if 'has children' in exc.args[0]:
-                LOG.info('Volume %s will be deleted later.', volume_name)
+            origin = self.nms.zvol.get_child_prop(volume_path, 'origin')
+        except jsonrpc.NmsException as error:
+            if error.code == 'ENOENT':
                 return
             raise
-        if origin and self._is_clone_snapshot_name(origin):
-            try:
-                self.nms.snapshot.destroy(origin, '')
-            except exception.NexentaException as exc:
-                if 'does not exist' in exc.args[0]:
-                    LOG.info('Snapshot %s does not exist, it was '
-                             'already deleted.', origin)
-                    return
-                raise
+        self.nms.zvol.destroy(volume_path, '-r')
+        if not origin:
+            return
+        template = self.origin_snapshot_template
+        parent_path, snapshot_name = origin.split('@')
+        if not self._match_template(template, snapshot_name):
+            return
+        try:
+            self.nms.snapshot.destroy(origin, '-d')
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to delete origin snapshot %(origin)s '
+                      'of volume %(volume)s: %(error)s',
+                      {'origin': origin,
+                       'volume': volume['name'],
+                       'error': error})
 
     def create_cloned_volume(self, volume, src_vref):
         """Creates a clone of the specified volume.
@@ -332,212 +268,460 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: new volume reference
         :param src_vref: source volume reference
         """
-        snapshot = {'volume_name': src_vref['name'],
-                    'name': self._get_clone_snapshot_name(volume),
-                    'volume_size': src_vref['size']}
-        LOG.debug('Creating temp snapshot of the original volume: '
-                  '%(volume_name)s@%(name)s', snapshot)
-        # We don't delete this snapshot, because this snapshot will be origin
-        # of new volume. This snapshot will be automatically promoted by NMS
-        # when user will delete origin volume. But when cloned volume deleted
-        # we check its origin property and delete source snapshot if needed.
+        snapshot = {
+            'name': self.origin_snapshot_template % volume['id'],
+            'volume_id': src_vref['id'],
+            'volume_name': src_vref['name'],
+            'volume_size': src_vref['size']
+        }
         self.create_snapshot(snapshot)
         try:
             self.create_volume_from_snapshot(volume, snapshot)
-        except exception.NexentaException as exc:
-            with excutils.save_and_reraise_exception():
-                LOG.exception('Volume creation failed, deleting created '
-                              'snapshot %(volume_name)s@%(name)s', snapshot)
-            try:
-                self.delete_snapshot(snapshot)
-            except (exception.NexentaException, exception.SnapshotIsBusy):
-                LOG.warning('Failed to delete zfs snapshot '
-                            '%(volume_name)s@%(name)s', snapshot)
-            raise exc
-
-    def _get_zfs_send_recv_cmd(self, src, dst):
-        """Returns rrmgr command for source and destination."""
-        return utils.get_rrmgr_cmd(src, dst,
-                                   compression=self.rrmgr_compression,
-                                   tcp_buf_size=self.rrmgr_tcp_buf_size,
-                                   connections=self.rrmgr_connections)
-
-    @staticmethod
-    def get_nms_for_url(url):
-        """Returns initialized nms object for url."""
-        auto, scheme, user, password, host, port, path = (
-            utils.parse_nms_url(url))
-        return jsonrpc.NexentaJSONProxy(scheme, host, port, path, user,
-                                        password, auto=auto)
-
-    def migrate_volume(self, ctxt, volume, host):
-        """Migrate if volume and host are managed by Nexenta appliance.
-
-        :param ctxt: context
-        :param volume: a dictionary describing the volume to migrate
-        :param host: a dictionary describing the host to migrate to
-        """
-        LOG.debug('Enter: migrate_volume: id=%(id)s, host=%(host)s',
-                  {'id': volume['id'], 'host': host})
-        false_ret = (False, None)
-
-        if volume['status'] not in ('available', 'retyping'):
-            return false_ret
-
-        if 'capabilities' not in host:
-            return false_ret
-
-        capabilities = host['capabilities']
-
-        if ('location_info' not in capabilities or
-                'iscsi_target_portal_port' not in capabilities or
-                'nms_url' not in capabilities):
-            return false_ret
-
-        nms_url = capabilities['nms_url']
-        dst_parts = capabilities['location_info'].split(':')
-
-        if (capabilities.get('vendor_name') != 'Nexenta' or
-                dst_parts[0] != self.__class__.__name__ or
-                capabilities['free_capacity_gb'] < volume['size']):
-            return false_ret
-
-        dst_host, dst_volume = dst_parts[1:]
-
-        ssh_bound = False
-        ssh_bindings = self.nms.appliance.ssh_list_bindings()
-        for bind in ssh_bindings:
-            if dst_host.startswith(bind.split('@')[1].split(':')[0]):
-                ssh_bound = True
-                break
-        if not ssh_bound:
-            LOG.warning("Remote NexentaStor appliance at %s should be "
-                        "SSH-bound.", dst_host)
-
-        # Create temporary snapshot of volume on NexentaStor Appliance.
-        snapshot = {
-            'volume_name': volume['name'],
-            'name': utils.get_migrate_snapshot_name(volume)
-        }
-        self.create_snapshot(snapshot)
-
-        src = '%(volume)s/%(zvol)s@%(snapshot)s' % {
-            'volume': self.volume,
-            'zvol': volume['name'],
-            'snapshot': snapshot['name']
-        }
-        dst = ':'.join([dst_host, dst_volume])
-
-        try:
-            self.nms.appliance.execute(self._get_zfs_send_recv_cmd(src, dst))
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot send source snapshot %(src)s to "
-                        "destination %(dst)s. Reason: %(exc)s",
-                        {'src': src, 'dst': dst, 'exc': exc})
-            return false_ret
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to create clone %(clone)s '
+                      'from volume %(volume)s: %(error)s',
+                      {'clone': volume['name'],
+                       'volume': src_vref['name'],
+                       'error': error})
+            raise
         finally:
             try:
                 self.delete_snapshot(snapshot)
-            except exception.NexentaException as exc:
-                LOG.warning("Cannot delete temporary source snapshot "
-                            "%(src)s on NexentaStor Appliance: %(exc)s",
-                            {'src': src, 'exc': exc})
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to delete temporary snapshot '
+                          '%(volume)s@%(snapshot)s: %(error)s',
+                          {'volume': src_vref['name'],
+                           'snapshot': snapshot['name'],
+                           'error': error})
+
+    def _get_bound_host(self, host):
+        """Get user@host:port from SSH bindings."""
         try:
-            self.delete_volume(volume)
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot delete source volume %(volume)s on "
-                        "NexentaStor Appliance: %(exc)s",
-                        {'volume': volume['name'], 'exc': exc})
+            bindings = self.nms.appliance.ssh_list_bindings()
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get SSH bindings: %(error)s',
+                      {'error': error})
+            return None
+        for user_host_port in bindings:
+            binding = bindings[user_host_port]
+            if not (isinstance(binding, list) and len(binding) == 4):
+                LOG.warning('Skip incompatible SSH binding: %(binding)s',
+                            {'binding': binding})
+                continue
+            data = binding[2]
+            items = data.split(',')
+            for item in items:
+                if host == item.strip():
+                    return user_host_port
+        return None
 
-        dst_nms = self.get_nms_for_url(nms_url)
-        dst_snapshot = '%s/%s@%s' % (dst_volume, volume['name'],
-                                     snapshot['name'])
+    def _svc_state(self, fmri, state):
+        retries = 10
+        delay = 30
+        while retries:
+            greenthread.sleep(delay)
+            retries -= 1
+            try:
+                status = self.nms.autosvc.get_state(fmri)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to get state of migration '
+                          'service %(fmri)s: %(error)s',
+                          {'fmri': fmri, 'error': error})
+                continue
+            if status == 'uninitialized':
+                continue
+            elif status == state:
+                return True
+            if state == 'online':
+                method = getattr(self.nms.autosvc, 'enable')
+            elif state == 'disabled':
+                method = getattr(self.nms.autosvc, 'disable')
+            else:
+                LOG.error('Request unknown service state: %(state)s',
+                          {'state': state})
+                return False
+            try:
+                method(fmri)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to change state of migration service '
+                          '%(fmri)s to %(state)s: %(error)s',
+                          {'fmri': fmri, 'state': state, 'error': error})
+        LOG.error('Unable to change state of migration service %(fmri)s '
+                  'to %(state)s: maximum retries exceeded',
+                  {'fmri': fmri, 'state': state})
+        return False
+
+    def _svc_progress(self, fmri):
+        """Get progress for SMF service."""
+        progress = 0
         try:
-            dst_nms.snapshot.destroy(dst_snapshot, '')
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot delete temporary destination snapshot "
-                        "%(dst)s on NexentaStor Appliance: %(exc)s",
-                        {'dst': dst_snapshot, 'exc': exc})
-        return True, None
+            estimations = self.nms.autosync.get_estimations(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get estimations for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return progress
+        size = estimations.get('curt_siz')
+        sent = estimations.get('curt_sen')
+        try:
+            size = float(size)
+            sent = float(sent)
+            if size > 0:
+                progress = int(100 * sent / size)
+        except (TypeError, ValueError) as error:
+            LOG.error('Failed to parse estimations statistics '
+                      '%(estimations)s for migration service '
+                      '%(fmri)s: %(error)s',
+                      {'estimations': estimations,
+                       'fmri': fmri, 'error': error})
+        return progress
 
-    def retype(self, context, volume, new_type, diff, host):
-        """Convert the volume to be of the new type.
+    def _svc_result(self, fmri):
+        try:
+            props = self.nms.autosvc.get_child_props(fmri, '')
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get properties of migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return False
+        history = props.get('zfs/run_history')
+        if not history:
+            LOG.error('Failed to get history of migration service '
+                      '%(fmri)s: %(props)s',
+                      {'fmri': fmri, 'props': props})
+            return False
+        results = history.split()
+        if len(results) > 1:
+            LOG.warning('Found unexpected replication sessions for '
+                        'migration service %(fmri)s: %(history)s',
+                        {'fmri': fmri, 'history': history})
+        latest = results.pop()
+        start, stop, code = latest.split('::')
+        try:
+            start = int(start)
+            stop = int(stop)
+            code = int(code)
+        except (TypeError, ValueError) as error:
+            LOG.error('Failed to parse history %(history)s for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'history': history, 'fmri': fmri, 'error': error})
+            return False
+        delta = stop - start
+        if code != 1:
+            LOG.error('Migration service %(fmri)s failed after %(delta)s '
+                      'seconds, please check the service log below',
+                      {'fmri': fmri, 'delta': delta})
+            return False
+        LOG.info('Migration service %(fmri)s successfully finished in '
+                 '%(delta)s seconds',
+                 {'fmri': fmri, 'delta': delta})
+        return True
 
-        :param ctxt: Context
+    def _svc_cleanup(self, fmri, migrated=False):
+        props = None
+        flags = {
+            'src_properties': '1',
+            'dst_properties': '1',
+            'src_snapshots': '1',
+            'dst_snapshots': '1'
+        }
+        if not migrated:
+            flags['dst_datasets'] = '1'
+        try:
+            props = self.nms.autosvc.get_child_props(fmri, '')
+            props['zfs/sync-recursive'] = '1'
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get properties of migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        try:
+            self.nms.autosvc.unschedule(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to unschedule migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        self._svc_state(fmri, 'disabled')
+        try:
+            self.nms.autosvc.destroy(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to destroy migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        if not props:
+            return
+        try:
+            src_pid, dst_pid = self.nms.autosync.cleanup(props, flags)
+        except jsonrpc.NmsException as error:
+            src_pid = dst_pid = 0
+            LOG.error('Failed to cleanup migration service %(fmri)s: '
+                      '%(error)s',
+                      {'fmri': fmri, 'error': error})
+        for pid in [src_pid, dst_pid]:
+            while pid:
+                try:
+                    self.nms.job.get_jobparams(pid)
+                except jsonrpc.NmsException as error:
+                    if error.code == 'ENOENT':
+                        break
+                greenthread.sleep(30)
+        if migrated:
+            return
+        path = props.get('restarter/logfile')
+        if not path:
+            return
+        try:
+            content = self.nms.logviewer.get_tail(path, units.Mi)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get log file content for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return
+        log = '\n'.join(content)
+        LOG.error('Migration service %(fmri)s log: %(log)s',
+                  {'fmri': fmri, 'log': log})
+
+    def _migrate_volume(self, volume, host, path):
+        delay = 30
+        retries = 10
+        src_path = self._get_volume_path(volume)
+        dst_path = posixpath.join(path, volume['name'])
+        hosts = self._get_host_addresses()
+        if host in hosts:
+            dst_host = 'localhost'
+            service_direction = '0'
+            service_proto = 'zfs'
+            if src_path == dst_path:
+                LOG.info('Skip local to local replication: source '
+                         'volume %(src_path)s and destination volume '
+                         '%(dst_path)s are the same local volume',
+                         {'src_path': src_path, 'dst_path': dst_path})
+                return True
+        else:
+            service_direction = '1'
+            service_proto = 'zfs+rr'
+            dst_host = self._get_bound_host(host)
+            if not dst_host:
+                LOG.error('Storage assisted volume migration is '
+                          'unavailable: the destination host '
+                          '%(host)s should be SSH bound',
+                          {'host': host})
+                return False
+        service_name = '%(prefix)s-%(volume)s' % {
+            'prefix': self.migration_service_prefix,
+            'volume': volume['name']
+        }
+        comment = 'Migrate %(src)s to %(host)s:%(dst)s' % {
+            'src': src_path,
+            'host': dst_host,
+            'dst': dst_path
+        }
+        yesterday = timeutils.utcnow() - datetime.timedelta(days=1)
+        dst_path = path
+        rate_limit = 0
+        if self.migration_throttle:
+            rate_limit = self.migration_throttle * units.Ki
+        payload = {
+            'comment': comment,
+            'custom_name': service_name,
+            'from-fs': src_path,
+            'to-host': dst_host,
+            'to-fs': dst_path,
+            'direction': service_direction,
+            'marker_name': self.migration_snapshot_prefix,
+            'proto': service_proto,
+            'day': six.text_type(yesterday.day),
+            'rate_limit': six.text_type(rate_limit),
+            '_unique': 'type from-host from-fs to-host to-fs',
+            'method': 'sync',
+            'from-host': 'localhost',
+            'period_multiplier': '1',
+            'keep_src': '1',
+            'keep_dst': '1',
+            'trace_level': '30',
+            'type': 'monthly',
+            'nconn': '2',
+            'period': '12',
+            'mbuffer_size': '16',
+            'minute': '0',
+            'hour': '0',
+            'flags': '0',
+            'estimations': '0',
+            'force': '0',
+            'reverse_capable': '0',
+            'sync-recursive': '0',
+            'auto-clone': '0',
+            'flip_options': '0',
+            'direction_flipped': '0',
+            'retry': '0',
+            'success_counter': '0',
+            'dircontent': '0',
+            'zip_level': '0',
+            'auto-mount': '0',
+            'marker': '',
+            'exclude': '',
+            'run_history': '',
+            'progress-marker': '',
+            'from-snapshot': '',
+            'latest-suffix': '',
+            'trunk': '',
+            'options': ''
+        }
+        try:
+            fmri = self.nms.autosvc.fmri_create('auto-sync', comment,
+                                                src_path, 0, payload)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to create migration service '
+                      'with payload %(payload)s: %(error)s',
+                      {'payload': payload, 'error': error})
+            return False
+        if not self._svc_state(fmri, 'online'):
+            self._svc_cleanup(fmri)
+            return False
+        service_running = False
+        try:
+            self.nms.autosvc.execute(fmri)
+            service_running = True
+            LOG.info('Migration service %(fmri)s successfully started',
+                     {'fmri': fmri})
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to start migration service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        if not service_running:
+            LOG.error('Migration service %(fmri)s is offline',
+                      {'fmri': fmri})
+            self._svc_cleanup(fmri)
+            return False
+        service_history = None
+        service_retries = retries
+        service_progress = 0
+        while service_retries and not service_history:
+            greenthread.sleep(delay)
+            service_retries -= 1
+            try:
+                service_props = self.nms.autosvc.get_child_props(fmri, '')
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to get properties of migration service '
+                          '%(fmri)s: %(error)s',
+                          {'fmri': fmri, 'error': error})
+                continue
+            service_history = service_props.get('zfs/run_history')
+            service_started = service_props.get('zfs/time_started')
+            if service_started == 'N/A':
+                continue
+            progress = self._svc_progress(fmri)
+            if progress > service_progress:
+                service_progress = progress
+                service_retries = retries
+            LOG.info('Migration service %(fmri)s replication progress: '
+                     '%(service_progress)s%%',
+                     {'fmri': fmri, 'service_progress': service_progress})
+        if not service_history:
+            self._svc_cleanup(fmri)
+            return False
+        volume_migrated = self._svc_result(fmri)
+        self._svc_cleanup(fmri, volume_migrated)
+        if volume_migrated:
+            try:
+                self.delete_volume(volume)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to delete source volume %(volume)s '
+                          'after successful migration: %(error)s',
+                          {'volume': volume['name'], 'error': error})
+        return volume_migrated
+
+    def migrate_volume(self, context, volume, host):
+        """Migrate the volume to the specified host.
+
+        Returns a boolean indicating whether the migration occurred,
+        as well as model_update.
+
+        :param context: Security context
         :param volume: A dictionary describing the volume to migrate
-        :param new_type: A dictionary describing the volume type to convert to
-        :param diff: A dictionary with the difference between the two types
         :param host: A dictionary describing the host to migrate to, where
                      host['host'] is its name, and host['capabilities'] is a
                      dictionary of its reported capabilities.
         """
-        LOG.debug('Retype volume request %(vol)s to be %(type)s '
-                  '(host: %(host)s), diff %(diff)s.',
-                  {'vol': volume['name'],
-                   'type': new_type,
-                   'host': host,
-                   'diff': diff})
-
-        options = dict(
-            compression='compression',
-            dedup='dedup',
-            description='nms:description'
-        )
-
-        retyped = False
-        migrated = False
-
+        LOG.info('Start storage assisted volume migration '
+                 'for volume %(volume)s to host %(host)s',
+                 {'volume': volume['name'],
+                  'host': host['host']})
+        false_ret = (False, None)
+        if 'capabilities' not in host:
+            LOG.error('No host capabilities found for '
+                      'the destination host %(host)s',
+                      {'host': host['host']})
+            return false_ret
         capabilities = host['capabilities']
-        src_backend = self.__class__.__name__
-        dst_backend = capabilities['location_info'].split(':')[0]
-        if src_backend != dst_backend:
-            LOG.warning('Cannot retype from %(src_backend)s to '
-                        '%(dst_backend)s.',
-                        {
-                            'src_backend': src_backend,
-                            'dst_backend': dst_backend,
-                        })
-            return False
+        required_capabilities = [
+            'vendor_name',
+            'location_info',
+            'storage_protocol',
+            'free_capacity_gb'
+        ]
+        for capability in required_capabilities:
+            if capability not in capabilities:
+                LOG.error('Required host capability %(capability)s not '
+                          'found for the destination host %(host)s',
+                          {'capability': capability, 'host': host['host']})
+                return false_ret
+        vendor = capabilities['vendor_name']
+        if vendor != self.vendor_name:
+            LOG.error('Unsupported vendor %(vendor)s found '
+                      'for the destination host %(host)s',
+                      {'vendor': vendor, 'host': host['host']})
+            return false_ret
+        location = capabilities['location_info']
+        try:
+            driver, san_host, san_path = location.split(':')
+        except ValueError as error:
+            LOG.error('Failed to parse location info %(location)s '
+                      'for the destination host %(host)s: %(error)s',
+                      {'location': location, 'host': host['host'],
+                       'error': error})
+            return false_ret
+        if not (driver and san_host and san_path):
+            LOG.error('Incomplete location info %(location)s '
+                      'found for the destination host %(host)s',
+                      {'location': location, 'host': host['host']})
+            return false_ret
+        if driver != self.driver_name:
+            LOG.error('Unsupported storage driver %(driver)s '
+                      'found for the destination host %(host)s',
+                      {'driver': driver, 'host': host['host']})
+            return false_ret
+        storage_protocol = capabilities['storage_protocol']
+        if storage_protocol != self.storage_protocol:
+            LOG.error('Unsupported storage protocol %(protocol)s '
+                      'found for the destination host %(host)s',
+                      {'protocol': storage_protocol,
+                       'host': host['host']})
+            return false_ret
+        free_capacity_gb = capabilities['free_capacity_gb']
+        if free_capacity_gb < volume['size']:
+            LOG.error('There is not enough space available on the '
+                      'destination host %(host)s to migrate volume '
+                      '%(volume)s, available space: %(free)sG, '
+                      'required space: %(required)sG',
+                      {'host': host['host'], 'volume': volume['name'],
+                       'free': free_capacity_gb,
+                       'required': volume['size']})
+            return false_ret
+        if self._migrate_volume(volume, san_host, san_path):
+            return (True, None)
+        return false_ret
 
-        hosts = (volume['host'], host['host'])
-        old, new = hosts
-        if old != new:
-            migrated, provider_location = self.migrate_volume(
-                context, volume, host)
-
-        if not migrated:
-            nms = self.nms
-        else:
-            nms_url = capabilities['nms_url']
-            nms = self.get_nms_for_url(nms_url)
-
-        zvol = '%s/%s' % (
-            capabilities['location_info'].split(':')[-1], volume['name'])
-
-        for opt in options:
-            old, new = diff.get('extra_specs').get(opt, (False, False))
-            if old != new:
-                LOG.debug('Changing %(opt)s from %(old)s to %(new)s.',
-                          {'opt': opt, 'old': old, 'new': new})
-                try:
-                    nms.zvol.set_child_prop(
-                        zvol, options[opt], new)
-                    retyped = True
-                except exception.NexentaException:
-                    LOG.error('Error trying to change %(opt)s'
-                              ' from %(old)s to %(new)s',
-                              {'opt': opt, 'old': old, 'new': new})
-                    return False, None
-        return retyped or migrated, None
+    def retype(self, context, volume, new_type, diff, host):
+        """Convert the volume to be of the new type."""
+        pass
 
     def create_snapshot(self, snapshot):
-        """Create snapshot of existing zvol on appliance.
+        """Creates a snapshot.
 
         :param snapshot: snapshot reference
         """
-        self.nms.zvol.create_snapshot(
-            self._get_zvol_name(snapshot['volume_name']),
-            snapshot['name'], '')
+        snapshot_path = self._get_snapshot_path(snapshot)
+        volume_path, snapshot_name = snapshot_path.split('@')
+        self.nms.zvol.create_snapshot(volume_path, snapshot_name, '')
 
     def create_volume_from_snapshot(self, volume, snapshot):
         """Create new volume from other's snapshot on appliance.
@@ -545,12 +729,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: reference of volume to be created
         :param snapshot: reference of source snapshot
         """
-        self.nms.zvol.clone(
-            '%s@%s' % (self._get_zvol_name(snapshot['volume_name']),
-                       snapshot['name']),
-            self._get_zvol_name(volume['name']))
-        if (('size' in volume) and (
-                volume['size'] > snapshot['volume_size'])):
+        snapshot_path = self._get_snapshot_path(snapshot)
+        clone_path = self._get_volume_path(volume)
+        self.nms.zvol.clone(snapshot_path, clone_path)
+        if volume['size'] > snapshot['volume_size']:
             self.extend_volume(volume, volume['size'])
 
     def delete_snapshot(self, snapshot):
@@ -558,28 +740,23 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
 
         :param snapshot: snapshot reference
         """
-        volume_name = self._get_zvol_name(snapshot['volume_name'])
-        snapshot_name = '%s@%s' % (volume_name, snapshot['name'])
-        try:
-            self.nms.snapshot.destroy(snapshot_name, '')
-        except exception.NexentaException as exc:
-            if "does not exist" in exc.args[0]:
-                LOG.info('Snapshot %s does not exist, it seems it was '
-                         'already deleted.', snapshot_name)
-                return
-            elif "snapshot has dependent clones" in exc.args[0]:
-                LOG.info('Snapshot %s has dependent clones, will be '
-                         'deleted later.', snapshot_name)
-                return
-            raise
+        snapshot_path = self._get_snapshot_path(snapshot)
+        self.nms.snapshot.destroy(snapshot_path, '-d')
+
+    def snapshot_revert_use_temp_snapshot(self):
+        # Considering that NexentaStor based drivers use COW images
+        # for storing snapshots, having chains of such images,
+        # creating a backup snapshot when reverting one is not
+        # actually helpful.
+        return False
+
+    def revert_to_snapshot(self, context, volume, snapshot):
+        """Revert volume to snapshot."""
+        snapshot_path = self._get_snapshot_path(snapshot)
+        self.nms.snapshot.rollback(snapshot_path, '')
 
     def local_path(self, volume):
-        """Return local path to existing local volume.
-
-        We never have local volumes, so it raises NotImplementedError.
-
-        :raise: :py:exc:`NotImplementedError`
-        """
+        """Return local path to existing local volume."""
         raise NotImplementedError
 
     def _target_exists(self, target):
@@ -589,163 +766,612 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :return: True if target exist, else False
         """
         targets = self.nms.stmf.list_targets()
-        if not targets:
-            return False
-        return (target in targets)
+        return target in targets
 
-    def _target_group_exists(self, target_group):
+    def _target_group_exists(self, group):
         """Check if target group exist.
 
-        :param target_group: target group
+        :param group: target group
         :return: True if target group exist, else False
         """
         groups = self.nms.stmf.list_targetgroups()
-        if not groups:
-            return False
-        return target_group in groups
+        return group in groups
 
-    def _target_member_in_target_group(self, target_group, target_member):
+    def _target_member_in_target_group(self, group, member):
         """Check if target member in target group.
 
-        :param target_group: target group
-        :param target_member: target member
+        :param group: target group
+        :param member: target member
         :return: True if target member in target group, else False
         :raises: NexentaException if target group doesn't exist
         """
-        members = self.nms.stmf.list_targetgroup_members(target_group)
-        if not members:
-            return False
-        return target_member in members
+        members = self.nms.stmf.list_targetgroup_members(group)
+        return member in members
 
-    def _lu_exists(self, zvol_name):
+    def _lu_exists(self, volume_path):
         """Check if LU exists on appliance.
 
-        :param zvol_name: Zvol name
-        :raises: NexentaException if zvol not exists
+        :param volume_path: volume path
+        :raises: NmsException if volume not exists
         :return: True if LU exists, else False
         """
         try:
-            return bool(self.nms.scsidisk.lu_exists(zvol_name))
-        except exception.NexentaException as exc:
-            if 'does not exist' not in exc.args[0]:
-                raise
-            return False
+            return bool(self.nms.scsidisk.lu_exists(volume_path))
+        except jsonrpc.NmsException as error:
+            if error.code == 'ENOENT':
+                return False
+            raise
 
-    def _is_lu_shared(self, zvol_name):
+    def _is_lu_shared(self, volume_path):
         """Check if LU exists on appliance and shared.
 
-        :param zvol_name: Zvol name
-        :raises: NexentaException if Zvol not exist
+        :param volume_path: volume path
+        :raises: NmsException if volume not exist
         :return: True if LU exists and shared, else False
         """
         try:
-            shared = self.nms.scsidisk.lu_shared(zvol_name) > 0
-        except exception.NexentaException as exc:
-            if 'does not exist for zvol' not in exc.args[0]:
-                raise  # Zvol does not exists
-            shared = False  # LU does not exist
-        return shared
+            return bool(self.nms.scsidisk.lu_shared(volume_path))
+        except jsonrpc.NmsException as error:
+            if error.code == 'ENOENT':
+                return False
+            raise
 
-    def create_export(self, _ctx, volume, connector):
-        """Create new export for zvol.
+    def create_export(self, context, volume, connector):
+        """Driver entry point to get the export info for a new volume."""
+        pass
 
-        :param volume: reference of volume to be exported
-        :return: iscsiadm-formatted provider location string
+    def ensure_export(self, context, volume):
+        """Driver entry point to get the export info for an existing volume."""
+        pass
+
+    def remove_export(self, context, volume):
+        """Driver entry point to remove an export for a volume."""
+        pass
+
+    def _get_host_addresses(self):
+        """Return NexentaStor IP addresses list."""
+        addresses = []
+        items = self.nms.appliance.execute('ipadm show-addr -p -o addr')
+        for item in items:
+            cidr = six.text_type(item)
+            addr, mask = cidr.split('/')
+            obj = ipaddress.ip_address(addr)
+            if not obj.is_loopback:
+                addresses.append(obj.exploded)
+        LOG.debug('Configured IP addresses: %(addresses)s',
+                  {'addresses': addresses})
+        return addresses
+
+    def _get_host_portals(self):
+        """Return NexentaStor iSCSI portals list."""
+        portals = []
+        addresses = self._get_host_addresses()
+        for address in addresses:
+            portal = '%s:%s' % (address, self.portal_port)
+            portals.append(portal)
+        LOG.debug('Configured iSCSI portals: %(portals)s',
+                  {'portals': portals})
+        return portals
+
+    def _get_host_portal_groups(self):
+        """Return NexentaStor iSCSI portal groups dictionary."""
+        portal_groups = {}
+        default_portal = '%s:%s' % (self.san_host, self.portal_port)
+        host_portals = self._get_host_portals()
+        host_portal_groups = self.nms.iscsitarget.list_tpg()
+        for group in host_portal_groups:
+            group_portals = host_portal_groups[group]
+            if not self.tpgs:
+                if default_portal in group_portals:
+                    LOG.debug('Use default portal %(portal)s '
+                              'for portal group %(group)s',
+                              {'portal': default_portal,
+                               'group': group})
+                    portal_groups[group] = [default_portal]
+                continue
+            if group not in self.tpgs:
+                LOG.debug('Skip existing but not configured '
+                          'target portal group %(group)s',
+                          {'group': group})
+                continue
+            portals = []
+            for portal in group_portals:
+                if portal not in host_portals:
+                    LOG.debug('Skip non-existing '
+                              'portal %(portal)s',
+                              {'portal': portal})
+                    continue
+                portals.append(portal)
+            if portals:
+                portal_groups[group] = portals
+        LOG.debug('Configured host target '
+                  'portal groups: %(groups)s',
+                  {'groups': portal_groups})
+        return portal_groups
+
+    def _get_host_targets(self):
+        """Return NexentaStor iSCSI targets dictionary."""
+        targets = {}
+        default_portal = '%s:%s' % (self.san_host, self.portal_port)
+        host_portal_groups = self._get_host_portal_groups()
+        stmf_targets = self.nms.stmf.list_targets()
+        for name in stmf_targets:
+            if not name.startswith(self.target_prefix):
+                LOG.debug('Skip not a cinder target %(name)s',
+                          {'name': name})
+                continue
+            target = stmf_targets[name]
+            if not ('protocol' in target and target['protocol'] == 'iSCSI'):
+                LOG.debug('Skip non-iSCSI target %(target)s',
+                          {'target': target})
+                continue
+            if not ('status' in target and target['status'] == 'Online'):
+                LOG.debug('Skip non-online iSCSI target %(target)s',
+                          {'target': target})
+                continue
+            target_portals = []
+            props = self.nms.iscsitarget.get_target_props(name)
+            if 'tpgs' in props:
+                target_portal_groups = props['tpgs'].split(',')
+                for group in target_portal_groups:
+                    if group not in host_portal_groups:
+                        LOG.debug('Skip existing but unsuitable target portal '
+                                  'group %(group)s for iSCSI target %(name)s',
+                                  {'group': group, 'name': name})
+                        continue
+                    portals = host_portal_groups[group]
+                    target_portals += portals
+            else:
+                portals = [default_portal]
+                target_portals += portals
+            if target_portals:
+                targets[name] = target_portals
+        LOG.debug('Configured iSCSI targets: %(targets)s',
+                  {'targets': targets})
+        return targets
+
+    def _target_group_props(self, group_name, host_targets):
+        """Check existing targets/portals for the given target group.
+
+        :param group_name: target group name
+        :param host_targets: host targets dictionary
+        :returns: dictionary of portals per target
         """
-        model_update = self._do_export(_ctx, volume)
+        if not group_name.startswith(self.target_group_prefix):
+            LOG.debug('Skip not a cinder target group %(group)s',
+                      {'group': group_name})
+            return {}
+        group_targets = self.nms.stmf.list_targetgroup_members(group_name)
+        if not group_targets:
+            LOG.debug('Skip target group %(group)s: group has no members',
+                      {'group': group_name})
+            return {}
+        group_props = {}
+        for target_name in group_targets:
+            if target_name not in host_targets:
+                LOG.debug('Skip existing but unsuitable member '
+                          'of target group %(group)s: %(target)s',
+                          {'group': group_name,
+                           'target': target_name})
+                continue
+            portals = host_targets[target_name]
+            if not portals:
+                LOG.debug('Skip existing but unsuitable member '
+                          'of target group %(group)s: %(target)s',
+                          {'group': group_name,
+                           'target': target_name})
+                continue
+            LOG.debug('Found member of target group %(group)s: '
+                      'iSCSI target %(target)s listening on '
+                      'portals %(portals)s',
+                      {'group': group_name,
+                       'target': target_name,
+                       'portals': portals})
+            group_props[target_name] = portals
+        LOG.debug('Target group %(group)s members: %(members)s',
+                  {'group': group_name,
+                   'members': group_props})
+        return group_props
+
+    def initialize_connection(self, volume, connector):
+        """Do all steps to get zfs volume exported at separate target.
+
+        :param volume: volume reference
+        :param connector: connector reference
+        :returns: dictionary of connection information
+        """
+        volume_path = self._get_volume_path(volume)
+        host_iqn = connector.get('initiator')
+        LOG.debug('Initialize connection for volume: %(volume)s and '
+                  'initiator: %(initiator)s',
+                  {'volume': volume['name'], 'initiator': host_iqn})
+        suffix = uuid.uuid4().hex
+        host_targets = self._get_host_targets()
+        host_groups = ['All']
+        host_group = self._get_host_group(host_iqn)
+        if host_group:
+            host_groups.append(host_group)
+        props_portals = []
+        props_iqns = []
+        props_luns = []
+        mappings = []
+        if self._is_lu_shared(volume_path):
+            mappings = self.nms.scsidisk.list_lun_mapping_entries(volume_path)
+        for mapping in mappings:
+            mapping_lu = int(mapping['lun'])
+            mapping_hg = mapping['host_group']
+            mapping_tg = mapping['target_group']
+            mapping_id = mapping['entry_number']
+            if mapping_tg == 'All':
+                LOG.debug('Delete LUN mapping %(id)s for target group %(tg)s',
+                          {'id': mapping_id, 'tg': mapping_tg})
+                self.nms.scsidisk.remove_lun_mapping_entry(volume_path,
+                                                           mapping_id)
+                continue
+            if mapping_hg not in host_groups:
+                LOG.debug('Skip LUN mapping %(id)s for host group %(hg)s',
+                          {'id': mapping_id, 'hg': mapping_hg})
+                continue
+            group_props = self._target_group_props(mapping_tg,
+                                                   host_targets)
+            if not group_props:
+                LOG.debug('Skip LUN mapping %(id)s for target group %(tg)s',
+                          {'id': mapping_id, 'tg': mapping_tg})
+                continue
+            for target_iqn in group_props:
+                target_portals = group_props[target_iqn]
+                props_portals += target_portals
+                props_iqns += [target_iqn] * len(target_portals)
+                props_luns += [mapping_lu] * len(target_portals)
+
+        props = {}
+        props['discard'] = True
+        props['target_discovered'] = False
+        props['encrypted'] = False
+        props['qos_specs'] = None
+        props['volume_id'] = volume['id']
+        props['access_mode'] = 'rw'
+        multipath = connector.get('multipath', False)
+        if props_luns:
+            if multipath:
+                props['target_portals'] = props_portals
+                props['target_iqns'] = props_iqns
+                props['target_luns'] = props_luns
+            else:
+                index = random.randrange(len(props_luns))
+                props['target_portal'] = props_portals[index]
+                props['target_iqn'] = props_iqns[index]
+                props['target_lun'] = props_luns[index]
+            LOG.debug('Use existing LUN mapping %(props)s',
+                      {'props': props})
+            return {'driver_volume_type': self.driver_volume_type,
+                    'data': props}
+
+        if host_group is None:
+            host_group = '%s-%s' % (self.host_group_prefix, suffix)
+            self._create_host_group(host_group, host_iqn)
+        else:
+            LOG.debug('Use existing host group %(group)s',
+                      {'group': host_group})
+
+        mappings_stat = {}
+        group_targets = {}
+        target_groups = self.nms.stmf.list_targetgroups()
+        for target_group in target_groups:
+            if (target_group in self.mappings and
+                    self.mappings[target_group] >= self.lpt):
+                LOG.debug('Skip existing target group %(group)s: '
+                          '%(count)s LUN mappings limit reached',
+                          {'group': target_group,
+                           'count': self.mappings[target_group]})
+                continue
+            group_props = self._target_group_props(target_group,
+                                                   host_targets)
+            if not group_props:
+                LOG.debug('Skip unsuitable target group %(group)s',
+                          {'group': target_group})
+                continue
+            group_targets[target_group] = group_props
+            if target_group in self.mappings:
+                mappings_stat[target_group] = self.mappings[target_group]
+            else:
+                mappings_stat[target_group] = self.mappings[target_group] = 0
+
+        if mappings_stat:
+            target_group = min(mappings_stat, key=mappings_stat.get)
+            LOG.debug('Use existing target group %(group)s with '
+                      '%(count)s LUN mappings created',
+                      {'group': target_group,
+                       'count': mappings_stat[target_group]})
+        else:
+            target = '%s:%s' % (self.target_prefix, suffix)
+            target_group = '%s-%s' % (self.target_group_prefix, suffix)
+            self._create_target_group(target_group, target)
+            host_targets = self._get_host_targets()
+            group_props = self._target_group_props(target_group, host_targets)
+            group_targets[target_group] = group_props
+            self.mappings[target_group] = 0
+        if not self._lu_exists(volume_path):
+            payload = {'serial': volume['id']}
+            self.nms.scsidisk.create_lu(volume_path, payload)
+        if not self.configuration.nexenta_lu_writebackcache_disabled:
+            self.nms.scsidisk.writeback_cache_enable(volume_path)
+        payload = {
+            'target_group': target_group,
+            'host_group': host_group
+        }
+        entry = self.nms.scsidisk.add_lun_mapping_entry(volume_path, payload)
+        self.mappings[target_group] += 1
+        lun = int(entry['lun'])
+        targets = group_targets[target_group]
+        for target in targets:
+            portals = targets[target]
+            props_portals += portals
+            props_iqns += [target] * len(portals)
+            props_luns += [lun] * len(portals)
+
+        if multipath:
+            props['target_portals'] = props_portals
+            props['target_iqns'] = props_iqns
+            props['target_luns'] = props_luns
+        else:
+            index = random.randrange(len(props_luns))
+            props['target_portal'] = props_portals[index]
+            props['target_iqn'] = props_iqns[index]
+            props['target_lun'] = props_luns[index]
+        LOG.debug('Created new LUN mapping: %(props)s',
+                  {'props': props})
+        return {'driver_volume_type': self.driver_volume_type,
+                'data': props}
+
+    def _get_host_group(self, member):
+        """Find existing host group by group member.
+
+        :param member: host group member
+        :returns: host group name
+        """
+        groups = self.nms.stmf.list_hostgroups()
+        for group in groups:
+            members = self.nms.stmf.list_hostgroup_members(group)
+            if member in members:
+                LOG.debug('Found host group %(group)s for member %(member)s',
+                          {'group': group, 'member': member})
+                return group
+        return None
+
+    def _create_host_group(self, group, member):
+        """Create a new host group.
+
+        :param group: host group name
+        :param member: host group member
+        """
+        LOG.debug('Create new host group %(group)s',
+                  {'group': group})
+        self.nms.stmf.create_hostgroup(group)
+        LOG.debug('Add member %(member)s to host group %(group)s',
+                  {'member': member, 'group': group})
+        self.nms.stmf.add_hostgroup_member(group, member)
+
+    def terminate_connection(self, volume, connector, **kwargs):
+        """Terminate a connection to a volume.
+
+        :param volume: a volume object
+        :param connector: a connector object
+        :returns: dictionary of connection information
+        """
+        info = {'driver_volume_type': self.driver_volume_type, 'data': {}}
+        volume_path = self._get_volume_path(volume)
+        host_groups = []
+        host_iqn = None
+        if isinstance(connector, dict) and 'initiator' in connector:
+            connectors = []
+            if 'volume_attachment' in volume:
+                if isinstance(volume['volume_attachment'], list):
+                    for attachment in volume['volume_attachment']:
+                        if not isinstance(attachment, dict):
+                            continue
+                        if 'connector' not in attachment:
+                            continue
+                        connectors.append(attachment['connector'])
+            if connectors.count(connector) > 1:
+                LOG.debug('Detected %(count)s connections from host '
+                          '%(host_name)s (IP:%(host_ip)s) to volume '
+                          '%(volume)s, skip terminating connection',
+                          {'count': connectors.count(connector),
+                           'host_name': connector.get('host', 'unknown'),
+                           'host_ip': connector.get('ip', 'unknown'),
+                           'volume': volume['name']})
+                return True
+            host_iqn = connector['initiator']
+            host_groups.append('All')
+            host_group = self._get_host_group(host_iqn)
+            if host_group is not None:
+                host_groups.append(host_group)
+            LOG.debug('Terminate connection for volume %(volume)s and '
+                      'initiator %(initiator)s',
+                      {'volume': volume['name'],
+                       'initiator': host_iqn})
+        else:
+            LOG.debug('Terminate all connections for volume %(volume)s',
+                      {'volume': volume['name']})
+
+        if not self._is_lu_shared(volume_path):
+            LOG.debug('No LUN mappings found for volume %(volume)s',
+                      {'volume': volume['name']})
+            return info
+        mappings = self.nms.scsidisk.list_lun_mapping_entries(volume_path)
+        for mapping in mappings:
+            mapping_hg = mapping['host_group']
+            mapping_tg = mapping['target_group']
+            mapping_id = mapping['entry_number']
+            if host_iqn is None or mapping_hg in host_groups:
+                LOG.debug('Delete LUN mapping %(id)s for volume %(volume)s, '
+                          'arget group %(tg)s and host group %(hg)s',
+                          {'id': mapping_id, 'volume': volume['name'],
+                           'tg': mapping_tg, 'hg': mapping_hg})
+                if (mapping_tg in self.mappings and
+                        self.mappings[mapping_tg] > 0):
+                    self.mappings[mapping_tg] -= 1
+                else:
+                    self.mappings[mapping_tg] = 0
+                self.nms.scsidisk.remove_lun_mapping_entry(volume_path,
+                                                           mapping_id)
+            else:
+                LOG.debug('Keep LUN mapping %(id)s for volume %(volume)s, '
+                          'target group %(tg)s and host group %(hg)s',
+                          {'id': mapping_id, 'volume': volume['name'],
+                           'tg': mapping_tg, 'hg': mapping_hg})
+        return info
+
+    def update_migrated_volume(self, context, volume, new_volume,
+                               original_volume_status):
+        """Return model update for migrated volume.
+
+        This method should rename the back-end volume name on the
+        destination host back to its original name on the source host.
+
+        :param context: The context of the caller
+        :param volume: The original volume that was migrated to this backend
+        :param new_volume: The migration volume object that was created on
+                           this backend as part of the migration process
+        :param original_volume_status: The status of the original volume
+        :returns: model_update to update DB with any needed changes
+        """
+        name_id = None
+        volume_path = self._get_volume_path(volume)
+        new_volume_path = self._get_volume_path(new_volume)
+        try:
+            self.terminate_connection(new_volume, None)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to terminate all connections '
+                      'to migrated volume %(volume)s before '
+                      'renaming: %(error)s',
+                      {'volume': new_volume['name'],
+                       'error': error})
+        payload = 'zfs rename %(new_volume)s %(volume)s' % {
+            'new_volume': new_volume_path,
+            'volume': volume_path
+        }
+        try:
+            self.nms.appliance.execute(payload)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to rename volume %(new_volume)s '
+                      'to %(volume)s after migration: %(error)s',
+                      {'new_volume': new_volume['name'],
+                       'volume': volume['name'],
+                       'error': error})
+            name_id = new_volume._name_id or new_volume.id
+        model_update = {'_name_id': name_id}
         return model_update
-
-    def ensure_export(self, _ctx, volume):
-        self._do_export(_ctx, volume)
-
-    @coordination.synchronized('{self.lock}')
-    def _do_export(self, _ctx, volume):
-        """Recreate parts of export if necessary.
-
-        :param volume: reference of volume to be exported
-        """
-        zvol_name = self._get_zvol_name(volume['name'])
-        target_name = self._get_target_name(volume)
-        target_group_name = self._get_target_group_name(target_name)
-
-        entry = None
-        if not self._lu_exists(zvol_name):
-            try:
-                entry = self.nms.scsidisk.create_lu(zvol_name, {})
-            except exception.NexentaException as exc:
-                if 'in use' not in exc.args[0]:
-                    raise
-                LOG.info('Ignored LU creation error %s while ensuring '
-                         'export.', exc)
-        if not self._is_lu_shared(zvol_name):
-            try:
-                entry = self.nms.scsidisk.add_lun_mapping_entry(zvol_name, {
-                    'target_group': target_group_name})
-            except exception.NexentaException as exc:
-                if 'view entry exists' not in exc.args[0]:
-                    raise
-                LOG.info('Ignored LUN mapping entry addition error %s '
-                         'while ensuring export.', exc)
-        model_update = {}
-        if entry:
-            provider_location = '%(host)s:%(port)s,1 %(name)s %(lun)s' % {
-                'host': self.nms_host,
-                'port': self.configuration.nexenta_iscsi_target_portal_port,
-                'name': target_name,
-                'lun': entry['lun'],
-            }
-            model_update = {'provider_location': provider_location}
-        return model_update
-
-    @coordination.synchronized('{self.lock}')
-    def remove_export(self, _ctx, volume):
-        """Destroy all resources created to export zvol.
-
-        :param volume: reference of volume to be unexported
-        """
-        target_name = self._get_target_name(volume)
-        self.targets[target_name].remove(volume['name'])
-        zvol_name = self._get_zvol_name(volume['name'])
-        self.nms.scsidisk.delete_lu(zvol_name)
 
     def get_volume_stats(self, refresh=False):
         """Get volume stats.
 
         If 'refresh' is True, run update the stats first.
         """
-        if refresh:
+        if refresh or not self._stats:
             self._update_volume_stats()
 
         return self._stats
 
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor appliance."""
-        LOG.debug('Updating volume stats')
-
-        stats = self.nms.volume.get_child_props(
-            self.configuration.nexenta_volume, 'health|size|used|available')
-
-        total_amount = utils.str2gib_size(stats['size'])
-        free_amount = utils.str2gib_size(stats['available'])
-
-        location_info = '%(driver)s:%(host)s:%(volume)s' % {
-            'driver': self.__class__.__name__,
-            'host': self.nms_host,
-            'volume': self.volume
+        stats = {'available': None, 'used': None}
+        payload = '|'.join(stats.keys())
+        props = self.nms.folder.get_child_props(self.root_path, payload)
+        for key in stats:
+            if not props.get(key):
+                LOG.error('Unable to get %(key)s statistics for %(path)s '
+                          'from properties %(props)s',
+                          {'path': self.root_path, 'props': props})
+                continue
+            text = '%sB' % props[key]
+            try:
+                value = strutils.string_to_bytes(text, return_int=True)
+                stats[key] = value
+            except ValueError as error:
+                LOG.error('Failed to convert text value %(text)s to '
+                          'bytes for the %(key)s property: %(error)s',
+                          {'text': text, 'key': key, 'error': error})
+        if None in stats.values():
+            allocated_capacity_gb = 'unknown'
+            free_capacity_gb = 'unknown'
+            total_capacity_gb = 'unknown'
+        else:
+            free_capacity_gb = stats['available'] // units.Gi
+            allocated_capacity_gb = stats['used'] // units.Gi
+            total_capacity_gb = free_capacity_gb + allocated_capacity_gb
+        provisioned_capacity_gb = total_volumes = 0
+        ctxt = context.get_admin_context()
+        volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        for volume in volumes:
+            provisioned_capacity_gb += volume['size']
+            total_volumes += 1
+        volume_backend_name = (
+            self.configuration.safe_get('volume_backend_name'))
+        if not volume_backend_name:
+            LOG.error('Failed to get configured volume backend name')
+            volume_backend_name = '%(product)s_%(protocol)s' % {
+                'product': self.product_name,
+                'protocol': self.storage_protocol
+            }
+        description = (
+            self.configuration.safe_get('nexenta_dataset_description'))
+        if not description:
+            description = '%(product)s %(host)s:%(pool)s/%(group)s' % {
+                'product': self.product_name,
+                'host': self.configuration.nexenta_host,
+                'pool': self.configuration.nexenta_volume,
+                'group': self.configuration.nexenta_folder
+            }
+        max_over_subscription_ratio = (
+            self.configuration.safe_get('max_over_subscription_ratio'))
+        reserved_percentage = (
+            self.configuration.safe_get('reserved_percentage'))
+        if reserved_percentage is None:
+            reserved_percentage = 0
+        location_info = '%(driver)s:%(host)s:%(path)s' % {
+            'driver': self.driver_name,
+            'host': self.configuration.nexenta_host,
+            'path': self.root_path
         }
+        display_name = 'Capabilities of %(product)s %(protocol)s driver' % {
+            'product': self.product_name,
+            'protocol': self.storage_protocol
+        }
+        visibility = 'public'
         self._stats = {
-            'vendor_name': 'Nexenta',
-            'dedup': self.volume_deduplication,
-            'compression': self.volume_compression,
-            'description': self.volume_description,
             'driver_version': self.VERSION,
-            'storage_protocol': 'iSCSI',
-            'total_capacity_gb': total_amount,
-            'free_capacity_gb': free_amount,
-            'reserved_percentage': self.configuration.reserved_percentage,
-            'QoS_support': False,
-            'volume_backend_name': self.backend_name,
+            'vendor_name': self.vendor_name,
+            'storage_protocol': self.storage_protocol,
+            'volume_backend_name': volume_backend_name,
             'location_info': location_info,
-            'iscsi_target_portal_port': self.iscsi_target_portal_port,
+            'description': description,
+            'display_name': display_name,
+            'pool_name': self.configuration.nexenta_volume,
+            'multiattach': True,
+            'QoS_support': False,
+            'consistencygroup_support': False,
+            'consistent_group_snapshot_enabled': False,
+            'online_extend_support': True,
+            'sparse_copy_volume': True,
+            'thin_provisioning_support': True,
+            'thick_provisioning_support': True,
+            'total_capacity_gb': total_capacity_gb,
+            'allocated_capacity_gb': allocated_capacity_gb,
+            'free_capacity_gb': free_capacity_gb,
+            'provisioned_capacity_gb': provisioned_capacity_gb,
+            'total_volumes': total_volumes,
+            'max_over_subscription_ratio': max_over_subscription_ratio,
+            'reserved_percentage': reserved_percentage,
+            'visibility': visibility,
+            'dedup': self.configuration.nexenta_dataset_dedup,
+            'compression': self.configuration.nexenta_dataset_compression,
+            'iscsi_target_portal_port': self.portal_port,
             'nms_url': self.nms.url
         }
+        LOG.debug('Updated volume backend statistics for host %(host)s '
+                  'and volume backend %(volume_backend_name)s: %(stats)s',
+                  {'host': self.host,
+                   'volume_backend_name': volume_backend_name,
+                   'stats': self._stats})

--- a/cinder/volume/drivers/nexenta/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/jsonrpc.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -13,90 +13,348 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from oslo_log import log as logging
-from oslo_serialization import jsonutils
-import requests
-from requests.packages.urllib3 import exceptions
+import hashlib
+import json
 
+from oslo_log import log as logging
+import requests
+import six
+from six.moves import html_parser
+
+from cinder import coordination
 from cinder import exception
-from cinder.utils import retry
+from cinder.i18n import _
 
 LOG = logging.getLogger(__name__)
-TIMEOUT = 60
-NMS_PLUGINS = {
-    'rrdaemon_plugin': 'nms-rrdaemon',
-    'rsf_plugin': 'nms-rsf-cluster'
-}
-
-requests.packages.urllib3.disable_warnings(exceptions.InsecureRequestWarning)
-requests.packages.urllib3.disable_warnings(
-    exceptions.InsecurePlatformWarning)
 
 
-class NexentaJSONProxy(object):
+class NmsException(exception.VolumeDriverException):
 
-    retry_exc_tuple = (requests.exceptions.ConnectionError,)
+    def __init__(self, data=None, **kwargs):
+        defaults = {
+            'name': 'Nexenta Error',
+            'code': 'EPROTO',
+            'source': 'Nexenta Cinder Driver',
+            'message': 'Unknown Error'
+        }
+        if isinstance(data, dict):
+            for key in defaults:
+                if key in kwargs:
+                    continue
+                if key in data:
+                    kwargs[key] = data[key]
+                else:
+                    kwargs[key] = defaults[key]
+        elif isinstance(data, six.string_types):
+            if 'message' not in kwargs:
+                kwargs['message'] = data
+        for key in defaults:
+            if key not in kwargs:
+                kwargs[key] = defaults[key]
+        message = (_('%(message)s (source: %(source)s, '
+                     'name: %(name)s, code: %(code)s)')
+                   % kwargs)
+        del kwargs['message']
+        self.code = kwargs['code']
+        super(NmsException, self).__init__(message, **kwargs)
 
-    def __init__(self, scheme, host, port, path, user, password, verify,
-                 auto=False, obj=None, method=None, session=None):
-        if session:
-            self.session = session
-        else:
-            self.session = requests.Session()
-            self.session.auth = (user, password)
-            self.session.headers.update({'Content-Type': 'application/json'})
-        self.scheme = scheme.lower()
-        self.host = host
-        self.port = port
-        self.verify = verify
-        self.path = path
-        self.user = user
-        self.password = password
-        self.auto = auto
-        self.obj = obj
+
+class NmsParser(html_parser.HTMLParser, object):
+
+    def __init__(self):
+        super(NmsParser, self).__init__()
+        self.data = []
+
+    def handle_data(self, data):
+        data = data.strip()
+        data = data.replace('\n', ' ')
+        if data:
+            self.data.append(data)
+
+
+class NmsRequest(object):
+
+    def __init__(self, nms, method):
+        self.nms = nms
         self.method = method
 
-    def __getattr__(self, name):
-        if not self.obj:
-            obj, method = name, None
-        elif not self.method:
-            obj, method = self.obj, name
+    @coordination.synchronized('{self.nms.proxy.lock}')
+    def __call__(self, *args):
+        timeout = self.nms.proxy.timeout
+        url = self.nms.proxy.url
+        payload = {
+            self.nms.kind: self.nms.name,
+            'method': self.method,
+            'params': args
+        }
+        LOG.debug('NMS request start: post %(url)s %(payload)s',
+                  {'url': url, 'payload': payload})
+        data = json.dumps(payload)
+        try:
+            response = self.nms.proxy.session.post(url, data=data,
+                                                   timeout=timeout)
+        except requests.exceptions.ConnectionError as error:
+            if not self.nms.proxy.auto:
+                raise
+            if self.nms.proxy.scheme == 'http':
+                self.nms.proxy.scheme == 'https'
+            else:
+                self.nms.proxy.scheme == 'http'
+            url = self.nms.proxy.url
+            LOG.error('Try to failover to %(scheme)s scheme: %(url)s',
+                      {'scheme': self.nms.proxy.scheme, 'url': url})
+            response = self.nms.proxy.session.post(url, data=data,
+                                                   timeout=timeout)
+        LOG.debug('NMS request done: post %(url)s %(payload)s, '
+                  'response status: %(status)s, response reason: '
+                  '%(reason)s, response time: %(time)s seconds, '
+                  'response content: %(content)s',
+                  {'url': url, 'payload': payload,
+                   'status': response.status_code,
+                   'reason': response.reason,
+                   'time': response.elapsed.total_seconds(),
+                   'content': response.content})
+
+        if not response.content:
+            message = 'No content %(status)s %(reason)s' % {
+                'status': response.status_code,
+                'reason': response.reason
+            }
+            raise NmsException(code='EPROTO', source=url, message=message)
+
+        try:
+            content = json.loads(response.content)
+        except (TypeError, ValueError) as error:
+            LOG.debug('Failed to parse JSON %(content)s: %(error)s',
+                      {'content': response.content, 'error': error})
+            try:
+                parser = NmsParser()
+                parser.feed(response.content)
+                message = ', '.join(parser.data)
+            except html_parser.HTMLParseError as error:
+                LOG.debug('Failed to parse HTML %(content)s: %(error)s',
+                          {'content': response.content, 'error': error})
+                message = response.content
+            raise NmsException(code='EBADMSG', source=url, message=message)
+
+        if not (response.ok and isinstance(content, dict)):
+            message = '%(status)s %(reason)s %(content)s' % {
+                'status': response.status_code,
+                'reason': response.reason,
+                'content': content
+            }
+            raise NmsException(code='EPROTO', source=url, message=message)
+
+        if 'error' in content and content['error'] is not None:
+            error = content['error']
+            if isinstance(error, dict) and 'message' in error:
+                message = error['message']
+            else:
+                message = error
+            self.check_error(url, message)
+
+        if 'result' in content and content['result'] is not None:
+            result = content['result']
         else:
-            obj, method = '%s.%s' % (self.obj, self.method), name
-        return NexentaJSONProxy(self.scheme, self.host, self.port, self.path,
-                                self.user, self.password, self.verify,
-                                self.auto, obj, method, self.session)
+            result = None
+
+        LOG.debug('NMS request result for %(payload)s: %(result)s',
+                  {'payload': payload, 'result': result})
+        return result
+
+    def check_error(self, url, message):
+        if 'already exists' in message:
+            code = 'EEXIST'
+        elif 'already configured' in message:
+            code = 'EEXIST'
+        elif 'has children' in message:
+            code = 'EEXIST'
+        elif 'in use' in message:
+            code = 'EBUSY'
+        elif 'does not exist' in message:
+            code = 'ENOENT'
+        else:
+            code = 'EPROTO'
+        ignored = {
+            'EEXIST': [
+                'add_hostgroup_member',
+                'add_lun_mapping_entry',
+                'add_targetgroup_member',
+                'clone',
+                'create',
+                'create_hostgroup',
+                'create_lu',
+                'create_snapshot',
+                'create_target',
+                'create_targetgroup',
+                'create_with_props'
+            ],
+            'ENOENT': [
+                'delete_lu',
+                'destroy',
+                'remove_lun_mapping_entry'
+            ]
+        }
+        if code in ignored and self.method in ignored[code]:
+            LOG.debug('Ignore %(kind)s %(name)s %(method)s error: %(error)s',
+                      {'kind': self.nms.kind, 'name': self.nms.name,
+                       'method': self.method, 'error': message})
+            return
+        raise NmsException(code=code, source=url, message=message)
+
+
+class NmsObject(object):
+
+    def __init__(self, proxy, name):
+        self.kind = 'object'
+        self.proxy = proxy
+        self.name = name
+        plugins = {
+            'autosync_plugin': 'nms-autosync',
+            'rrdaemon_plugin': 'nms-rrdaemon',
+            'rsf_plugin': 'nms-rsf-cluster'
+        }
+        if name in plugins:
+            self.kind = 'plugin'
+            self.name = plugins[name]
+
+    def __getattr__(self, method):
+        return NmsRequest(self, method)
+
+
+class NmsProxy(object):
+
+    def __init__(self, proto, path, conf):
+        self.path = path
+        self.lock = 'nms'
+        self.auto = False
+        self.scheme = conf.nexenta_rest_protocol
+        if self.scheme == 'auto':
+            self.auto = True
+            self.scheme = 'http'
+        if conf.nexenta_rest_address:
+            self.host = conf.nexenta_rest_address
+        elif conf.nexenta_host:
+            self.host = conf.nexenta_host
+        elif proto == 'nfs' and conf.nas_host:
+            self.host = conf.nas_host
+        else:
+            message = (_('NexentaStor Rest API address is not defined, '
+                         'please check the Cinder configuration file for '
+                         'NexentaStor backend and nexenta_rest_address, '
+                         'nexenta_host or nas_host configuration options'))
+            raise NmsException(code='EINVAL', message=message)
+        if conf.nexenta_rest_port:
+            self.port = conf.nexenta_rest_port
+        else:
+            self.port = 8457
+        self.headers = {
+            'Content-Type': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+        self.timeout = (conf.nexenta_rest_connect_timeout,
+                        conf.nexenta_rest_read_timeout)
+        max_retries = requests.packages.urllib3.util.retry.Retry(
+            total=conf.nexenta_rest_retry_count,
+            backoff_factor=conf.nexenta_rest_backoff_factor)
+        adapter = requests.adapters.HTTPAdapter(max_retries=max_retries)
+        self.session = requests.Session()
+        self.session.auth = (conf.nexenta_user, conf.nexenta_password)
+        self.session.verify = conf.driver_ssl_cert_verify
+        self.session.headers.update(self.headers)
+        self.session.mount('http://', adapter)
+        self.session.mount('https://', adapter)
+        if not conf.driver_ssl_cert_verify:
+            requests.packages.urllib3.disable_warnings()
+        self.update_lock()
+
+    def __getattr__(self, name):
+        return NmsObject(self, name)
+
+    def update_lock(self):
+        signature = None
+        license_info = {}
+        try:
+            license_info = self.appliance.get_license_info()
+        except NmsException as error:
+            LOG.error('Unable to get license information: %(error)s',
+                      {'error': error})
+        key = 'machine_sig'
+        if isinstance(license_info, dict) and key in license_info:
+            signature = license_info[key]
+            LOG.debug('Host signature: %(signature)s',
+                      {'signature': signature})
+        plugins = {}
+        try:
+            plugins = self.plugin.get_names('')
+        except NmsException as error:
+            LOG.error('Unable to get installed plugins: %(error)s',
+                      {'error': error})
+        plugin = 'nms-rsf-cluster'
+        if isinstance(plugins, list) and plugin in plugins:
+            names = []
+            try:
+                names = self.rsf_plugin.get_names('')
+            except NmsException as error:
+                LOG.error('Unable to get HA cluster name: %(error)s',
+                          {'error': error})
+            if isinstance(names, list) and len(names) == 1:
+                name = names.pop()
+                conf = {}
+                try:
+                    conf = self.rsf_plugin.get_child_props(name, '')
+                except NmsException as error:
+                    LOG.error('Unable to get HA cluster %(name)s '
+                              'configuration: %(error)s',
+                              {'name': name, 'error': error})
+                key = 'machinesigs'
+                if isinstance(conf, dict) and key in conf:
+                    data = conf[key]
+                    nodes = {}
+                    try:
+                        nodes = json.loads(data)
+                    except (TypeError, ValueError) as error:
+                        LOG.error('Unable to parse HA cluster %(name)s '
+                                  'configuration %(data)s: %(error)s',
+                                  {'name': name, 'data': data,
+                                   'error': error})
+                    if nodes and isinstance(nodes, dict):
+                        signatures = nodes.values()
+                        if signature and signature in signatures:
+                            signature = ':'.join(sorted(signatures))
+                            LOG.debug('HA cluster %(name)s hosts '
+                                      'signatures: %(signatures)s',
+                                      {'name': name,
+                                       'signatures': signatures})
+                        else:
+                            LOG.debug('HA cluster %(name)s configuration '
+                                      '%(conf)s does not contain signature '
+                                      'for configured host %(host)s',
+                                      {'name': name, 'conf': conf,
+                                       'host': self.host})
+                    else:
+                        LOG.debug('HA cluster %(name)s configuration %(conf)s '
+                                  'does not contain valid hosts signatures',
+                                  {'name': name, 'conf': conf})
+                else:
+                    LOG.debug('Hosts signatures unavailable for HA cluster '
+                              '%(name)s and cluster configuration %(conf)s',
+                              {'name': name, 'conf': conf})
+            else:
+                LOG.debug('HA cluster plugin %(plugin)s is not configured',
+                          {'plugin': plugin})
+        else:
+            LOG.debug('HA cluster plugin %(plugin)s is not installed',
+                      {'plugin': plugin})
+        if not signature:
+            signature = self.host
+        lock = '%s:%s' % (signature, self.path)
+        if six.PY3:
+            lock = lock.encode('utf-8')
+        self.lock = hashlib.md5(lock).hexdigest()
+        LOG.debug('NMS coordination lock: %(lock)s',
+                  {'lock': self.lock})
 
     @property
     def url(self):
-        return '%s://%s:%s%s' % (self.scheme, self.host, self.port, self.path)
-
-    def __hash__(self):
-        return self.url.__hash__()
-
-    def __repr__(self):
-        return 'NMS proxy: %s' % self.url
-
-    @retry(retry_exc_tuple, retries=6)
-    def __call__(self, *args):
-        if self.obj in NMS_PLUGINS:
-            kind, name = 'plugin', NMS_PLUGINS[self.obj]
-        else:
-            kind, name = 'object', self.obj
-
-        data = jsonutils.dumps({
-            kind: name,
-            'method': self.method,
-            'params': args
-        })
-
-        LOG.debug('Sending JSON data: %s', data)
-        r = self.session.post(self.url, data=data, timeout=TIMEOUT,
-                              verify=self.verify)
-        response = r.json()
-
-        LOG.debug('Got response: %s', response)
-        if response.get('error') is not None:
-            message = response['error'].get('message', '')
-            raise exception.NexentaException(message)
-        return response.get('result')
+        return '%s://%s:%s/rest/nms' % (self.scheme, self.host, self.port)

--- a/cinder/volume/drivers/nexenta/nfs.py
+++ b/cinder/volume/drivers/nexenta/nfs.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -13,32 +13,34 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import datetime
+import difflib
 import hashlib
+import ipaddress
 import os
-import re
-import six
+import posixpath
 
 from eventlet import greenthread
 from oslo_log import log as logging
+from oslo_utils import strutils
+from oslo_utils import timeutils
 from oslo_utils import units
+import six
 
 from cinder import context
-from cinder import db
-from cinder import exception
 from cinder.i18n import _
 from cinder import interface
+from cinder import objects
+from cinder.privsep import fs
 from cinder.volume.drivers.nexenta import jsonrpc
 from cinder.volume.drivers.nexenta import options
-from cinder.volume.drivers.nexenta import utils
 from cinder.volume.drivers import nfs
 
-VERSION = '1.3.2'
 LOG = logging.getLogger(__name__)
-BLOCK_SIZE_MB = 1
 
 
 @interface.volumedriver
-class NexentaNfsDriver(nfs.NfsDriver):  # pylint: disable=R0921
+class NexentaNfsDriver(nfs.NfsDriver):
     """Executes volume driver commands on Nexenta Appliance.
 
     Version history:
@@ -57,427 +59,158 @@ class NexentaNfsDriver(nfs.NfsDriver):  # pylint: disable=R0921
         1.3.1 - Cache capacity info and check shared folders on setup.
         1.3.2 - Pass mount_point_base in init_conn to support host-based
                 migration.
+        1.4.0 - Refactored NFS driver.
+              - Improved storage assisted volume migration.
+              - Added revert to snapshot support.
+              - Added volume multi-attach.
+              - Fixed automatic mode for nexenta_rest_protocol.
+              - Added deferred deletion for snapshots.
+              - Added synchronization for NMS REST API calls.
+              - Added configuration parameters for REST API connect/read
+                timeouts, connection retries and backoff factor.
+              - Disabled non-blocking mandatory locks.
+              - Added informative exception messages for REST API.
+              - Improved collection of backend statistics.
     """
 
-    driver_prefix = 'nexenta'
-    volume_backend_name = 'NexentaNfsDriver'
-    VERSION = VERSION
-    VOLUME_FILE_NAME = 'volume'
+    VERSION = '1.4.0'
+    CI_WIKI_NAME = 'Nexenta_CI'
 
-    # ThirdPartySystems wiki page
-    CI_WIKI_NAME = "Nexenta_CI"
+    vendor_name = 'Nexenta'
+    product_name = 'NexentaStor4'
+    storage_protocol = 'NFS'
+    driver_volume_type = 'nfs'
 
     def __init__(self, *args, **kwargs):
         super(NexentaNfsDriver, self).__init__(*args, **kwargs)
-        if self.configuration:
-            self.configuration.append_config_values(
-                options.NEXENTA_CONNECTION_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_NFS_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_DATASET_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_RRMGR_OPTS)
-
-        self.verify_ssl = self.configuration.driver_ssl_cert_verify
-        self.nms_cache_volroot = self.configuration.nexenta_nms_cache_volroot
-        self.rrmgr_compression = self.configuration.nexenta_rrmgr_compression
-        self.rrmgr_tcp_buf_size = self.configuration.nexenta_rrmgr_tcp_buf_size
-        self.rrmgr_connections = self.configuration.nexenta_rrmgr_connections
-        self.nfs_mount_point_base = self.configuration.nexenta_mount_point_base
+        if not self.configuration:
+            message = (_('%(product_name)s %(storage_protocol)s '
+                         'backend configuration not found')
+                       % {'product_name': self.product_name,
+                          'storage_protocol': self.storage_protocol})
+            raise jsonrpc.NmsException(code='ENODATA', message=message)
+        self.configuration.append_config_values(
+            options.NEXENTA_CONNECTION_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_NFS_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_DATASET_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_RRMGR_OPTS)
+        self.nms = None
+        self.driver_name = self.__class__.__name__
+        self.nas_host = self.configuration.nas_host
+        self.root_path = self.configuration.nas_share_path
+        self.mount_point_base = self.configuration.nexenta_mount_point_base
         self.volume_compression = (
             self.configuration.nexenta_dataset_compression)
-        self.volume_deduplication = self.configuration.nexenta_dataset_dedup
-        self.volume_description = (
-            self.configuration.nexenta_dataset_description)
         self.sparsed_volumes = self.configuration.nexenta_sparsed_volumes
-        self._nms2volroot = {}
-        self.share2nms = {}
-        self.nfs_versions = {}
-        self.shares_with_capacities = {}
+        self.origin_snapshot_template = (
+            self.configuration.nexenta_origin_snapshot_template)
+        self.migration_snapshot_prefix = (
+            self.configuration.nexenta_migration_snapshot_prefix)
+        self.migration_service_prefix = (
+            self.configuration.nexenta_migration_service_prefix)
+        self.migration_throttle = (
+            self.configuration.nexenta_migration_throttle)
 
-    @property
-    def backend_name(self):
-        backend_name = None
-        if self.configuration:
-            backend_name = self.configuration.safe_get('volume_backend_name')
-        if not backend_name:
-            backend_name = self.__class__.__name__
-        return backend_name
+    @staticmethod
+    def get_driver_options():
+        return (
+            options.NEXENTA_CONNECTION_OPTS +
+            options.NEXENTA_NFS_OPTS +
+            options.NEXENTA_DATASET_OPTS +
+            options.NEXENTA_RRMGR_OPTS
+        )
 
     def do_setup(self, context):
-        shares_config = getattr(self.configuration, self.driver_prefix +
-                                '_shares_config')
-        if shares_config:
-            self.configuration.nfs_shares_config = shares_config
-        super(NexentaNfsDriver, self).do_setup(context)
-        self._load_shares_config(shares_config)
-        self._mount_subfolders()
+        self.nms = jsonrpc.NmsProxy(self.driver_volume_type,
+                                    self.root_path,
+                                    self.configuration)
 
     def check_for_setup_error(self):
-        """Verify that the volume for our folder exists.
+        """Check root filesystem, NFS service and NFS share."""
+        if not self.nms.folder.object_exists(self.root_path):
+            message = (_('NFS root filesystem %(path)s not found')
+                       % {'path': self.root_path})
+            raise jsonrpc.NmsException(code='ENOENT', message=message)
+        filesystem = self.nms.folder.get_child_props(self.root_path, '')
+        if filesystem['mountpoint'] == 'none':
+            message = (_('NFS root filesystem %(path)s is not writable')
+                       % {'path': self.root_path})
+            raise jsonrpc.NefException(code='ENOENT', message=message)
+        if filesystem['mounted'] == 'no':
+            message = (_('NFS root filesystem %(path)s is not mounted')
+                       % {'path': self.root_path})
+            raise jsonrpc.NefException(code='ENOTDIR', message=message)
+        if filesystem['nbmand'] == 'on':
+            self.nms.folder.set_child_prop(self.root_path, 'nbmand', 'off')
+        fmri = 'svc:/network/nfs/server:default'
+        state = self.nms.netsvc.get_state(fmri)
+        if state != 'online':
+            message = (_('NFS service is not online: %(state)s')
+                       % {'state': state})
+            raise jsonrpc.NmsException(code='ESRCH', message=message)
+        shared = self.nms.netstorsvc.is_folder_shared(fmri, self.root_path)
+        if not shared:
+            message = (_('NFS root filesystem %(path)s is not shared')
+                       % {'path': self.root_path})
+            raise jsonrpc.NmsException(code='ENOENT', message=message)
 
-        :raise: :py:exc:`LookupError`
-        """
-        if self.share2nms:
-            for nfs_share in self.share2nms:
-                nms = self.share2nms[nfs_share]
-                volume_name, dataset = self._get_share_datasets(nfs_share)
-                if not nms.volume.object_exists(volume_name):
-                    raise LookupError(_("Volume %s does not exist in Nexenta "
-                                        "Store appliance"), volume_name)
-                folder = '%s/%s' % (volume_name, dataset)
-                if not nms.folder.object_exists(folder):
-                    raise LookupError(_("Folder %s does not exist in Nexenta "
-                                        "Store appliance"), folder)
-                if (folder not in nms.netstorsvc.get_shared_folders(
-                        'svc:/network/nfs/server:default', '')):
-                    self._share_folder(nms, volume_name, dataset)
-                self._get_capacity_info(nfs_share)
-
-    def migrate_volume(self, ctxt, volume, host):
-        """Migrate if volume and host are managed by Nexenta appliance.
-
-        :param ctxt: context
-        :param volume: a dictionary describing the volume to migrate
-        :param host: a dictionary describing the host to migrate to
-        """
-        LOG.debug('Enter: migrate_volume: id=%(id)s, host=%(host)s',
-                  {'id': volume['id'], 'host': host})
-
-        false_ret = (False, None)
-
-        if volume['status'] not in ('available', 'retyping'):
-            LOG.warning("Volume status must be 'available' or 'retyping'."
-                        " Current volume status: %s", volume['status'])
-            return false_ret
-
-        if 'capabilities' not in host:
-            LOG.warning("Unsupported host. No capabilities found")
-            return false_ret
-
-        capabilities = host['capabilities']
-        ns_shares = capabilities['ns_shares']
-        dst_parts = capabilities['location_info'].split(':')
-        dst_host, dst_volume = dst_parts[1:]
-
-        if (capabilities.get('vendor_name') != 'Nexenta' or
-                dst_parts[0] != self.__class__.__name__ or
-                capabilities['free_capacity_gb'] < volume['size']):
-            return false_ret
-
-        nms = self.share2nms[volume['provider_location']]
-        ssh_bindings = nms.appliance.ssh_list_bindings()
-        shares = []
-        for bind in ssh_bindings:
-            for share in ns_shares:
-                if (share.startswith(bind.split('@')[1].split(':')[0]) and
-                        ns_shares[share] >= volume['size']):
-                    shares.append(share)
-        if len(shares) == 0:
-            LOG.warning("Remote NexentaStor appliance at %s should be "
-                        "SSH-bound.", share)
-            return false_ret
-        share = sorted(shares, key=ns_shares.get, reverse=True)[0]
-        snapshot = {
-            'volume_name': volume['name'],
-            'volume_id': volume['id'],
-            'name': utils.get_migrate_snapshot_name(volume)
-        }
-        self.create_snapshot(snapshot)
-        location = volume['provider_location']
-        src = '%(share)s/%(volume)s@%(snapshot)s' % {
-            'share': location.split(':')[1].split('volumes/')[1],
-            'volume': volume['name'],
-            'snapshot': snapshot['name']
-        }
-        dst = ':'.join([dst_host, dst_volume.split('/volumes/')[1]])
-        try:
-            nms.appliance.execute(self._get_zfs_send_recv_cmd(src, dst))
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot send source snapshot %(src)s to "
-                        "destination %(dst)s. Reason: %(exc)s",
-                        {'src': src, 'dst': dst, 'exc': exc})
-            return false_ret
-        finally:
-            try:
-                self.delete_snapshot(snapshot)
-            except exception.NexentaException as exc:
-                LOG.warning("Cannot delete temporary source snapshot "
-                            "%(src)s on NexentaStor Appliance: %(exc)s",
-                            {'src': src, 'exc': exc})
-        try:
-            self.delete_volume(volume)
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot delete source volume %(volume)s on "
-                        "NexentaStor Appliance: %(exc)s",
-                        {'volume': volume['name'], 'exc': exc})
-
-        dst_nms = self._get_nms_for_url(capabilities['nms_url'])
-        dst_snapshot = '%s/%s@%s' % (dst_volume.split('volumes/')[1],
-                                     volume['name'], snapshot['name'])
-        try:
-            dst_nms.snapshot.destroy(dst_snapshot, '')
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot delete temporary destination snapshot "
-                        "%(dst)s on NexentaStor Appliance: %(exc)s",
-                        {'dst': dst_snapshot, 'exc': exc})
-        return True, {'provider_location': share}
-
-    def _get_zfs_send_recv_cmd(self, src, dst):
-        """Returns rrmgr command for source and destination."""
-        return utils.get_rrmgr_cmd(src, dst,
-                                   compression=self.rrmgr_compression,
-                                   tcp_buf_size=self.rrmgr_tcp_buf_size,
-                                   connections=self.rrmgr_connections)
-
-    def initialize_connection(self, volume, connector):
-        """Allow connection to connector and return connection info.
+    def create_volume(self, volume):
+        """Creates a volume.
 
         :param volume: volume reference
-        :param connector: connector reference
+        :return: model update dict for volume reference
         """
-        export = '%s/%s' % (volume['provider_location'], volume['name'])
-        data = {'export': export, 'name': 'volume'}
-        if volume['provider_location'] in self.shares:
-            data['options'] = self.shares[volume['provider_location']]
-        return {
-            'driver_volume_type': self.driver_volume_type,
-            'data': data,
-            'mount_point_base': self.nfs_mount_point_base
+        volume_path = self._get_volume_path(volume)
+        volume_options = {
+            'compression': self.volume_compression
         }
-
-    def retype(self, context, volume, new_type, diff, host):
-        """Convert the volume to be of the new type.
-
-        :param ctxt: Context
-        :param volume: A dictionary describing the volume to migrate
-        :param new_type: A dictionary describing the volume type to convert to
-        :param diff: A dictionary with the difference between the two types
-        :param host: A dictionary describing the host to migrate to, where
-                     host['host'] is its name, and host['capabilities'] is a
-                     dictionary of its reported capabilities.
-        """
-        LOG.debug('Retype volume request %(vol)s to be %(type)s '
-                  '(host: %(host)s), diff %(diff)s.',
-                  {'vol': volume['name'],
-                   'type': new_type,
-                   'host': host,
-                   'diff': diff})
-
-        options = dict(
-            compression='compression',
-            dedup='dedup',
-            description='nms:description'
-        )
-
-        retyped = False
-        migrated = False
-        model_update = None
-
-        src_backend = self.__class__.__name__
-        dst_backend = host['capabilities']['location_info'].split(':')[0]
-        if src_backend != dst_backend:
-            LOG.warning('Cannot retype from %(src_backend)s to '
-                        '%(dst_backend)s.',
-                        {
-                            'src_backend': src_backend,
-                            'dst_backend': dst_backend
-                        })
-            return False
-
-        hosts = (volume['host'], host['host'])
-        old, new = hosts
-        if old != new:
-            migrated, provider_location = self.migrate_volume(
-                context, volume, host)
-
-        if not migrated:
-            provider_location = volume['provider_location']
-            nms = self.share2nms[provider_location]
-        else:
-            nms_url = host['capabilities']['nms_url']
-            nms = self._get_nms_for_url(nms_url)
-            model_update = provider_location
-            provider_location = provider_location['provider_location']
-
-        share = provider_location.split(':')[1].split('volumes/')[1]
-        folder = '%(share)s/%(volume)s' % {
-            'share': share,
-            'volume': volume['name']
-        }
-
-        for opt in options:
-            old, new = diff.get('extra_specs').get(opt, (False, False))
-            if old != new:
-                LOG.debug('Changing %(opt)s from %(old)s to %(new)s.',
-                          {'opt': opt, 'old': old, 'new': new})
-                try:
-                    nms.folder.set_child_prop(
-                        folder, options[opt], new)
-                    retyped = True
-                except exception.NexentaException:
-                    LOG.error('Error trying to change %(opt)s'
-                              ' from %(old)s to %(new)s',
-                              {'opt': opt, 'old': old, 'new': new})
-                    return False, None
-        return retyped or migrated, model_update
-
-    def _do_create_volume(self, volume):
-        nfs_share = volume['provider_location']
-        nms = self.share2nms[nfs_share]
-
-        vol, dataset = self._get_share_datasets(nfs_share)
-        folder = '%s/%s' % (dataset, volume['name'])
-        LOG.debug('Creating folder on Nexenta Store %s', folder)
-        nms.folder.create_with_props(
-            vol, folder,
-            {'compression': self.configuration.nexenta_dataset_compression}
-        )
-
-        volume_path = self.remote_path(volume)
-        volume_size = volume['size']
+        self.nms.folder.create_with_props(self.root_path,
+                                          volume['name'],
+                                          volume_options)
         try:
-            self._share_folder(nms, vol, folder)
-
-            if getattr(self.configuration,
-                       self.driver_prefix + '_sparsed_volumes'):
-                self._create_sparsed_file(nms, volume_path, volume_size)
+            self._set_volume_acl(volume)
+            self._mount_volume(volume)
+            volume_file = self.local_path(volume)
+            volume_size = volume['size']
+            if self.sparsed_volumes:
+                self._create_sparsed_file(volume_file, volume_size)
             else:
-                folder_path = '%s/%s' % (vol, folder)
-                compression = nms.folder.get_child_prop(
-                    folder_path, 'compression')
+                compression = self.nms.folder.get_child_prop(volume_path,
+                                                             'compression')
                 if compression != 'off':
-                    # Disable compression, because otherwise will not use space
-                    # on disk.
-                    nms.folder.set_child_prop(
-                        folder_path, 'compression', 'off')
-                try:
-                    self._create_regular_file(nms, volume_path, volume_size)
-                finally:
-                    if compression != 'off':
-                        # Backup default compression value if it was changed.
-                        nms.folder.set_child_prop(
-                            folder_path, 'compression', compression)
-
-            self._set_rw_permissions_for_all(nms, volume_path)
-
-            if self._get_nfs_server_version(nfs_share) < 4:
-                sub_share, mnt_path = self._get_subshare_mount_point(nfs_share,
-                                                                     volume)
-                self._ensure_share_mounted(sub_share, mnt_path)
-            self._get_capacity_info(nfs_share)
-        except exception.NexentaException as exc:
+                    self.nms.folder.set_child_prop(volume_file,
+                                                   'compression',
+                                                   'off')
+                self._create_regular_file(volume_file, volume_size)
+                if compression != 'off':
+                    self.nms.folder.set_child_prop(volume_path,
+                                                   'compression',
+                                                   compression)
+        except jsonrpc.NmsException as create_error:
             try:
-                nms.folder.destroy('%s/%s' % (vol, folder))
-            except exception.NexentaException:
-                LOG.warning("Cannot destroy created folder: "
-                            "%(vol)s/%(folder)s",
-                            {'vol': vol, 'folder': folder})
-            raise exc
+                self.nms.folder.destroy(volume_path, '-rf')
+            except jsonrpc.NmsException as delete_error:
+                LOG.debug('Failed to delete volume %(path)s: %(error)s',
+                          {'path': volume_path, 'error': delete_error})
+            raise create_error
+        finally:
+            self._unmount_volume(volume)
 
-    def create_volume_from_snapshot(self, volume, snapshot):
-        """Create new volume from other's snapshot on appliance.
+    def copy_image_to_volume(self, context, volume, image_service, image_id):
+        LOG.debug('Copy image %(image)s to volume %(volume)s',
+                  {'image': image_id, 'volume': volume['name']})
+        self._mount_volume(volume)
+        super(NexentaNfsDriver, self).copy_image_to_volume(
+            context, volume, image_service, image_id)
+        self._unmount_volume(volume)
 
-        :param volume: reference of volume to be created
-        :param snapshot: reference of source snapshot
-        """
-        self._ensure_shares_mounted()
-
-        snapshot_vol = self._get_snapshot_volume(snapshot)
-        nfs_share = snapshot_vol['provider_location']
-        volume['provider_location'] = nfs_share
-        nms = self.share2nms[nfs_share]
-
-        vol, dataset = self._get_share_datasets(nfs_share)
-        snapshot_name = '%s/%s/%s@%s' % (vol, dataset, snapshot['volume_name'],
-                                         snapshot['name'])
-        folder = '%s/%s' % (dataset, volume['name'])
-        nms.folder.clone(snapshot_name, '%s/%s' % (vol, folder))
-
-        try:
-            self._share_folder(nms, vol, folder)
-        except exception.NexentaException as exc:
-            try:
-                nms.folder.destroy('%s/%s' % (vol, folder), '')
-            except exception.NexentaException:
-                LOG.warning("Cannot destroy cloned folder: "
-                            "%(vol)s/%(folder)s",
-                            {'vol': vol, 'folder': folder})
-            raise exc
-
-        if self._get_nfs_server_version(nfs_share) < 4:
-            sub_share, mnt_path = self._get_subshare_mount_point(nfs_share,
-                                                                 volume)
-            self._ensure_share_mounted(sub_share, mnt_path)
-
-        if (('size' in volume) and (
-                volume['size'] > snapshot['volume_size'])):
-            self.extend_volume(volume, volume['size'])
-
-        return {'provider_location': volume['provider_location']}
-
-    def create_cloned_volume(self, volume, src_vref):
-        """Creates a clone of the specified volume.
-
-        :param volume: new volume reference
-        :param src_vref: source volume reference
-        """
-        LOG.info('Creating clone of volume: %s', src_vref['id'])
-        snapshot = {'volume_name': src_vref['name'],
-                    'volume_id': src_vref['id'],
-                    'volume_size': src_vref['size'],
-                    'name': self._get_clone_snapshot_name(volume)}
-        # We don't delete this snapshot, because this snapshot will be origin
-        # of new volume. This snapshot will be automatically promoted by NMS
-        # when user will delete its origin.
-        self.create_snapshot(snapshot)
-        try:
-            return self.create_volume_from_snapshot(volume, snapshot)
-        except exception.NexentaException as exc:
-            LOG.error('Volume creation failed, deleting created snapshot '
-                      '%(volume_name)s@%(name)s', snapshot)
-            try:
-                self.delete_snapshot(snapshot)
-            except (exception.NexentaException, exception.SnapshotIsBusy):
-                LOG.warning('Failed to delete zfs snapshot '
-                            '%(volume_name)s@%(name)s', snapshot)
-            raise exc
-
-    def delete_volume(self, volume):
-        """Deletes a logical volume.
-
-        :param volume: volume reference
-        """
-        nfs_share = volume.get('provider_location')
-        if nfs_share:
-            nms = self.share2nms[nfs_share]
-            vol, parent_folder = self._get_share_datasets(nfs_share)
-            folder = '%s/%s/%s' % (vol, parent_folder, volume['name'])
-            mount_path = self.remote_path(volume).strip(
-                '/%s' % self.VOLUME_FILE_NAME)
-            if mount_path in self._remotefsclient._read_mounts():
-                self._execute('umount', mount_path, run_as_root=True)
-            try:
-                props = nms.folder.get_child_props(folder, 'origin') or {}
-                nms.folder.destroy(folder, '-r')
-            except exception.NexentaException as exc:
-                if 'does not exist' in exc.args[0]:
-                    LOG.info('Folder %s does not exist, it was '
-                             'already deleted.', folder)
-                    return
-                raise
-            self._get_capacity_info(nfs_share)
-            origin = props.get('origin')
-            if origin and self._is_clone_snapshot_name(origin):
-                try:
-                    nms.snapshot.destroy(origin, '')
-                except exception.NexentaException as exc:
-                    if 'does not exist' in exc.args[0]:
-                        LOG.info('Snapshot %s does not exist, it was '
-                                 'already deleted.', origin)
-                        return
-                    raise
+    def copy_volume_to_image(self, context, volume, image_service, image_meta):
+        LOG.debug('Copy volume %(volume)s to image %(image)s',
+                  {'volume': volume['name'], 'image': image_meta['id']})
+        self._mount_volume(volume)
+        super(NexentaNfsDriver, self).copy_volume_to_image(
+            context, volume, image_service, image_meta)
+        self._unmount_volume(volume)
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -485,352 +218,897 @@ class NexentaNfsDriver(nfs.NfsDriver):  # pylint: disable=R0921
         :param volume: volume reference
         :param new_size: volume new size in GB
         """
-        LOG.info('Extending volume: %(id)s New size: %(size)s GB',
-                 {'id': volume['id'], 'size': new_size})
-        nfs_share = volume['provider_location']
-        nms = self.share2nms[nfs_share]
-        volume_path = self.remote_path(volume)
-        if getattr(self.configuration,
-                   self.driver_prefix + '_sparsed_volumes'):
-            self._create_sparsed_file(nms, volume_path, new_size)
+        LOG.debug('Extend volume %(volume)s, new size: %(size)sGB',
+                  {'volume': volume['name'], 'size': new_size})
+        self._mount_volume(volume)
+        volume_file = self.local_path(volume)
+        if self.sparsed_volumes:
+            self._execute('truncate', '-s',
+                          '%dG' % new_size,
+                          volume_file,
+                          run_as_root=True)
         else:
-            block_count = ((new_size - volume['size']) * units.Gi /
-                           (BLOCK_SIZE_MB * units.Mi))
+            seek = volume['size'] * units.Ki
+            count = (new_size - volume['size']) * units.Ki
+            self._execute('dd',
+                          'if=/dev/zero',
+                          'of=%s' % volume_file,
+                          'bs=%d' % units.Mi,
+                          'seek=%d' % seek,
+                          'count=%d' % count,
+                          run_as_root=True)
+        self._unmount_volume(volume)
 
-            nms.appliance.execute(
-                'dd if=/dev/zero seek=%(seek)d of=%(path)s'
-                ' bs=%(bs)dM count=%(count)d' % {
-                    'seek': volume['size'] * units.Gi / (
-                        BLOCK_SIZE_MB * units.Mi),
-                    'path': volume_path,
-                    'bs': BLOCK_SIZE_MB,
-                    'count': block_count
-                }
-            )
+    def delete_volume(self, volume):
+        """Deletes a logical volume.
+
+        :param volume: volume reference
+        """
+        volume_path = self._get_volume_path(volume)
+        try:
+            origin = self.nms.folder.get_child_prop(volume_path, 'origin')
+        except jsonrpc.NmsException as error:
+            if error.code == 'ENOENT':
+                return
+            raise
+        self.nms.folder.destroy(volume_path, '-rf')
+        if not origin:
+            return
+        template = self.origin_snapshot_template
+        parent_path, snapshot_name = origin.split('@')
+        if not self._match_template(template, snapshot_name):
+            return
+        try:
+            self.nms.snapshot.destroy(origin, '-d')
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to delete origin snapshot %(origin)s '
+                      'of volume %(volume)s: %(error)s',
+                      {'origin': origin,
+                       'volume': volume['name'],
+                       'error': error})
+
+    def create_volume_from_snapshot(self, volume, snapshot):
+        """Create new volume from other's snapshot on appliance.
+
+        :param volume: reference of volume to be created
+        :param snapshot: reference of source snapshot
+        """
+        LOG.debug('Create volume %(volume)s from snapshot %(snapshot)s',
+                  {'volume': volume['name'], 'snapshot': snapshot['name']})
+        snapshot_path = self._get_snapshot_path(snapshot)
+        clone_path = self._get_volume_path(volume)
+        self.nms.folder.clone(snapshot_path, clone_path)
+        if volume['size'] > snapshot['volume_size']:
+            new_size = volume['size']
+            volume['size'] = snapshot['volume_size']
+            self.extend_volume(volume, new_size)
+            volume['size'] = new_size
+
+    def create_cloned_volume(self, volume, src_vref):
+        """Creates a clone of the specified volume.
+
+        :param volume: new volume reference
+        :param src_vref: source volume reference
+        """
+        snapshot = {
+            'name': self.origin_snapshot_template % volume['id'],
+            'volume_id': src_vref['id'],
+            'volume_name': src_vref['name'],
+            'volume_size': src_vref['size']
+        }
+        self.create_snapshot(snapshot)
+        try:
+            self.create_volume_from_snapshot(volume, snapshot)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to create clone %(clone)s '
+                      'from volume %(volume)s: %(error)s',
+                      {'clone': volume['name'],
+                       'volume': src_vref['name'],
+                       'error': error})
+            raise
+        finally:
+            try:
+                self.delete_snapshot(snapshot)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to delete temporary snapshot '
+                          '%(volume)s@%(snapshot)s: %(error)s',
+                          {'volume': src_vref['name'],
+                           'snapshot': snapshot['name'],
+                           'error': error})
+
+    def _ensure_share_unmounted(self, share):
+        """Ensure that NFS share is unmounted on the host.
+
+        :param share: share path
+        """
+        attempts = max(1, self.configuration.nfs_mount_attempts)
+        path = self._get_mount_point_for_share(share)
+        if path not in self._remotefsclient._read_mounts():
+            LOG.debug('NFS share %(share)s is not mounted at %(path)s',
+                      {'share': share, 'path': path})
+            return
+        for attempt in range(attempts):
+            try:
+                fs.umount(path)
+                LOG.debug('NFS share %(share)s has been unmounted at %(path)s',
+                          {'share': share, 'path': path})
+                break
+            except Exception as error:
+                if attempt == (attempts - 1):
+                    LOG.error('Failed to unmount NFS share %(share)s '
+                              'after %(attempts)s attempts',
+                              {'share': share, 'attempts': attempts})
+                    raise
+                LOG.debug('Unmount attempt %(attempt)s failed: %(error)s, '
+                          'retrying unmount %(share)s from %(path)s',
+                          {'attempt': attempt, 'error': error,
+                           'share': share, 'path': path})
+                greenthread.sleep(1)
+        self._delete(path)
+
+    def _delete(self, path):
+        """Override parent method for safe remove mountpoint."""
+        try:
+            os.rmdir(path)
+            LOG.debug('The mountpoint %(path)s has been successfully removed',
+                      {'path': path})
+        except OSError as error:
+            LOG.debug('Failed to remove mountpoint %(path)s: %(error)s',
+                      {'path': path, 'error': error.strerror})
+
+    def _mount_volume(self, volume):
+        """Ensure that volume is activated and mounted on the host."""
+        share = self._get_volume_share(volume)
+        self._ensure_share_mounted(share)
+
+    def _unmount_volume(self, volume):
+        """Ensure that volume is unmounted on the host."""
+        try:
+            share = self._get_volume_share(volume)
+        except jsonrpc.NmsException as error:
+            if error.code == 'ENOENT':
+                return
+        self._ensure_share_unmounted(share)
+
+    def create_export(self, context, volume, connector):
+        """Driver entry point to get the export info for a new volume."""
+        pass
+
+    def ensure_export(self, context, volume):
+        """Driver entry point to get the export info for an existing volume."""
+        pass
+
+    def remove_export(self, context, volume):
+        """Driver entry point to remove an export for a volume."""
+        pass
+
+    def terminate_connection(self, volume, connector, **kwargs):
+        """Terminate a connection to a volume.
+
+        :param volume: a volume object
+        :param connector: a connector object
+        :returns: dictionary of connection information
+        """
+        LOG.debug('Terminate volume connection for %(volume)s',
+                  {'volume': volume['name']})
+        self._unmount_volume(volume)
+
+    def initialize_connection(self, volume, connector):
+        """Allow connection to connector and return connection info.
+
+        :param volume: volume reference
+        :param connector: connector reference
+        :returns: dictionary of connection information
+        """
+        LOG.debug('Initialize volume connection for %(volume)s',
+                  {'volume': volume['name']})
+        share = self._get_volume_share(volume)
+        data = {
+            'export': share,
+            'name': 'volume'
+        }
+        nfs_options = self.configuration.safe_get('nfs_mount_options')
+        nas_options = self.configuration.safe_get('nas_mount_options')
+        if nfs_options and nas_options:
+            LOG.debug('Overriding NFS mount options for volume %(volume)s: '
+                      'nfs_mount_options = "%(nfs_options)s" with '
+                      'nas_mount_options = "%(nas_options)s"',
+                      {'volume': volume['name'],
+                       'nfs_options': nfs_options,
+                       'nas_options': nas_options})
+        if nas_options:
+            data['options'] = '-o %s' % nas_options
+        elif nfs_options:
+            data['options'] = '-o %s' % nfs_options
+        info = {
+            'driver_volume_type': self.driver_volume_type,
+            'mount_point_base': self.mount_point_base,
+            'data': data
+        }
+        return info
+
+    def _get_bound_host(self, host):
+        """Get user@host:port from SSH bindings."""
+        try:
+            bindings = self.nms.appliance.ssh_list_bindings()
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get SSH bindings: %(error)s',
+                      {'error': error})
+            return None
+        for user_host_port in bindings:
+            binding = bindings[user_host_port]
+            if not (isinstance(binding, list) and len(binding) == 4):
+                LOG.warning('Skip incompatible SSH binding: %(binding)s',
+                            {'binding': binding})
+                continue
+            data = binding[2]
+            items = data.split(',')
+            for item in items:
+                if host == item.strip():
+                    return user_host_port
+        return None
+
+    def _svc_state(self, fmri, state):
+        retries = 10
+        delay = 30
+        while retries:
+            greenthread.sleep(delay)
+            retries -= 1
+            try:
+                status = self.nms.autosvc.get_state(fmri)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to get state of migration '
+                          'service %(fmri)s: %(error)s',
+                          {'fmri': fmri, 'error': error})
+                continue
+            if status == 'uninitialized':
+                continue
+            elif status == state:
+                return True
+            if state == 'online':
+                method = getattr(self.nms.autosvc, 'enable')
+            elif state == 'disabled':
+                method = getattr(self.nms.autosvc, 'disable')
+            else:
+                LOG.error('Request unknown service state: %(state)s',
+                          {'state': state})
+                return False
+            try:
+                method(fmri)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to change state of migration service '
+                          '%(fmri)s to %(state)s: %(error)s',
+                          {'fmri': fmri, 'state': state, 'error': error})
+        LOG.error('Unable to change state of migration service %(fmri)s '
+                  'to %(state)s: maximum retries exceeded',
+                  {'fmri': fmri, 'state': state})
+        return False
+
+    def _svc_progress(self, fmri):
+        """Get progress for SMF service."""
+        progress = 0
+        try:
+            estimations = self.nms.autosync.get_estimations(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get estimations for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return progress
+        size = estimations.get('curt_siz')
+        sent = estimations.get('curt_sen')
+        try:
+            size = float(size)
+            sent = float(sent)
+            if size > 0:
+                progress = int(100 * sent / size)
+        except (TypeError, ValueError) as error:
+            LOG.error('Failed to parse estimations statistics '
+                      '%(estimations)s for migration service '
+                      '%(fmri)s: %(error)s',
+                      {'estimations': estimations,
+                       'fmri': fmri, 'error': error})
+        return progress
+
+    def _svc_result(self, fmri):
+        try:
+            props = self.nms.autosvc.get_child_props(fmri, '')
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get properties of migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return False
+        history = props.get('zfs/run_history')
+        if not history:
+            LOG.error('Failed to get history of migration service '
+                      '%(fmri)s: %(props)s',
+                      {'fmri': fmri, 'props': props})
+            return False
+        results = history.split()
+        if len(results) > 1:
+            LOG.warning('Found unexpected replication sessions for '
+                        'migration service %(fmri)s: %(history)s',
+                        {'fmri': fmri, 'history': history})
+        latest = results.pop()
+        start, stop, code = latest.split('::')
+        try:
+            start = int(start)
+            stop = int(stop)
+            code = int(code)
+        except (TypeError, ValueError) as error:
+            LOG.error('Failed to parse history %(history)s for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'history': history, 'fmri': fmri, 'error': error})
+            return False
+        delta = stop - start
+        if code != 1:
+            LOG.error('Migration service %(fmri)s failed after %(delta)s '
+                      'seconds, please check the service log below',
+                      {'fmri': fmri, 'delta': delta})
+            return False
+        LOG.info('Migration service %(fmri)s successfully finished in '
+                 '%(delta)s seconds',
+                 {'fmri': fmri, 'delta': delta})
+        return True
+
+    def _svc_cleanup(self, fmri, migrated=False):
+        props = None
+        flags = {
+            'src_properties': '1',
+            'dst_properties': '1',
+            'src_snapshots': '1',
+            'dst_snapshots': '1'
+        }
+        if not migrated:
+            flags['dst_datasets'] = '1'
+        try:
+            props = self.nms.autosvc.get_child_props(fmri, '')
+            props['zfs/sync-recursive'] = '1'
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get properties of migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        try:
+            self.nms.autosvc.unschedule(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to unschedule migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        self._svc_state(fmri, 'disabled')
+        try:
+            self.nms.autosvc.destroy(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to destroy migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        if not props:
+            return
+        try:
+            src_pid, dst_pid = self.nms.autosync.cleanup(props, flags)
+        except jsonrpc.NmsException as error:
+            src_pid = dst_pid = 0
+            LOG.error('Failed to cleanup migration service %(fmri)s: '
+                      '%(error)s',
+                      {'fmri': fmri, 'error': error})
+        for pid in [src_pid, dst_pid]:
+            while pid:
+                try:
+                    self.nms.job.get_jobparams(pid)
+                except jsonrpc.NmsException as error:
+                    if error.code == 'ENOENT':
+                        break
+                greenthread.sleep(30)
+        if migrated:
+            return
+        path = props.get('restarter/logfile')
+        if not path:
+            return
+        try:
+            content = self.nms.logviewer.get_tail(path, units.Mi)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get log file content for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return
+        log = '\n'.join(content)
+        LOG.error('Migration service %(fmri)s log: %(log)s',
+                  {'fmri': fmri, 'log': log})
+
+    def _migrate_volume(self, volume, host, path):
+        delay = 30
+        retries = 10
+        src_path = self._get_volume_path(volume)
+        dst_path = posixpath.join(path, volume['name'])
+        hosts = self._get_host_addresses()
+        if host in hosts:
+            dst_host = 'localhost'
+            service_direction = '0'
+            service_proto = 'zfs'
+            if src_path == dst_path:
+                LOG.info('Skip local to local replication: source '
+                         'volume %(src_path)s and destination volume '
+                         '%(dst_path)s are the same local volume',
+                         {'src_path': src_path, 'dst_path': dst_path})
+                return True
+        else:
+            service_direction = '1'
+            service_proto = 'zfs+rr'
+            dst_host = self._get_bound_host(host)
+            if not dst_host:
+                LOG.error('Storage assisted volume migration is '
+                          'unavailable: the destination host '
+                          '%(host)s should be SSH bound',
+                          {'host': host})
+                return False
+        service_name = '%(prefix)s-%(volume)s' % {
+            'prefix': self.migration_service_prefix,
+            'volume': volume['name']
+        }
+        comment = 'Migrate %(src)s to %(host)s:%(dst)s' % {
+            'src': src_path,
+            'host': dst_host,
+            'dst': dst_path
+        }
+        yesterday = timeutils.utcnow() - datetime.timedelta(days=1)
+        dst_path = path
+        rate_limit = 0
+        if self.migration_throttle:
+            rate_limit = self.migration_throttle * units.Ki
+        payload = {
+            'comment': comment,
+            'custom_name': service_name,
+            'from-fs': src_path,
+            'to-host': dst_host,
+            'to-fs': dst_path,
+            'direction': service_direction,
+            'marker_name': self.migration_snapshot_prefix,
+            'proto': service_proto,
+            'day': six.text_type(yesterday.day),
+            'rate_limit': six.text_type(rate_limit),
+            '_unique': 'type from-host from-fs to-host to-fs',
+            'method': 'sync',
+            'from-host': 'localhost',
+            'period_multiplier': '1',
+            'keep_src': '1',
+            'keep_dst': '1',
+            'trace_level': '30',
+            'type': 'monthly',
+            'nconn': '2',
+            'period': '12',
+            'mbuffer_size': '16',
+            'minute': '0',
+            'hour': '0',
+            'flags': '0',
+            'estimations': '0',
+            'force': '0',
+            'reverse_capable': '0',
+            'sync-recursive': '0',
+            'auto-clone': '0',
+            'flip_options': '0',
+            'direction_flipped': '0',
+            'retry': '0',
+            'success_counter': '0',
+            'dircontent': '0',
+            'zip_level': '0',
+            'auto-mount': '0',
+            'marker': '',
+            'exclude': '',
+            'run_history': '',
+            'progress-marker': '',
+            'from-snapshot': '',
+            'latest-suffix': '',
+            'trunk': '',
+            'options': ''
+        }
+        try:
+            fmri = self.nms.autosvc.fmri_create('auto-sync', comment,
+                                                src_path, 0, payload)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to create migration service '
+                      'with payload %(payload)s: %(error)s',
+                      {'payload': payload, 'error': error})
+            return False
+        if not self._svc_state(fmri, 'online'):
+            self._svc_cleanup(fmri)
+            return False
+        service_running = False
+        try:
+            self.nms.autosvc.execute(fmri)
+            service_running = True
+            LOG.info('Migration service %(fmri)s successfully started',
+                     {'fmri': fmri})
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to start migration service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        if not service_running:
+            LOG.error('Migration service %(fmri)s is offline',
+                      {'fmri': fmri})
+            self._svc_cleanup(fmri)
+            return False
+        service_history = None
+        service_retries = retries
+        service_progress = 0
+        while service_retries and not service_history:
+            greenthread.sleep(delay)
+            service_retries -= 1
+            try:
+                service_props = self.nms.autosvc.get_child_props(fmri, '')
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to get properties of migration service '
+                          '%(fmri)s: %(error)s',
+                          {'fmri': fmri, 'error': error})
+                continue
+            service_history = service_props.get('zfs/run_history')
+            service_started = service_props.get('zfs/time_started')
+            if service_started == 'N/A':
+                continue
+            progress = self._svc_progress(fmri)
+            if progress > service_progress:
+                service_progress = progress
+                service_retries = retries
+            LOG.info('Migration service %(fmri)s replication progress: '
+                     '%(service_progress)s%%',
+                     {'fmri': fmri, 'service_progress': service_progress})
+        if not service_history:
+            self._svc_cleanup(fmri)
+            return False
+        volume_migrated = self._svc_result(fmri)
+        self._svc_cleanup(fmri, volume_migrated)
+        if volume_migrated:
+            try:
+                self.delete_volume(volume)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to delete source volume %(volume)s '
+                          'after successful migration: %(error)s',
+                          {'volume': volume['name'], 'error': error})
+        return volume_migrated
+
+    def migrate_volume(self, context, volume, host):
+        """Migrate the volume to the specified host.
+
+        Returns a boolean indicating whether the migration occurred,
+        as well as model_update.
+
+        :param context: Security context
+        :param volume: A dictionary describing the volume to migrate
+        :param host: A dictionary describing the host to migrate to, where
+                     host['host'] is its name, and host['capabilities'] is a
+                     dictionary of its reported capabilities.
+        """
+        LOG.info('Start storage assisted volume migration '
+                 'for volume %(volume)s to host %(host)s',
+                 {'volume': volume['name'],
+                  'host': host['host']})
+        false_ret = (False, None)
+        if 'capabilities' not in host:
+            LOG.error('No host capabilities found for '
+                      'the destination host %(host)s',
+                      {'host': host['host']})
+            return false_ret
+        capabilities = host['capabilities']
+        required_capabilities = [
+            'vendor_name',
+            'location_info',
+            'storage_protocol',
+            'free_capacity_gb'
+        ]
+        for capability in required_capabilities:
+            if capability not in capabilities:
+                LOG.error('Required host capability %(capability)s not '
+                          'found for the destination host %(host)s',
+                          {'capability': capability, 'host': host['host']})
+                return false_ret
+        vendor = capabilities['vendor_name']
+        if vendor != self.vendor_name:
+            LOG.error('Unsupported vendor %(vendor)s found '
+                      'for the destination host %(host)s',
+                      {'vendor': vendor, 'host': host['host']})
+            return false_ret
+        location = capabilities['location_info']
+        try:
+            driver, nas_host, nas_path = location.split(':')
+        except ValueError as error:
+            LOG.error('Failed to parse location info %(location)s '
+                      'for the destination host %(host)s: %(error)s',
+                      {'location': location, 'host': host['host'],
+                       'error': error})
+            return false_ret
+        if not (driver and nas_host and nas_path):
+            LOG.error('Incomplete location info %(location)s '
+                      'found for the destination host %(host)s',
+                      {'location': location, 'host': host['host']})
+            return false_ret
+        if driver != self.driver_name:
+            LOG.error('Unsupported storage driver %(driver)s '
+                      'found for the destination host %(host)s',
+                      {'driver': driver, 'host': host['host']})
+            return false_ret
+        storage_protocol = capabilities['storage_protocol']
+        if storage_protocol != self.storage_protocol:
+            LOG.error('Unsupported storage protocol %(protocol)s '
+                      'found for the destination host %(host)s',
+                      {'protocol': storage_protocol,
+                       'host': host['host']})
+            return false_ret
+        free_capacity_gb = capabilities['free_capacity_gb']
+        if free_capacity_gb < volume['size']:
+            LOG.error('There is not enough space available on the '
+                      'destination host %(host)s to migrate volume '
+                      '%(volume)s, available space: %(free)sG, '
+                      'required space: %(required)sG',
+                      {'host': host['host'], 'volume': volume['name'],
+                       'free': free_capacity_gb,
+                       'required': volume['size']})
+            return false_ret
+        if self._migrate_volume(volume, nas_host, nas_path):
+            return (True, None)
+        return false_ret
+
+    def update_migrated_volume(self, context, volume, new_volume,
+                               original_volume_status):
+        """Return model update for migrated volume.
+
+        This method should rename the back-end volume name on the
+        destination host back to its original name on the source host.
+
+        :param context: The context of the caller
+        :param volume: The original volume that was migrated to this backend
+        :param new_volume: The migration volume object that was created on
+                           this backend as part of the migration process
+        :param original_volume_status: The status of the original volume
+        :returns: model_update to update DB with any needed changes
+        """
+        name_id = None
+        volume_path = self._get_volume_path(volume)
+        new_volume_path = self._get_volume_path(new_volume)
+        try:
+            self.terminate_connection(new_volume, None)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to terminate all connections '
+                      'to migrated volume %(volume)s before '
+                      'renaming: %(error)s',
+                      {'volume': new_volume['name'],
+                       'error': error})
+        cmd = 'zfs rename %(new_volume)s %(volume)s' % {
+            'new_volume': new_volume_path,
+            'volume': volume_path
+        }
+        try:
+            self.nms.appliance.execute(cmd)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to rename volume %(new_volume)s '
+                      'to %(volume)s after migration: %(error)s',
+                      {'new_volume': new_volume['name'],
+                       'volume': volume['name'],
+                       'error': error})
+            name_id = new_volume._name_id or new_volume.id
+        model_update = {'_name_id': name_id}
+        return model_update
+
+    def retype(self, context, volume, new_type, diff, host):
+        """Convert the volume to be of the new type."""
+        pass
 
     def create_snapshot(self, snapshot):
         """Creates a snapshot.
 
         :param snapshot: snapshot reference
         """
-        volume = self._get_snapshot_volume(snapshot)
-        nfs_share = volume['provider_location']
-        nms = self.share2nms[nfs_share]
-        vol, dataset = self._get_share_datasets(nfs_share)
-        folder = '%s/%s/%s' % (vol, dataset, volume['name'])
-        nms.folder.create_snapshot(folder, snapshot['name'], '-r')
+        snapshot_path = self._get_snapshot_path(snapshot)
+        volume_path, snapshot_name = snapshot_path.split('@')
+        self.nms.folder.create_snapshot(volume_path, snapshot_name, '')
 
     def delete_snapshot(self, snapshot):
         """Deletes a snapshot.
 
         :param snapshot: snapshot reference
         """
-        volume = self._get_snapshot_volume(snapshot)
-        nfs_share = volume['provider_location']
-        nms = self.share2nms[nfs_share]
-        vol, dataset = self._get_share_datasets(nfs_share)
-        folder = '%s/%s/%s' % (vol, dataset, volume['name'])
-        try:
-            nms.snapshot.destroy('%s@%s' % (folder, snapshot['name']), '')
-        except exception.NexentaException as exc:
-            if 'does not exist' in exc.args[0]:
-                LOG.info('Snapshot %(folder)s@%(snapshot)s does not '
-                         'exist, it was already deleted.',
-                         {
-                             'folder': folder,
-                             'snapshot': snapshot,
-                         })
-                return
-            elif 'has dependent clones' in exc.args[0]:
-                LOG.info('Snapshot %(folder)s@%(snapshot)s has dependent '
-                         'clones, it will be deleted later.',
-                         {
-                             'folder': folder,
-                             'snapshot': snapshot,
-                         })
-                return
+        snapshot_path = self._get_snapshot_path(snapshot)
+        self.nms.snapshot.destroy(snapshot_path, '-d')
 
-    def _create_sparsed_file(self, nms, path, size):
-        """Creates file with 0 disk usage.
+    def snapshot_revert_use_temp_snapshot(self):
+        # Considering that NexentaStor based drivers use COW images
+        # for storing snapshots, having chains of such images,
+        # creating a backup snapshot when reverting one is not
+        # actually helpful.
+        return False
 
-        :param nms: nms object
-        :param path: path to new file
-        :param size: size of file
+    def revert_to_snapshot(self, context, volume, snapshot):
+        """Revert volume to snapshot."""
+        snapshot_path = self._get_snapshot_path(snapshot)
+        self.nms.snapshot.rollback(snapshot_path, '')
+
+    def _set_volume_acl(self, volume):
+        volume_path = self._get_volume_path(volume)
+        group = 'everyone@'
+        acl = {
+            'allow': [
+                'full_set',
+                'dir_inherit',
+                'file_inherit'
+            ]
+        }
+        self.nms.folder.set_group_acl(volume_path, group, acl)
+
+    def _get_volume_share(self, volume):
+        """Return NFS share path for the volume."""
+        volume_path = self._get_volume_path(volume)
+        filesystem = self.nms.folder.get_child_props(volume_path, '')
+        if filesystem['mountpoint'] == 'none':
+            self.nms.folder.inherit_prop(volume_path, 'mountpoint', 0)
+            filesystem = self.nms.folder.get_child_props(volume_path, '')
+        if filesystem['mounted'] != 'yes':
+            self.nms.folder.mount(volume_path, 0)
+        share = '%s:%s' % (self.nas_host, filesystem['mountpoint'])
+        return share
+
+    def _local_volume_dir(self, volume):
+        """Get volume dir (mounted locally fs path) for given volume.
+
+        :param volume: volume reference
         """
-        nms.appliance.execute(
-            'truncate --size %(size)dG %(path)s' % {
-                'path': path,
-                'size': size
-            }
-        )
-
-    def _create_regular_file(self, nms, path, size):
-        """Creates regular file of given size.
-
-        Takes a lot of time for large files.
-
-        :param nms: nms object
-        :param path: path to new file
-        :param size: size of file
-        """
-        block_count = size * units.Gi / (BLOCK_SIZE_MB * units.Mi)
-
-        LOG.info('Creating regular file: %s.'
-                 'This may take some time.', path)
-
-        nms.appliance.execute(
-            'dd if=/dev/zero of=%(path)s bs=%(bs)dM count=%(count)d' % {
-                'path': path,
-                'bs': BLOCK_SIZE_MB,
-                'count': block_count
-            }
-        )
-
-        LOG.info('Regular file: %s created.', path)
-
-    def _set_rw_permissions_for_all(self, nms, path):
-        """Sets 666 permissions for the path.
-
-        :param nms: nms object
-        :param path: path to file
-        """
-        nms.appliance.execute('chmod ugo+rw %s' % path)
+        share = self._get_volume_share(volume)
+        if six.PY3:
+            share = share.encode('utf-8')
+        path = hashlib.md5(share).hexdigest()
+        return os.path.join(self.mount_point_base, path)
 
     def local_path(self, volume):
         """Get volume path (mounted locally fs path) for given volume.
 
         :param volume: volume reference
         """
-        nfs_share = volume['provider_location']
-        return os.path.join(self._get_mount_point_for_share(nfs_share),
-                            volume['name'], 'volume')
+        volume_dir = self._local_volume_dir(volume)
+        return os.path.join(volume_dir, 'volume')
 
-    def _get_mount_point_for_share(self, nfs_share):
-        """Returns path to mount point NFS share.
+    def get_volume_stats(self, refresh=False):
+        """Get volume stats.
 
-        :param nfs_share: example 172.18.194.100:/var/nfs
+        If 'refresh' is True, update the stats first.
         """
-        nfs_share = nfs_share.encode('utf-8')
-        return os.path.join(self.configuration.nexenta_mount_point_base,
-                            hashlib.md5(nfs_share).hexdigest())
+        if refresh or not self._stats:
+            self._update_volume_stats()
 
-    def remote_path(self, volume):
-        """Get volume path (mounted remotely fs path) for given volume.
-
-        :param volume: volume reference
-        """
-        nfs_share = volume['provider_location']
-        share = nfs_share.split(':')[1].rstrip('/')
-        return '%s/%s/volume' % (share, volume['name'])
-
-    def _share_folder(self, nms, volume, folder):
-        """Share NFS folder on NexentaStor Appliance.
-
-        :param nms: nms object
-        :param volume: volume name
-        :param folder: folder name
-        """
-        path = '%s/%s' % (volume, folder.lstrip('/'))
-        share_opts = {
-            'read_write': '*',
-            'read_only': '',
-            'root': 'nobody',
-            'extra_options': 'anon=0',
-            'recursive': 'true',
-            'anonymous_rw': 'true',
-        }
-        LOG.debug('Sharing folder %s on Nexenta Store', folder)
-        nms.netstorsvc.share_folder('svc:/network/nfs/server:default', path,
-                                    share_opts)
-
-    def _load_shares_config(self, share_file):
-        self.shares = {}
-        self.share2nms = {}
-
-        for share in self._read_config_file(share_file):
-            # A configuration line may be either:
-            # host:/share_name  http://user:pass@host:[port]/
-            # or
-            # host:/share_name  http://user:pass@host:[port]/
-            #    -o options=123,rw --other
-            if not share.strip():
-                continue
-            if share.startswith('#'):
-                continue
-
-            share_info = re.split(r'\s+', share, 2)
-
-            share_address = share_info[0].strip()
-            nms_url = share_info[1].strip()
-            share_opts = share_info[2].strip() if len(share_info) > 2 else None
-
-            if not re.match(r'.+:/.+', share_address):
-                LOG.warning("Share %s ignored due to invalid format. "
-                            "Must be of form address:/export.",
-                            share_address)
-                continue
-
-            self.shares[share_address] = share_opts
-            self.share2nms[share_address] = self._get_nms_for_url(nms_url)
-
-        LOG.debug('Shares loaded: %s', self.shares)
-
-    def _get_subshare_mount_point(self, nfs_share, volume):
-        mnt_path = '%s/%s' % (
-            self._get_mount_point_for_share(nfs_share), volume['name'])
-        sub_share = '%s/%s' % (nfs_share, volume['name'])
-        return sub_share, mnt_path
-
-    def _ensure_share_mounted(self, nfs_share, mount_path=None):
-        """Ensure that NFS share is mounted on the host.
-
-        Unlike the parent method this one accepts mount_path as an optional
-        parameter and uses it as a mount point if provided.
-
-        :param nfs_share: NFS share name
-        :param mount_path: mount path on the host
-        """
-        mnt_flags = []
-        if self.shares.get(nfs_share) is not None:
-            mnt_flags = self.shares[nfs_share].split()
-        num_attempts = max(1, self.configuration.nfs_mount_attempts)
-        for attempt in range(num_attempts):
-            try:
-                if mount_path is None:
-                    self._remotefsclient.mount(nfs_share, mnt_flags)
-                else:
-                    if mount_path in self._remotefsclient._read_mounts():
-                        LOG.info('Already mounted: %s', mount_path)
-                        return
-
-                    self._execute('mkdir', '-p', mount_path,
-                                  check_exit_code=False)
-                    self._remotefsclient._mount_nfs(nfs_share, mount_path,
-                                                    mnt_flags)
-                return
-            except Exception as e:
-                if attempt == (num_attempts - 1):
-                    LOG.error('Mount failure for %(share)s after '
-                              '%(count)d attempts.', {
-                                  'share': nfs_share,
-                                  'count': num_attempts})
-                    raise exception.NfsException(six.text_type(e))
-                LOG.warning(
-                    'Mount attempt %(attempt)d failed: %(error)s. '
-                    'Retrying mount ...', {
-                        'attempt': attempt,
-                        'error': e})
-                greenthread.sleep(1)
-
-    def _mount_subfolders(self):
-        ctxt = context.get_admin_context()
-        vol_entries = self.db.volume_get_all_by_host(ctxt, self.host)
-        for vol in vol_entries:
-            nfs_share = vol['provider_location']
-            if ((nfs_share in self.shares) and
-                    (self._get_nfs_server_version(nfs_share) < 4)):
-                sub_share, mnt_path = self._get_subshare_mount_point(
-                    nfs_share, vol)
-                self._ensure_share_mounted(sub_share, mnt_path)
-
-    def _get_nfs_server_version(self, share):
-        if not self.nfs_versions.get(share):
-            nms = self.share2nms[share]
-            nfs_opts = nms.netsvc.get_confopts(
-                'svc:/network/nfs/server:default', 'configure')
-            try:
-                self.nfs_versions[share] = int(
-                    nfs_opts['nfs_server_versmax']['current'])
-            except KeyError:
-                self.nfs_versions[share] = int(
-                    nfs_opts['server_versmax']['current'])
-        return self.nfs_versions[share]
-
-    def _get_capacity_info(self, nfs_share):
-        """Calculate available space on the NFS share.
-
-        :param nfs_share: example 172.18.194.100:/var/nfs
-        """
-        nms = self.share2nms[nfs_share]
-        ns_volume, ns_folder = self._get_share_datasets(nfs_share)
-        folder_props = nms.folder.get_child_props('%s/%s' % (ns_volume,
-                                                             ns_folder),
-                                                  'used|available')
-        free = utils.str2size(folder_props['available'])
-        allocated = utils.str2size(folder_props['used'])
-        self.shares_with_capacities[nfs_share] = {
-            'free': utils.str2gib_size(free),
-            'total': utils.str2gib_size(free + allocated)}
-        return free + allocated, free, allocated
-
-    def _get_nms_for_url(self, url):
-        """Returns initialized nms object for url."""
-        auto, scheme, user, password, host, port, path = (
-            utils.parse_nms_url(url))
-        return jsonrpc.NexentaJSONProxy(scheme, host, port, path, user,
-                                        password, auto=auto,
-                                        verify=self.verify_ssl)
-
-    def _get_snapshot_volume(self, snapshot):
-        ctxt = context.get_admin_context()
-        return db.volume_get(ctxt, snapshot['volume_id'])
-
-    def _get_volroot(self, nms):
-        """Returns volroot property value from NexentaStor appliance."""
-        if not self.nms_cache_volroot:
-            return nms.server.get_prop('volroot')
-        if nms not in self._nms2volroot:
-            self._nms2volroot[nms] = nms.server.get_prop('volroot')
-        return self._nms2volroot[nms]
-
-    def _get_share_datasets(self, nfs_share):
-        nms = self.share2nms[nfs_share]
-        volroot = self._get_volroot(nms)
-        path = nfs_share.split(':')[1][len(volroot):].strip('/')
-        volume_name = path.split('/')[0]
-        folder_name = '/'.join(path.split('/')[1:])
-        return volume_name, folder_name
-
-    def _get_clone_snapshot_name(self, volume):
-        """Return name for snapshot that will be used to clone the volume."""
-        return 'cinder-clone-snapshot-%(id)s' % volume
-
-    def _is_clone_snapshot_name(self, snapshot):
-        """Check if snapshot is created for cloning."""
-        name = snapshot.split('@')[-1]
-        return name.startswith('cinder-clone-snapshot-')
+        return self._stats
 
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor appliance."""
-        LOG.debug('Updating volume stats')
-        total_space = 0
-        free_space = 0
-        share = None
-        for _share in self._mounted_shares:
-            if self.shares_with_capacities[_share]['free'] > free_space:
-                free_space = self.shares_with_capacities[_share]['free']
-                total_space = self.shares_with_capacities[_share]['total']
-                share = _share
-
-        location_info = '%(driver)s:%(share)s' % {
-            'driver': self.__class__.__name__,
-            'share': share
+        pool_name = self.root_path.split('/')[0]
+        stats = {'available': None, 'used': None}
+        payload = '|'.join(stats.keys())
+        props = self.nms.folder.get_child_props(self.root_path, payload)
+        for key in stats:
+            if not props.get(key):
+                LOG.error('Unable to get %(key)s statistics for %(path)s '
+                          'from properties %(props)s',
+                          {'path': self.root_path, 'props': props})
+                continue
+            text = '%sB' % props[key]
+            try:
+                value = strutils.string_to_bytes(text, return_int=True)
+                stats[key] = value
+            except ValueError as error:
+                LOG.error('Failed to convert text value %(text)s to '
+                          'bytes for the %(key)s property: %(error)s',
+                          {'text': text, 'key': key, 'error': error})
+        if None in stats.values():
+            allocated_capacity_gb = 'unknown'
+            free_capacity_gb = 'unknown'
+            total_capacity_gb = 'unknown'
+        else:
+            free_capacity_gb = stats['available'] // units.Gi
+            allocated_capacity_gb = stats['used'] // units.Gi
+            total_capacity_gb = free_capacity_gb + allocated_capacity_gb
+        provisioned_capacity_gb = total_volumes = 0
+        ctxt = context.get_admin_context()
+        volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        for volume in volumes:
+            provisioned_capacity_gb += volume['size']
+            total_volumes += 1
+        volume_backend_name = (
+            self.configuration.safe_get('volume_backend_name'))
+        if not volume_backend_name:
+            LOG.error('Failed to get configured volume backend name')
+            volume_backend_name = '%(product)s_%(protocol)s' % {
+                'product': self.product_name,
+                'protocol': self.storage_protocol
+            }
+        description = (
+            self.configuration.safe_get('nexenta_dataset_description'))
+        if not description:
+            description = '%(product)s %(host)s:%(path)s' % {
+                'product': self.product_name,
+                'host': self.configuration.nas_host,
+                'path': self.configuration.nas_share_path
+            }
+        max_over_subscription_ratio = (
+            self.configuration.safe_get('max_over_subscription_ratio'))
+        reserved_percentage = (
+            self.configuration.safe_get('reserved_percentage'))
+        if reserved_percentage is None:
+            reserved_percentage = 0
+        location_info = '%(driver)s:%(host)s:%(path)s' % {
+            'driver': self.driver_name,
+            'host': self.configuration.nas_host,
+            'path': self.configuration.nas_share_path
         }
-        nms_url = self.share2nms[share].url
+        display_name = 'Capabilities of %(product)s %(protocol)s driver' % {
+            'product': self.product_name,
+            'protocol': self.storage_protocol
+        }
+        visibility = 'public'
         self._stats = {
-            'vendor_name': 'Nexenta',
-            'dedup': self.volume_deduplication,
-            'compression': self.volume_compression,
-            'description': self.volume_description,
-            'nms_url': nms_url,
-            'ns_shares': self.shares_with_capacities,
             'driver_version': self.VERSION,
-            'storage_protocol': 'NFS',
-            'total_capacity_gb': total_space,
-            'free_capacity_gb': free_space,
-            'reserved_percentage': self.configuration.reserved_percentage,
-            'QoS_support': False,
+            'vendor_name': self.vendor_name,
+            'storage_protocol': self.storage_protocol,
+            'volume_backend_name': volume_backend_name,
             'location_info': location_info,
-            'volume_backend_name': self.backend_name,
-            'nfs_mount_point_base': self.nfs_mount_point_base
+            'description': description,
+            'display_name': display_name,
+            'pool_name': pool_name,
+            'multiattach': True,
+            'QoS_support': False,
+            'consistencygroup_support': False,
+            'consistent_group_snapshot_enabled': False,
+            'online_extend_support': True,
+            'sparse_copy_volume': True,
+            'thin_provisioning_support': True,
+            'thick_provisioning_support': True,
+            'total_capacity_gb': total_capacity_gb,
+            'allocated_capacity_gb': allocated_capacity_gb,
+            'free_capacity_gb': free_capacity_gb,
+            'provisioned_capacity_gb': provisioned_capacity_gb,
+            'total_volumes': total_volumes,
+            'max_over_subscription_ratio': max_over_subscription_ratio,
+            'reserved_percentage': reserved_percentage,
+            'visibility': visibility,
+            'dedup': self.configuration.nexenta_dataset_dedup,
+            'compression': self.configuration.nexenta_dataset_compression,
+            'nms_url': self.nms.url
         }
+        LOG.debug('Updated volume backend statistics for host %(host)s '
+                  'and volume backend %(volume_backend_name)s: %(stats)s',
+                  {'host': self.host,
+                   'volume_backend_name': volume_backend_name,
+                   'stats': self._stats})
+
+    def _get_volume_path(self, volume):
+        """Return ZFS datset path for the volume."""
+        return posixpath.join(self.root_path, volume['name'])
+
+    def _get_snapshot_path(self, snapshot):
+        """Return ZFS snapshot path for the snapshot."""
+        volume_name = snapshot['volume_name']
+        snapshot_name = snapshot['name']
+        volume_path = posixpath.join(self.root_path, volume_name)
+        return '%s@%s' % (volume_path, snapshot_name)
+
+    def _get_host_addresses(self):
+        """Return NexentaStor IP addresses list."""
+        addresses = []
+        items = self.nms.appliance.execute('ipadm show-addr -p -o addr')
+        for item in items:
+            cidr = six.text_type(item)
+            addr, mask = cidr.split('/')
+            obj = ipaddress.ip_address(addr)
+            if not obj.is_loopback:
+                addresses.append(obj.exploded)
+        LOG.debug('Configured IP addresses: %(addresses)s',
+                  {'addresses': addresses})
+        return addresses
+
+    @staticmethod
+    def _match_template(template, name):
+        sequence = difflib.SequenceMatcher(None, name, template)
+        added = deleted = result = ''
+        for tag, a1, a2, b1, b2 in sequence.get_opcodes():
+            if tag == 'equal':
+                result += ''.join(sequence.a[a1:a2])
+            elif tag == 'delete':
+                deleted += ''.join(sequence.a[a1:a2])
+            elif tag == 'insert':
+                added += ''.join(sequence.b[b1:b2])
+            elif tag == 'replace':
+                result += ''.join(sequence.b[b1:b2])
+        if result == template and not (added or deleted):
+            return True
+        return False

--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -314,17 +314,24 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         volume_path = self._get_volume_path(volume)
         if isinstance(connector, dict) and 'initiator' in connector:
             connectors = []
-            for attachment in volume['volume_attachment']:
-                connectors.append(attachment.get('connector'))
+            if 'volume_attachment' in volume:
+                if isinstance(volume['volume_attachment'], list):
+                    for attachment in volume['volume_attachment']:
+                        if not isinstance(attachment, dict):
+                            continue
+                        if 'connector' not in attachment:
+                            continue
+                        connectors.append(attachment['connector'])
             if connectors.count(connector) > 1:
-                LOG.debug('Detected multiple connections on host '
-                          '%(host_name)s [%(host_ip)s] for volume '
-                          '%(volume)s, skip terminate volume connection',
-                          {'host_name': connector.get('host', 'unknown'),
+                LOG.debug('Detected %(count)s connections from host '
+                          '%(host_name)s (IP:%(host_ip)s) to volume '
+                          '%(volume)s, skip terminating connection',
+                          {'count': connectors.count(connector),
+                           'host_name': connector.get('host', 'unknown'),
                            'host_ip': connector.get('ip', 'unknown'),
                            'volume': volume['name']})
                 return True
-            host_iqn = connector.get('initiator')
+            host_iqn = connector['initiator']
             host_groups.append(options.DEFAULT_HOST_GROUP)
             host_group = self._get_host_group(host_iqn)
             if host_group is not None:
@@ -645,7 +652,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 props['target_iqns'] = props_iqns
                 props['target_luns'] = props_luns
             else:
-                index = random.randrange(0, len(props_luns))
+                index = random.randrange(len(props_luns))
                 props['target_portal'] = props_portals[index]
                 props['target_iqn'] = props_iqns[index]
                 props['target_lun'] = props_luns[index]
@@ -710,7 +717,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                    'hostGroup': host_group}
         self.nef.mappings.create(payload)
         mapping = {}
-        for attempt in range(0, self.nef.retries):
+        for attempt in range(self.nef.retries):
             mapping = self.nef.mappings.list(payload)
             if mapping:
                 break
@@ -727,7 +734,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             props['target_iqns'] = props_iqns
             props['target_luns'] = props_luns
         else:
-            index = random.randrange(0, len(props_luns))
+            index = random.randrange(len(props_luns))
             props['target_portal'] = props_portals[index]
             props['target_iqn'] = props_iqns[index]
             props['target_lun'] = props_luns[index]

--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -237,7 +237,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
             LOG.debug('NFS share %(share)s is not mounted at %(path)s',
                       {'share': share, 'path': path})
             return
-        for attempt in range(0, attempts):
+        for attempt in range(attempts):
             try:
                 fs.umount(path)
                 LOG.debug('NFS share %(share)s has been unmounted at %(path)s',
@@ -880,7 +880,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: volume reference
         """
         share = self._get_volume_share(volume)
-        if isinstance(share, six.text_type):
+        if six.PY3:
             share = share.encode('utf-8')
         path = hashlib.md5(share).hexdigest()
         return os.path.join(self.mount_point_base, path)

--- a/cinder/volume/drivers/nexenta/options.py
+++ b/cinder/volume/drivers/nexenta/options.py
@@ -132,28 +132,35 @@ NEXENTA_CONNECTION_OPTS = [
 ]
 
 NEXENTA_ISCSI_OPTS = [
-    cfg.StrOpt('nexenta_iscsi_target_portal_groups',
-               default='',
-               help='NexentaStor target portal groups'),
+    cfg.ListOpt('nexenta_iscsi_target_portal_groups',
+                default=[],
+                help='List of comma-separated NexentaStor4 iSCSI target '
+                     'portal groups'),
     cfg.StrOpt('nexenta_iscsi_target_portals',
                default='',
                help='Comma separated list of portals for NexentaStor5, in'
                     'format of IP1:port1,IP2:port2. Port is optional, '
                     'default=3260. Example: 10.10.10.1:3267,10.10.1.2'),
     cfg.StrOpt('nexenta_iscsi_target_host_group',
+               deprecated_for_removal=True,
+               deprecated_reason='NexentaStor cinder driver has been '
+                                 'refactored and host groups are created '
+                                 'dynamically. So the configuration '
+                                 'parameter nexenta_iscsi_target_host_group '
+                                 'is no longer used.',
                default='all',
                help='Group of hosts which are allowed to access volumes'),
     cfg.IntOpt('nexenta_iscsi_target_portal_port',
                default=3260,
-               help='Nexenta appliance iSCSI target portal port'),
+               help='NexentaStor iSCSI target portal port'),
     cfg.IntOpt('nexenta_luns_per_target',
                default=100,
-               help='Amount of LUNs per iSCSI target'),
+               help='Limit of LUNs per iSCSI target'),
     cfg.StrOpt('nexenta_volume',
                default='cinder',
                help='NexentaStor pool name that holds all volumes'),
     cfg.StrOpt('nexenta_target_prefix',
-               default='iqn.1986-03.com.sun:02:cinder',
+               default='iqn.2005-07.com.nexenta:01:cinder',
                help='iqn prefix for NexentaStor iSCSI targets'),
     cfg.StrOpt('nexenta_target_group_prefix',
                default='cinder',
@@ -184,13 +191,13 @@ NEXENTA_NFS_OPTS = [
                 help='Create volumes as QCOW2 files rather than raw files'),
     cfg.BoolOpt('nexenta_nms_cache_volroot',
                 default=True,
-                help=('If set True cache NexentaStor appliance volroot option '
-                      'value.'))
+                help='If set True cache NexentaStor appliance volroot option '
+                     'value.')
 ]
 
 NEXENTA_DATASET_OPTS = [
     cfg.StrOpt('nexenta_dataset_compression',
-               default='on',
+               default='lz4',
                choices=['on', 'off', 'gzip', 'gzip-1', 'gzip-2', 'gzip-3',
                         'gzip-4', 'gzip-5', 'gzip-6', 'gzip-7', 'gzip-8',
                         'gzip-9', 'lzjb', 'zle', 'lz4'],
@@ -206,7 +213,7 @@ NEXENTA_DATASET_OPTS = [
                default='',
                help='Human-readable description for the folder.'),
     cfg.IntOpt('nexenta_blocksize',
-               default=4096,
+               default=32768,
                help='Block size for datasets'),
     cfg.IntOpt('nexenta_ns5_blocksize',
                default=32,
@@ -214,6 +221,16 @@ NEXENTA_DATASET_OPTS = [
     cfg.BoolOpt('nexenta_sparse',
                 default=False,
                 help='Enables or disables the creation of sparse datasets'),
+    cfg.IntOpt('nexenta_migration_throttle',
+               min=1,
+               max=2047,
+               help='Throttle migration throughput in MegaBytes per second'),
+    cfg.StrOpt('nexenta_migration_service_prefix',
+               default='cinder-migration',
+               help='Prefix for migration service name'),
+    cfg.StrOpt('nexenta_migration_snapshot_prefix',
+               default='migration-snapshot',
+               help='Prefix for migration snapshot name'),
     cfg.StrOpt('nexenta_origin_snapshot_template',
                default='origin-snapshot-%s',
                help='Template string to generate origin name of clone'),


### PR DESCRIPTION
 NEX-20387 Our provided openstack driver does not deal gracefully with a slow pool
 NEX-18892 Sync Cinder driver from Newton to another Openstack branches

**Pep8**
```
pep8 run-test-pre: PYTHONHASHSEED='1977895257'
pep8 run-test: commands[0] | flake8 .
pep8 run-test: commands[1] | /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 run-test: commands[2] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder /opt/stack/cinder/doc/source/ /opt/stack/cinder/releasenotes/notes
___________________________________ summary ____________________________________
  pep8: commands succeeded
  congratulations :)
```

**Unit tests**
```
======
Totals
======
Ran: 196 tests in 2.0000 sec.
 - Passed: 196
 - Skipped: 0
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 9.4188 sec.
```

**NexentaStor5 NFS functional tests**
```
======
Totals
======
Ran: 273 tests in 4228.0000 sec.
 - Passed: 268
 - Skipped: 5
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3354.3319 sec.
```

**NexentaStor5 iSCSI  functional tests**
```
======
Totals
======
Ran: 273 tests in 5202.0000 sec.
 - Passed: 269
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 4198.1642 sec.
```

**NexentaStor4 iSCSI  functional tests**
```
======
Totals
======
Ran: 270 tests in 4080.0000 sec.
 - Passed: 263
 - Skipped: 7
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3367.9566 sec.
```

**NexentaStor4 NFS  functional tests**
```
======
Totals
======
Ran: 270 tests in 3983.0000 sec.
 - Passed: 262
 - Skipped: 8
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3217.3102 sec.
```