### PR TITLE
Liberty: NEX-20582, NEX-20387 and NEX-18892

### DIFF
--- a/cinder/volume/drivers/nexenta/iscsi.py
+++ b/cinder/volume/drivers/nexenta/iscsi.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Nexenta Systems, Inc. All Rights Reserved.
+# Copyright 2019 Nexenta Systems, Inc. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -12,19 +12,27 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import datetime
+import difflib
+import ipaddress
+import posixpath
+import random
+import uuid
+
+from eventlet import greenthread
+from oslo_log import log as logging
+from oslo_utils import strutils
+from oslo_utils import timeutils
+from oslo_utils import units
 import six
 
-from oslo_log import log as logging
-from oslo_utils import excutils
-
-from cinder import exception
+from cinder import context
 from cinder.i18n import _
+from cinder import objects
 from cinder.volume import driver
 from cinder.volume.drivers.nexenta import jsonrpc
 from cinder.volume.drivers.nexenta import options
-from cinder.volume.drivers.nexenta import utils
 
-VERSION = '1.3.2'
 LOG = logging.getLogger(__name__)
 
 
@@ -51,173 +59,142 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         1.3.0.1 - Target creation refactor.
         1.3.1 - Added ZFS cleanup.
         1.3.2 - Added support for target_portal_group and zvol folder.
+        1.3.3 - Added synchronization for Comstar API calls.
+        1.4.0 - Fixed automatic mode for nexenta_rest_protocol.
+              - Fixed compatibility with initial driver version.
+              - Fixed deletion of temporary snapshots.
+              - Fixed creation of volumes with enabled compression option.
+              - Refactored LUN creation, use host group for LUN mappings.
+              - Refactored storage assisted volume migration.
+              - Added deferred deletion for snapshots.
+              - Added volume multi-attach.
+              - Added report discard support.
+              - Added informative exception messages for REST API.
+              - Added configuration parameters for REST API connect/read.
+                timeouts, connection retries and backoff factor.
+              - Added configuration parameter for LUN writeback cache.
+              - Improved collection of backend statistics.
     """
 
-    VERSION = VERSION
-
-    # ThirdPartySystems wiki page
+    VERSION = '1.4.0'
     CI_WIKI_NAME = "Nexenta_CI"
+
+    vendor_name = 'Nexenta'
+    product_name = 'NexentaStor4'
+    storage_protocol = 'iSCSI'
+    driver_volume_type = 'iscsi'
 
     def __init__(self, *args, **kwargs):
         super(NexentaISCSIDriver, self).__init__(*args, **kwargs)
+        if not self.configuration:
+            message = (_('%(product_name)s %(storage_protocol)s '
+                         'backend configuration not found')
+                       % {'product_name': self.product_name,
+                          'storage_protocol': self.storage_protocol})
+            raise jsonrpc.NmsException(code='ENODATA', message=message)
+        self.configuration.append_config_values(
+            options.NEXENTA_CONNECTION_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_ISCSI_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_DATASET_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_RRMGR_OPTS)
         self.nms = None
-        self.targets = {}
-        if self.configuration:
-            self.configuration.append_config_values(
-                options.NEXENTA_CONNECTION_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_ISCSI_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_DATASET_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_RRMGR_OPTS)
-        self.verify_ssl = self.configuration.driver_ssl_cert_verify
-        self.nms_protocol = self.configuration.nexenta_rest_protocol
-        self.nms_host = self.configuration.nexenta_host
-        self.nms_port = self.configuration.nexenta_rest_port
-        self.nms_user = self.configuration.nexenta_user
-        self.nms_password = self.configuration.nexenta_password
+        self.mappings = {}
+        self.driver_name = self.__class__.__name__
+        self.san_host = self.configuration.nexenta_host
         self.volume = self.configuration.nexenta_volume
         self.folder = self.configuration.nexenta_folder
-        self.tpgs = self.configuration.nexenta_iscsi_target_portal_groups
         self.volume_compression = (
             self.configuration.nexenta_dataset_compression)
-        self.volume_deduplication = self.configuration.nexenta_dataset_dedup
-        self.volume_description = (
-            self.configuration.nexenta_dataset_description)
-        self.rrmgr_compression = self.configuration.nexenta_rrmgr_compression
-        self.rrmgr_tcp_buf_size = self.configuration.nexenta_rrmgr_tcp_buf_size
-        self.rrmgr_connections = self.configuration.nexenta_rrmgr_connections
-        self.iscsi_target_portal_port = (
-            self.configuration.nexenta_iscsi_target_portal_port)
-
-    @property
-    def backend_name(self):
-        backend_name = None
-        if self.configuration:
-            backend_name = self.configuration.safe_get('volume_backend_name')
-        if not backend_name:
-            backend_name = self.__class__.__name__
-        return backend_name
+        self.volume_blocksize = self.configuration.nexenta_blocksize
+        self.volume_sparse = self.configuration.nexenta_sparse
+        self.tpgs = self.configuration.nexenta_iscsi_target_portal_groups
+        self.target_prefix = self.configuration.nexenta_target_prefix
+        self.target_group_prefix = (
+            self.configuration.nexenta_target_group_prefix)
+        self.host_group_prefix = self.configuration.nexenta_host_group_prefix
+        self.lpt = self.configuration.nexenta_luns_per_target
+        self.portal_port = self.configuration.nexenta_iscsi_target_portal_port
+        self.origin_snapshot_template = (
+            self.configuration.nexenta_origin_snapshot_template)
+        self.migration_snapshot_prefix = (
+            self.configuration.nexenta_migration_snapshot_prefix)
+        self.migration_service_prefix = (
+            self.configuration.nexenta_migration_service_prefix)
+        self.migration_throttle = (
+            self.configuration.nexenta_migration_throttle)
+        if self.folder:
+            self.root_path = posixpath.join(self.volume, self.folder)
+        else:
+            self.root_path = self.volume
 
     def do_setup(self, context):
-        if self.nms_protocol == 'auto':
-            protocol, auto = 'http', True
-        else:
-            protocol, auto = self.nms_protocol, False
-        self.nms = jsonrpc.NexentaJSONProxy(
-            protocol, self.nms_host, self.nms_port, '/rest/nms', self.nms_user,
-            self.nms_password, self.verify_ssl, auto=auto)
+        self.nms = jsonrpc.NmsProxy(self.driver_volume_type,
+                                    self.root_path,
+                                    self.configuration)
 
     def check_for_setup_error(self):
-        """Verify that the volume for our zvols exists.
-
-        :raise: :py:exc:`LookupError`
-        """
+        """Verify that the volume, folder and tpgs exists."""
         if not self.nms.volume.object_exists(self.volume):
-            raise LookupError(_("Volume %s does not exist in Nexenta SA") %
-                              self.volume)
-        if self.folder:
-            folder = '%s/%s' % (self.volume, self.folder)
-            if not self.nms.folder.object_exists(folder):
-                raise LookupError(_("Folder %s does not exist in Nexenta "
-                                    "Store appliance"), folder)
+            message = (_('Volume %(volume)s not found')
+                       % {'volume': self.volume})
+            raise jsonrpc.NmsException(code='ENOENT', message=message)
+        if not self.nms.folder.object_exists(self.root_path):
+            message = (_('Folder %(folder)s not found')
+                       % {'folder': self.root_path})
+            raise jsonrpc.NmsException(code='ENOENT', message=message)
+        host_tpgs = self.nms.iscsitarget.list_tpg()
+        for tpg in self.tpgs:
+            if tpg in host_tpgs:
+                continue
+            message = (_('Target portal group %(tpg)s not found')
+                       % {'tpg': tpg})
+            raise jsonrpc.NmsException(code='ENOENT', message=message)
 
-    def _get_zvol_name(self, volume_name):
-        """Return zvol name that corresponds given volume name."""
-        if self.folder:
-            path = '%s/%s' % (self.volume, self.folder)
-        else:
-            path = self.volume
-        return '%s/%s' % (path, volume_name)
+    def _get_volume_path(self, volume):
+        """Return ZFS datset path for the volume."""
+        return posixpath.join(self.root_path, volume['name'])
 
-    def _create_target(self, target_idx):
-        target_name = '%s-%s-%i' % (
-            self.configuration.nexenta_target_prefix,
-            self.nms_host,
-            target_idx
-        )
-        target_group_name = self._get_target_group_name(target_name)
-
-        if not self._target_exists(target_name):
-            try:
-                self.nms.iscsitarget.create_target({
-                    'target_name': target_name,
-                    'tpgs': self.tpgs})
-            except exception.NexentaException as exc:
-                if 'already' in exc.args[0]:
-                    LOG.info('Ignored target creation error %s while '
-                             'ensuring export.',
-                             exc)
-                else:
-                    raise
-        if not self._target_group_exists(target_group_name):
-            try:
-                self.nms.stmf.create_targetgroup(target_group_name)
-            except exception.NexentaException as exc:
-                if ('already' in exc.args[0]):
-                    LOG.info('Ignored target group creation error %s '
-                             'while ensuring export.',
-                             exc)
-                else:
-                    raise
-        if not self._target_member_in_target_group(target_group_name,
-                                                   target_name):
-            try:
-                self.nms.stmf.add_targetgroup_member(target_group_name,
-                                                     target_name)
-            except exception.NexentaException as exc:
-                if ('already' in exc.args[0]):
-                    LOG.info('Ignored target group member addition error '
-                             '%s while ensuring export.', exc)
-                else:
-                    raise
-
-        self.targets[target_name] = []
-        return target_name
-
-    def _get_target_name(self, volume):
-        """Return iSCSI target name with least LUs."""
-        provider_location = volume.get('provider_location')
-        target_names = self.targets.keys()
-        if provider_location:
-            target_name = provider_location.split(',1 ')[1].split(' ')[0]
-            if not(self.targets.get(target_name)):
-                self.targets[target_name] = []
-            if not(volume['name'] in self.targets[target_name]):
-                self.targets[target_name].append(volume['name'])
-        elif not(target_names):
-            # create first target and target group
-            target_name = self._create_target(0)
-            self.targets[target_name].append(volume['name'])
-        else:
-            target_name = target_names[0]
-            for target in target_names:
-                if len(self.targets[target]) < len(self.targets[target_name]):
-                    target_name = target
-            if len(self.targets[target_name]) >= 20:
-                # create new target and target group
-                target_name = self._create_target(len(target_names))
-            if not(volume['name'] in self.targets[target_name]):
-                self.targets[target_name].append(volume['name'])
-        return target_name
-
-    def _get_target_group_name(self, target_name):
-        """Return Nexenta iSCSI target group name for volume."""
-        return target_name.replace(
-            self.configuration.nexenta_target_prefix,
-            self.configuration.nexenta_target_group_prefix
-        )
+    def _get_snapshot_path(self, snapshot):
+        """Return ZFS snapshot path for the snapshot."""
+        volume_name = snapshot['volume_name']
+        snapshot_name = snapshot['name']
+        volume_path = posixpath.join(self.root_path, volume_name)
+        return '%s@%s' % (volume_path, snapshot_name)
 
     @staticmethod
-    def _get_clone_snapshot_name(volume):
-        """Return name for snapshot that will be used to clone the volume."""
-        return 'cinder-clone-snapshot-%(id)s' % volume
+    def _match_template(template, name):
+        sequence = difflib.SequenceMatcher(None, name, template)
+        added = deleted = result = ''
+        for tag, a1, a2, b1, b2 in sequence.get_opcodes():
+            if tag == 'equal':
+                result += ''.join(sequence.a[a1:a2])
+            elif tag == 'delete':
+                deleted += ''.join(sequence.a[a1:a2])
+            elif tag == 'insert':
+                added += ''.join(sequence.b[b1:b2])
+            elif tag == 'replace':
+                result += ''.join(sequence.b[b1:b2])
+        if result == template and not (added or deleted):
+            return True
+        return False
 
-    @staticmethod
-    def _is_clone_snapshot_name(snapshot):
-        """Check if snapshot is created for cloning."""
-        return snapshot.startswith('cinder-clone-snapshot-')
+    def _create_target_group(self, group, target):
+        """Create a new target group with target member.
+
+        :param group: group name
+        :param target: group member
+        """
+        if not self._target_exists(target):
+            tpgs = ','.join(self.tpgs)
+            payload = {
+                'target_name': target,
+                'tpgs': tpgs
+            }
+            self.nms.iscsitarget.create_target(payload)
+        if not self._target_group_exists(group):
+            self.nms.stmf.create_targetgroup(group)
+        if not self._target_member_in_target_group(group, target):
+            self.nms.stmf.add_targetgroup_member(group, target)
 
     def create_volume(self, volume):
         """Create a zvol on appliance.
@@ -225,16 +202,15 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: volume reference
         :return: model update dict for volume reference
         """
-        try:
-            self.nms.zvol.create(
-                self._get_zvol_name(volume['name']),
-                '%sG' % (volume['size'],),
-                six.text_type(self.configuration.nexenta_blocksize),
-                self.configuration.nexenta_sparse)
-        except exception.NexentaException as exc:
-            if 'already exists' in exc.args[0]:
-                return
-            raise
+        volume_path = self._get_volume_path(volume)
+        volume_size = '%sG' % volume['size']
+        volume_blocksize = six.text_type(self.volume_blocksize)
+        volume_sparsed = self.volume_sparse
+        volume_options = {'compression': self.volume_compression}
+        self.nms.zvol.create_with_props(volume_path, volume_size,
+                                        volume_blocksize,
+                                        volume_sparsed,
+                                        volume_options)
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -242,39 +218,37 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: volume reference
         :param new_size: volume new size in GB
         """
-        LOG.info('Extending volume: %(id)s New size: %(size)s GB',
-                 {'id': volume['id'], 'size': new_size})
-        self.nms.zvol.set_child_prop(self._get_zvol_name(volume['name']),
-                                     'volsize', '%sG' % new_size)
+        volume_path = self._get_volume_path(volume)
+        volume_size = '%sG' % new_size
+        self.nms.zvol.set_child_prop(volume_path, 'volsize', volume_size)
 
     def delete_volume(self, volume):
-        """Destroy a zvol on appliance.
+        """Deletes a logical volume.
 
         :param volume: volume reference
         """
-        volume_name = self._get_zvol_name(volume['name'])
+        volume_path = self._get_volume_path(volume)
         try:
-            origin = self.nms.zvol.get_child_props(
-                volume_name, 'origin').get('origin')
-            self.nms.zvol.destroy(volume_name, '-r')
-        except exception.NexentaException as exc:
-            if 'does not exist' in exc.args[0]:
-                LOG.info('Volume %s does not exist, it '
-                         'seems it was already deleted.', volume_name)
-                return
-            if 'has children' in exc.args[0]:
-                LOG.info('Volume %s will be deleted later.', volume_name)
+            origin = self.nms.zvol.get_child_prop(volume_path, 'origin')
+        except jsonrpc.NmsException as error:
+            if error.code == 'ENOENT':
                 return
             raise
-        if origin and self._is_clone_snapshot_name(origin):
-            try:
-                self.nms.snapshot.destroy(origin, '')
-            except exception.NexentaException as exc:
-                if 'does not exist' in exc.args[0]:
-                    LOG.info('Snapshot %s does not exist, it was '
-                             'already deleted.', origin)
-                    return
-                raise
+        self.nms.zvol.destroy(volume_path, '-r')
+        if not origin:
+            return
+        template = self.origin_snapshot_template
+        parent_path, snapshot_name = origin.split('@')
+        if not self._match_template(template, snapshot_name):
+            return
+        try:
+            self.nms.snapshot.destroy(origin, '-d')
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to delete origin snapshot %(origin)s '
+                      'of volume %(volume)s: %(error)s',
+                      {'origin': origin,
+                       'volume': volume['name'],
+                       'error': error})
 
     def create_cloned_volume(self, volume, src_vref):
         """Creates a clone of the specified volume.
@@ -282,212 +256,460 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: new volume reference
         :param src_vref: source volume reference
         """
-        snapshot = {'volume_name': src_vref['name'],
-                    'name': self._get_clone_snapshot_name(volume),
-                    'volume_size': src_vref['size']}
-        LOG.debug('Creating temp snapshot of the original volume: '
-                  '%(volume_name)s@%(name)s', snapshot)
-        # We don't delete this snapshot, because this snapshot will be origin
-        # of new volume. This snapshot will be automatically promoted by NMS
-        # when user will delete origin volume. But when cloned volume deleted
-        # we check its origin property and delete source snapshot if needed.
+        snapshot = {
+            'name': self.origin_snapshot_template % volume['id'],
+            'volume_id': src_vref['id'],
+            'volume_name': src_vref['name'],
+            'volume_size': src_vref['size']
+        }
         self.create_snapshot(snapshot)
         try:
             self.create_volume_from_snapshot(volume, snapshot)
-        except exception.NexentaException:
-            with excutils.save_and_reraise_exception():
-                LOG.exception('Volume creation failed, deleting created '
-                              'snapshot %(volume_name)s@%(name)s', snapshot)
-            try:
-                self.delete_snapshot(snapshot)
-            except (exception.NexentaException, exception.SnapshotIsBusy):
-                LOG.warning('Failed to delete zfs snapshot '
-                            '%(volume_name)s@%(name)s', snapshot)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to create clone %(clone)s '
+                      'from volume %(volume)s: %(error)s',
+                      {'clone': volume['name'],
+                       'volume': src_vref['name'],
+                       'error': error})
             raise
-
-    def _get_zfs_send_recv_cmd(self, src, dst):
-        """Returns rrmgr command for source and destination."""
-        return utils.get_rrmgr_cmd(src, dst,
-                                   compression=self.rrmgr_compression,
-                                   tcp_buf_size=self.rrmgr_tcp_buf_size,
-                                   connections=self.rrmgr_connections)
-
-    @staticmethod
-    def get_nms_for_url(url):
-        """Returns initialized nms object for url."""
-        auto, scheme, user, password, host, port, path = (
-            utils.parse_nms_url(url))
-        return jsonrpc.NexentaJSONProxy(scheme, host, port, path, user,
-                                        password, auto=auto)
-
-    def migrate_volume(self, ctxt, volume, host):
-        """Migrate if volume and host are managed by Nexenta appliance.
-
-        :param ctxt: context
-        :param volume: a dictionary describing the volume to migrate
-        :param host: a dictionary describing the host to migrate to
-        """
-        LOG.debug('Enter: migrate_volume: id=%(id)s, host=%(host)s',
-                  {'id': volume['id'], 'host': host})
-        false_ret = (False, None)
-
-        if volume['status'] not in ('available', 'retyping'):
-            return false_ret
-
-        if 'capabilities' not in host:
-            return false_ret
-
-        capabilities = host['capabilities']
-
-        if ('location_info' not in capabilities or
-                'iscsi_target_portal_port' not in capabilities or
-                'nms_url' not in capabilities):
-            return false_ret
-
-        nms_url = capabilities['nms_url']
-        dst_parts = capabilities['location_info'].split(':')
-
-        if (capabilities.get('vendor_name') != 'Nexenta' or
-                dst_parts[0] != self.__class__.__name__ or
-                capabilities['free_capacity_gb'] < volume['size']):
-            return false_ret
-
-        dst_host, dst_volume = dst_parts[1:]
-
-        ssh_bound = False
-        ssh_bindings = self.nms.appliance.ssh_list_bindings()
-        for bind in ssh_bindings:
-            if dst_host.startswith(bind.split('@')[1].split(':')[0]):
-                ssh_bound = True
-                break
-        if not ssh_bound:
-            LOG.warning("Remote NexentaStor appliance at %s should be "
-                        "SSH-bound.", dst_host)
-
-        # Create temporary snapshot of volume on NexentaStor Appliance.
-        snapshot = {
-            'volume_name': volume['name'],
-            'name': utils.get_migrate_snapshot_name(volume)
-        }
-        self.create_snapshot(snapshot)
-
-        src = '%(volume)s/%(zvol)s@%(snapshot)s' % {
-            'volume': self.volume,
-            'zvol': volume['name'],
-            'snapshot': snapshot['name']
-        }
-        dst = ':'.join([dst_host, dst_volume])
-
-        try:
-            self.nms.appliance.execute(self._get_zfs_send_recv_cmd(src, dst))
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot send source snapshot %(src)s to "
-                        "destination %(dst)s. Reason: %(exc)s",
-                        {'src': src, 'dst': dst, 'exc': exc})
-            return false_ret
         finally:
             try:
                 self.delete_snapshot(snapshot)
-            except exception.NexentaException as exc:
-                LOG.warning("Cannot delete temporary source snapshot "
-                            "%(src)s on NexentaStor Appliance: %(exc)s",
-                            {'src': src, 'exc': exc})
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to delete temporary snapshot '
+                          '%(volume)s@%(snapshot)s: %(error)s',
+                          {'volume': src_vref['name'],
+                           'snapshot': snapshot['name'],
+                           'error': error})
+
+    def _get_bound_host(self, host):
+        """Get user@host:port from SSH bindings."""
         try:
-            self.delete_volume(volume)
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot delete source volume %(volume)s on "
-                        "NexentaStor Appliance: %(exc)s",
-                        {'volume': volume['name'], 'exc': exc})
+            bindings = self.nms.appliance.ssh_list_bindings()
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get SSH bindings: %(error)s',
+                      {'error': error})
+            return None
+        for user_host_port in bindings:
+            binding = bindings[user_host_port]
+            if not (isinstance(binding, list) and len(binding) == 4):
+                LOG.warning('Skip incompatible SSH binding: %(binding)s',
+                            {'binding': binding})
+                continue
+            data = binding[2]
+            items = data.split(',')
+            for item in items:
+                if host == item.strip():
+                    return user_host_port
+        return None
 
-        dst_nms = self.get_nms_for_url(nms_url)
-        dst_snapshot = '%s/%s@%s' % (dst_volume, volume['name'],
-                                     snapshot['name'])
+    def _svc_state(self, fmri, state):
+        retries = 10
+        delay = 30
+        while retries:
+            greenthread.sleep(delay)
+            retries -= 1
+            try:
+                status = self.nms.autosvc.get_state(fmri)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to get state of migration '
+                          'service %(fmri)s: %(error)s',
+                          {'fmri': fmri, 'error': error})
+                continue
+            if status == 'uninitialized':
+                continue
+            elif status == state:
+                return True
+            if state == 'online':
+                method = getattr(self.nms.autosvc, 'enable')
+            elif state == 'disabled':
+                method = getattr(self.nms.autosvc, 'disable')
+            else:
+                LOG.error('Request unknown service state: %(state)s',
+                          {'state': state})
+                return False
+            try:
+                method(fmri)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to change state of migration service '
+                          '%(fmri)s to %(state)s: %(error)s',
+                          {'fmri': fmri, 'state': state, 'error': error})
+        LOG.error('Unable to change state of migration service %(fmri)s '
+                  'to %(state)s: maximum retries exceeded',
+                  {'fmri': fmri, 'state': state})
+        return False
+
+    def _svc_progress(self, fmri):
+        """Get progress for SMF service."""
+        progress = 0
         try:
-            dst_nms.snapshot.destroy(dst_snapshot, '')
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot delete temporary destination snapshot "
-                        "%(dst)s on NexentaStor Appliance: %(exc)s",
-                        {'dst': dst_snapshot, 'exc': exc})
-        return True, None
+            estimations = self.nms.autosync.get_estimations(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get estimations for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return progress
+        size = estimations.get('curt_siz')
+        sent = estimations.get('curt_sen')
+        try:
+            size = float(size)
+            sent = float(sent)
+            if size > 0:
+                progress = int(100 * sent / size)
+        except (TypeError, ValueError) as error:
+            LOG.error('Failed to parse estimations statistics '
+                      '%(estimations)s for migration service '
+                      '%(fmri)s: %(error)s',
+                      {'estimations': estimations,
+                       'fmri': fmri, 'error': error})
+        return progress
 
-    def retype(self, context, volume, new_type, diff, host):
-        """Convert the volume to be of the new type.
+    def _svc_result(self, fmri):
+        try:
+            props = self.nms.autosvc.get_child_props(fmri, '')
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get properties of migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return False
+        history = props.get('zfs/run_history')
+        if not history:
+            LOG.error('Failed to get history of migration service '
+                      '%(fmri)s: %(props)s',
+                      {'fmri': fmri, 'props': props})
+            return False
+        results = history.split()
+        if len(results) > 1:
+            LOG.warning('Found unexpected replication sessions for '
+                        'migration service %(fmri)s: %(history)s',
+                        {'fmri': fmri, 'history': history})
+        latest = results.pop()
+        start, stop, code = latest.split('::')
+        try:
+            start = int(start)
+            stop = int(stop)
+            code = int(code)
+        except (TypeError, ValueError) as error:
+            LOG.error('Failed to parse history %(history)s for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'history': history, 'fmri': fmri, 'error': error})
+            return False
+        delta = stop - start
+        if code != 1:
+            LOG.error('Migration service %(fmri)s failed after %(delta)s '
+                      'seconds, please check the service log below',
+                      {'fmri': fmri, 'delta': delta})
+            return False
+        LOG.info('Migration service %(fmri)s successfully finished in '
+                 '%(delta)s seconds',
+                 {'fmri': fmri, 'delta': delta})
+        return True
 
-        :param ctxt: Context
+    def _svc_cleanup(self, fmri, migrated=False):
+        props = None
+        flags = {
+            'src_properties': '1',
+            'dst_properties': '1',
+            'src_snapshots': '1',
+            'dst_snapshots': '1'
+        }
+        if not migrated:
+            flags['dst_datasets'] = '1'
+        try:
+            props = self.nms.autosvc.get_child_props(fmri, '')
+            props['zfs/sync-recursive'] = '1'
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get properties of migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        try:
+            self.nms.autosvc.unschedule(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to unschedule migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        self._svc_state(fmri, 'disabled')
+        try:
+            self.nms.autosvc.destroy(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to destroy migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        if not props:
+            return
+        try:
+            src_pid, dst_pid = self.nms.autosync.cleanup(props, flags)
+        except jsonrpc.NmsException as error:
+            src_pid = dst_pid = 0
+            LOG.error('Failed to cleanup migration service %(fmri)s: '
+                      '%(error)s',
+                      {'fmri': fmri, 'error': error})
+        for pid in [src_pid, dst_pid]:
+            while pid:
+                try:
+                    self.nms.job.get_jobparams(pid)
+                except jsonrpc.NmsException as error:
+                    if error.code == 'ENOENT':
+                        break
+                greenthread.sleep(30)
+        if migrated:
+            return
+        path = props.get('restarter/logfile')
+        if not path:
+            return
+        try:
+            content = self.nms.logviewer.get_tail(path, units.Mi)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get log file content for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return
+        log = '\n'.join(content)
+        LOG.error('Migration service %(fmri)s log: %(log)s',
+                  {'fmri': fmri, 'log': log})
+
+    def _migrate_volume(self, volume, host, path):
+        delay = 30
+        retries = 10
+        src_path = self._get_volume_path(volume)
+        dst_path = posixpath.join(path, volume['name'])
+        hosts = self._get_host_addresses()
+        if host in hosts:
+            dst_host = 'localhost'
+            service_direction = '0'
+            service_proto = 'zfs'
+            if src_path == dst_path:
+                LOG.info('Skip local to local replication: source '
+                         'volume %(src_path)s and destination volume '
+                         '%(dst_path)s are the same local volume',
+                         {'src_path': src_path, 'dst_path': dst_path})
+                return True
+        else:
+            service_direction = '1'
+            service_proto = 'zfs+rr'
+            dst_host = self._get_bound_host(host)
+            if not dst_host:
+                LOG.error('Storage assisted volume migration is '
+                          'unavailable: the destination host '
+                          '%(host)s should be SSH bound',
+                          {'host': host})
+                return False
+        service_name = '%(prefix)s-%(volume)s' % {
+            'prefix': self.migration_service_prefix,
+            'volume': volume['name']
+        }
+        comment = 'Migrate %(src)s to %(host)s:%(dst)s' % {
+            'src': src_path,
+            'host': dst_host,
+            'dst': dst_path
+        }
+        yesterday = timeutils.utcnow() - datetime.timedelta(days=1)
+        dst_path = path
+        rate_limit = 0
+        if self.migration_throttle:
+            rate_limit = self.migration_throttle * units.Ki
+        payload = {
+            'comment': comment,
+            'custom_name': service_name,
+            'from-fs': src_path,
+            'to-host': dst_host,
+            'to-fs': dst_path,
+            'direction': service_direction,
+            'marker_name': self.migration_snapshot_prefix,
+            'proto': service_proto,
+            'day': six.text_type(yesterday.day),
+            'rate_limit': six.text_type(rate_limit),
+            '_unique': 'type from-host from-fs to-host to-fs',
+            'method': 'sync',
+            'from-host': 'localhost',
+            'period_multiplier': '1',
+            'keep_src': '1',
+            'keep_dst': '1',
+            'trace_level': '30',
+            'type': 'monthly',
+            'nconn': '2',
+            'period': '12',
+            'mbuffer_size': '16',
+            'minute': '0',
+            'hour': '0',
+            'flags': '0',
+            'estimations': '0',
+            'force': '0',
+            'reverse_capable': '0',
+            'sync-recursive': '0',
+            'auto-clone': '0',
+            'flip_options': '0',
+            'direction_flipped': '0',
+            'retry': '0',
+            'success_counter': '0',
+            'dircontent': '0',
+            'zip_level': '0',
+            'auto-mount': '0',
+            'marker': '',
+            'exclude': '',
+            'run_history': '',
+            'progress-marker': '',
+            'from-snapshot': '',
+            'latest-suffix': '',
+            'trunk': '',
+            'options': ''
+        }
+        try:
+            fmri = self.nms.autosvc.fmri_create('auto-sync', comment,
+                                                src_path, 0, payload)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to create migration service '
+                      'with payload %(payload)s: %(error)s',
+                      {'payload': payload, 'error': error})
+            return False
+        if not self._svc_state(fmri, 'online'):
+            self._svc_cleanup(fmri)
+            return False
+        service_running = False
+        try:
+            self.nms.autosvc.execute(fmri)
+            service_running = True
+            LOG.info('Migration service %(fmri)s successfully started',
+                     {'fmri': fmri})
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to start migration service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        if not service_running:
+            LOG.error('Migration service %(fmri)s is offline',
+                      {'fmri': fmri})
+            self._svc_cleanup(fmri)
+            return False
+        service_history = None
+        service_retries = retries
+        service_progress = 0
+        while service_retries and not service_history:
+            greenthread.sleep(delay)
+            service_retries -= 1
+            try:
+                service_props = self.nms.autosvc.get_child_props(fmri, '')
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to get properties of migration service '
+                          '%(fmri)s: %(error)s',
+                          {'fmri': fmri, 'error': error})
+                continue
+            service_history = service_props.get('zfs/run_history')
+            service_started = service_props.get('zfs/time_started')
+            if service_started == 'N/A':
+                continue
+            progress = self._svc_progress(fmri)
+            if progress > service_progress:
+                service_progress = progress
+                service_retries = retries
+            LOG.info('Migration service %(fmri)s replication progress: '
+                     '%(service_progress)s%%',
+                     {'fmri': fmri, 'service_progress': service_progress})
+        if not service_history:
+            self._svc_cleanup(fmri)
+            return False
+        volume_migrated = self._svc_result(fmri)
+        self._svc_cleanup(fmri, volume_migrated)
+        if volume_migrated:
+            try:
+                self.delete_volume(volume)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to delete source volume %(volume)s '
+                          'after successful migration: %(error)s',
+                          {'volume': volume['name'], 'error': error})
+        return volume_migrated
+
+    def migrate_volume(self, context, volume, host):
+        """Migrate the volume to the specified host.
+
+        Returns a boolean indicating whether the migration occurred,
+        as well as model_update.
+
+        :param context: Security context
         :param volume: A dictionary describing the volume to migrate
-        :param new_type: A dictionary describing the volume type to convert to
-        :param diff: A dictionary with the difference between the two types
         :param host: A dictionary describing the host to migrate to, where
                      host['host'] is its name, and host['capabilities'] is a
                      dictionary of its reported capabilities.
         """
-        LOG.debug('Retype volume request %(vol)s to be %(type)s '
-                  '(host: %(host)s), diff %(diff)s.',
-                  {'vol': volume['name'],
-                   'type': new_type,
-                   'host': host,
-                   'diff': diff})
-
-        options = dict(
-            compression='compression',
-            dedup='dedup',
-            description='nms:description'
-        )
-
-        retyped = False
-        migrated = False
-
+        LOG.info('Start storage assisted volume migration '
+                 'for volume %(volume)s to host %(host)s',
+                 {'volume': volume['name'],
+                  'host': host['host']})
+        false_ret = (False, None)
+        if 'capabilities' not in host:
+            LOG.error('No host capabilities found for '
+                      'the destination host %(host)s',
+                      {'host': host['host']})
+            return false_ret
         capabilities = host['capabilities']
-        src_backend = self.__class__.__name__
-        dst_backend = capabilities['location_info'].split(':')[0]
-        if src_backend != dst_backend:
-            LOG.warning('Cannot retype from %(src_backend)s to '
-                        '%(dst_backend)s.',
-                        {
-                            'src_backend': src_backend,
-                            'dst_backend': dst_backend,
-                        })
-            return False
+        required_capabilities = [
+            'vendor_name',
+            'location_info',
+            'storage_protocol',
+            'free_capacity_gb'
+        ]
+        for capability in required_capabilities:
+            if capability not in capabilities:
+                LOG.error('Required host capability %(capability)s not '
+                          'found for the destination host %(host)s',
+                          {'capability': capability, 'host': host['host']})
+                return false_ret
+        vendor = capabilities['vendor_name']
+        if vendor != self.vendor_name:
+            LOG.error('Unsupported vendor %(vendor)s found '
+                      'for the destination host %(host)s',
+                      {'vendor': vendor, 'host': host['host']})
+            return false_ret
+        location = capabilities['location_info']
+        try:
+            driver, san_host, san_path = location.split(':')
+        except ValueError as error:
+            LOG.error('Failed to parse location info %(location)s '
+                      'for the destination host %(host)s: %(error)s',
+                      {'location': location, 'host': host['host'],
+                       'error': error})
+            return false_ret
+        if not (driver and san_host and san_path):
+            LOG.error('Incomplete location info %(location)s '
+                      'found for the destination host %(host)s',
+                      {'location': location, 'host': host['host']})
+            return false_ret
+        if driver != self.driver_name:
+            LOG.error('Unsupported storage driver %(driver)s '
+                      'found for the destination host %(host)s',
+                      {'driver': driver, 'host': host['host']})
+            return false_ret
+        storage_protocol = capabilities['storage_protocol']
+        if storage_protocol != self.storage_protocol:
+            LOG.error('Unsupported storage protocol %(protocol)s '
+                      'found for the destination host %(host)s',
+                      {'protocol': storage_protocol,
+                       'host': host['host']})
+            return false_ret
+        free_capacity_gb = capabilities['free_capacity_gb']
+        if free_capacity_gb < volume['size']:
+            LOG.error('There is not enough space available on the '
+                      'destination host %(host)s to migrate volume '
+                      '%(volume)s, available space: %(free)sG, '
+                      'required space: %(required)sG',
+                      {'host': host['host'], 'volume': volume['name'],
+                       'free': free_capacity_gb,
+                       'required': volume['size']})
+            return false_ret
+        if self._migrate_volume(volume, san_host, san_path):
+            return (True, None)
+        return false_ret
 
-        hosts = (volume['host'], host['host'])
-        old, new = hosts
-        if old != new:
-            migrated, provider_location = self.migrate_volume(
-                context, volume, host)
-
-        if not migrated:
-            nms = self.nms
-        else:
-            nms_url = capabilities['nms_url']
-            nms = self.get_nms_for_url(nms_url)
-
-        zvol = '%s/%s' % (
-            capabilities['location_info'].split(':')[-1], volume['name'])
-
-        for opt in options:
-            old, new = diff.get('extra_specs').get(opt, (False, False))
-            if old != new:
-                LOG.debug('Changing %(opt)s from %(old)s to %(new)s.',
-                          {'opt': opt, 'old': old, 'new': new})
-                try:
-                    nms.zvol.set_child_prop(
-                        zvol, options[opt], new)
-                    retyped = True
-                except exception.NexentaException:
-                    LOG.error('Error trying to change %(opt)s'
-                              ' from %(old)s to %(new)s',
-                              {'opt': opt, 'old': old, 'new': new})
-                    return False, None
-        return retyped or migrated, None
+    def retype(self, context, volume, new_type, diff, host):
+        """Convert the volume to be of the new type."""
+        pass
 
     def create_snapshot(self, snapshot):
-        """Create snapshot of existing zvol on appliance.
+        """Creates a snapshot.
 
         :param snapshot: snapshot reference
         """
-        self.nms.zvol.create_snapshot(
-            self._get_zvol_name(snapshot['volume_name']),
-            snapshot['name'], '')
+        snapshot_path = self._get_snapshot_path(snapshot)
+        volume_path, snapshot_name = snapshot_path.split('@')
+        self.nms.zvol.create_snapshot(volume_path, snapshot_name, '')
 
     def create_volume_from_snapshot(self, volume, snapshot):
         """Create new volume from other's snapshot on appliance.
@@ -495,12 +717,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: reference of volume to be created
         :param snapshot: reference of source snapshot
         """
-        self.nms.zvol.clone(
-            '%s@%s' % (self._get_zvol_name(snapshot['volume_name']),
-                       snapshot['name']),
-            self._get_zvol_name(volume['name']))
-        if (('size' in volume) and (
-                volume['size'] > snapshot['volume_size'])):
+        snapshot_path = self._get_snapshot_path(snapshot)
+        clone_path = self._get_volume_path(volume)
+        self.nms.zvol.clone(snapshot_path, clone_path)
+        if volume['size'] > snapshot['volume_size']:
             self.extend_volume(volume, volume['size'])
 
     def delete_snapshot(self, snapshot):
@@ -508,28 +728,11 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
 
         :param snapshot: snapshot reference
         """
-        volume_name = self._get_zvol_name(snapshot['volume_name'])
-        snapshot_name = '%s@%s' % (volume_name, snapshot['name'])
-        try:
-            self.nms.snapshot.destroy(snapshot_name, '')
-        except exception.NexentaException as exc:
-            if "does not exist" in exc.args[0]:
-                LOG.info('Snapshot %s does not exist, it seems it was '
-                         'already deleted.', snapshot_name)
-                return
-            elif "snapshot has dependent clones" in exc.args[0]:
-                LOG.info('Snapshot %s has dependent clones, will be '
-                         'deleted later.', snapshot_name)
-                return
-            raise
+        snapshot_path = self._get_snapshot_path(snapshot)
+        self.nms.snapshot.destroy(snapshot_path, '-d')
 
     def local_path(self, volume):
-        """Return local path to existing local volume.
-
-        We never have local volumes, so it raises NotImplementedError.
-
-        :raise: :py:exc:`NotImplementedError`
-        """
+        """Return local path to existing local volume."""
         raise NotImplementedError
 
     def _target_exists(self, target):
@@ -539,161 +742,612 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :return: True if target exist, else False
         """
         targets = self.nms.stmf.list_targets()
-        if not targets:
-            return False
-        return (target in self.nms.stmf.list_targets())
+        return target in targets
 
-    def _target_group_exists(self, target_group):
+    def _target_group_exists(self, group):
         """Check if target group exist.
 
-        :param target_group: target group
+        :param group: target group
         :return: True if target group exist, else False
         """
         groups = self.nms.stmf.list_targetgroups()
-        if not groups:
-            return False
-        return target_group in groups
+        return group in groups
 
-    def _target_member_in_target_group(self, target_group, target_member):
+    def _target_member_in_target_group(self, group, member):
         """Check if target member in target group.
 
-        :param target_group: target group
-        :param target_member: target member
+        :param group: target group
+        :param member: target member
         :return: True if target member in target group, else False
         :raises: NexentaException if target group doesn't exist
         """
-        members = self.nms.stmf.list_targetgroup_members(target_group)
-        if not members:
-            return False
-        return target_member in members
+        members = self.nms.stmf.list_targetgroup_members(group)
+        return member in members
 
-    def _lu_exists(self, zvol_name):
+    def _lu_exists(self, volume_path):
         """Check if LU exists on appliance.
 
-        :param zvol_name: Zvol name
-        :raises: NexentaException if zvol not exists
+        :param volume_path: volume path
+        :raises: NmsException if volume not exists
         :return: True if LU exists, else False
         """
         try:
-            return bool(self.nms.scsidisk.lu_exists(zvol_name))
-        except exception.NexentaException as exc:
-            if 'does not exist' not in exc.args[0]:
-                raise
-            return False
+            return bool(self.nms.scsidisk.lu_exists(volume_path))
+        except jsonrpc.NmsException as error:
+            if error.code == 'ENOENT':
+                return False
+            raise
 
-    def _is_lu_shared(self, zvol_name):
+    def _is_lu_shared(self, volume_path):
         """Check if LU exists on appliance and shared.
 
-        :param zvol_name: Zvol name
-        :raises: NexentaException if Zvol not exist
+        :param volume_path: volume path
+        :raises: NmsException if volume not exist
         :return: True if LU exists and shared, else False
         """
         try:
-            shared = self.nms.scsidisk.lu_shared(zvol_name) > 0
-        except exception.NexentaException as exc:
-            if 'does not exist for zvol' not in exc.args[0]:
-                raise  # Zvol does not exists
-            shared = False  # LU does not exist
-        return shared
+            return bool(self.nms.scsidisk.lu_shared(volume_path))
+        except jsonrpc.NmsException as error:
+            if error.code == 'ENOENT':
+                return False
+            raise
 
-    def create_export(self, _ctx, volume, connector):
-        """Create new export for zvol.
+    def create_export(self, context, volume, connector):
+        """Driver entry point to get the export info for a new volume."""
+        pass
 
-        :param volume: reference of volume to be exported
-        :return: iscsiadm-formatted provider location string
+    def ensure_export(self, context, volume):
+        """Driver entry point to get the export info for an existing volume."""
+        pass
+
+    def remove_export(self, context, volume):
+        """Driver entry point to remove an export for a volume."""
+        pass
+
+    def _get_host_addresses(self):
+        """Return NexentaStor IP addresses list."""
+        addresses = []
+        items = self.nms.appliance.execute('ipadm show-addr -p -o addr')
+        for item in items:
+            cidr = six.text_type(item)
+            addr, mask = cidr.split('/')
+            obj = ipaddress.ip_address(addr)
+            if not obj.is_loopback:
+                addresses.append(obj.exploded)
+        LOG.debug('Configured IP addresses: %(addresses)s',
+                  {'addresses': addresses})
+        return addresses
+
+    def _get_host_portals(self):
+        """Return NexentaStor iSCSI portals list."""
+        portals = []
+        addresses = self._get_host_addresses()
+        for address in addresses:
+            portal = '%s:%s' % (address, self.portal_port)
+            portals.append(portal)
+        LOG.debug('Configured iSCSI portals: %(portals)s',
+                  {'portals': portals})
+        return portals
+
+    def _get_host_portal_groups(self):
+        """Return NexentaStor iSCSI portal groups dictionary."""
+        portal_groups = {}
+        default_portal = '%s:%s' % (self.san_host, self.portal_port)
+        host_portals = self._get_host_portals()
+        host_portal_groups = self.nms.iscsitarget.list_tpg()
+        for group in host_portal_groups:
+            group_portals = host_portal_groups[group]
+            if not self.tpgs:
+                if default_portal in group_portals:
+                    LOG.debug('Use default portal %(portal)s '
+                              'for portal group %(group)s',
+                              {'portal': default_portal,
+                               'group': group})
+                    portal_groups[group] = [default_portal]
+                continue
+            if group not in self.tpgs:
+                LOG.debug('Skip existing but not configured '
+                          'target portal group %(group)s',
+                          {'group': group})
+                continue
+            portals = []
+            for portal in group_portals:
+                if portal not in host_portals:
+                    LOG.debug('Skip non-existing '
+                              'portal %(portal)s',
+                              {'portal': portal})
+                    continue
+                portals.append(portal)
+            if portals:
+                portal_groups[group] = portals
+        LOG.debug('Configured host target '
+                  'portal groups: %(groups)s',
+                  {'groups': portal_groups})
+        return portal_groups
+
+    def _get_host_targets(self):
+        """Return NexentaStor iSCSI targets dictionary."""
+        targets = {}
+        default_portal = '%s:%s' % (self.san_host, self.portal_port)
+        host_portal_groups = self._get_host_portal_groups()
+        stmf_targets = self.nms.stmf.list_targets()
+        for name in stmf_targets:
+            if not name.startswith(self.target_prefix):
+                LOG.debug('Skip not a cinder target %(name)s',
+                          {'name': name})
+                continue
+            target = stmf_targets[name]
+            if not ('protocol' in target and target['protocol'] == 'iSCSI'):
+                LOG.debug('Skip non-iSCSI target %(target)s',
+                          {'target': target})
+                continue
+            if not ('status' in target and target['status'] == 'Online'):
+                LOG.debug('Skip non-online iSCSI target %(target)s',
+                          {'target': target})
+                continue
+            target_portals = []
+            props = self.nms.iscsitarget.get_target_props(name)
+            if 'tpgs' in props:
+                target_portal_groups = props['tpgs'].split(',')
+                for group in target_portal_groups:
+                    if group not in host_portal_groups:
+                        LOG.debug('Skip existing but unsuitable target portal '
+                                  'group %(group)s for iSCSI target %(name)s',
+                                  {'group': group, 'name': name})
+                        continue
+                    portals = host_portal_groups[group]
+                    target_portals += portals
+            else:
+                portals = [default_portal]
+                target_portals += portals
+            if target_portals:
+                targets[name] = target_portals
+        LOG.debug('Configured iSCSI targets: %(targets)s',
+                  {'targets': targets})
+        return targets
+
+    def _target_group_props(self, group_name, host_targets):
+        """Check existing targets/portals for the given target group.
+
+        :param group_name: target group name
+        :param host_targets: host targets dictionary
+        :returns: dictionary of portals per target
         """
-        model_update = self._do_export(_ctx, volume)
+        if not group_name.startswith(self.target_group_prefix):
+            LOG.debug('Skip not a cinder target group %(group)s',
+                      {'group': group_name})
+            return {}
+        group_targets = self.nms.stmf.list_targetgroup_members(group_name)
+        if not group_targets:
+            LOG.debug('Skip target group %(group)s: group has no members',
+                      {'group': group_name})
+            return {}
+        group_props = {}
+        for target_name in group_targets:
+            if target_name not in host_targets:
+                LOG.debug('Skip existing but unsuitable member '
+                          'of target group %(group)s: %(target)s',
+                          {'group': group_name,
+                           'target': target_name})
+                continue
+            portals = host_targets[target_name]
+            if not portals:
+                LOG.debug('Skip existing but unsuitable member '
+                          'of target group %(group)s: %(target)s',
+                          {'group': group_name,
+                           'target': target_name})
+                continue
+            LOG.debug('Found member of target group %(group)s: '
+                      'iSCSI target %(target)s listening on '
+                      'portals %(portals)s',
+                      {'group': group_name,
+                       'target': target_name,
+                       'portals': portals})
+            group_props[target_name] = portals
+        LOG.debug('Target group %(group)s members: %(members)s',
+                  {'group': group_name,
+                   'members': group_props})
+        return group_props
+
+    def initialize_connection(self, volume, connector):
+        """Do all steps to get zfs volume exported at separate target.
+
+        :param volume: volume reference
+        :param connector: connector reference
+        :returns: dictionary of connection information
+        """
+        volume_path = self._get_volume_path(volume)
+        host_iqn = connector.get('initiator')
+        LOG.debug('Initialize connection for volume: %(volume)s and '
+                  'initiator: %(initiator)s',
+                  {'volume': volume['name'], 'initiator': host_iqn})
+        suffix = uuid.uuid4().hex
+        host_targets = self._get_host_targets()
+        host_groups = ['All']
+        host_group = self._get_host_group(host_iqn)
+        if host_group:
+            host_groups.append(host_group)
+        props_portals = []
+        props_iqns = []
+        props_luns = []
+        mappings = []
+        if self._is_lu_shared(volume_path):
+            mappings = self.nms.scsidisk.list_lun_mapping_entries(volume_path)
+        for mapping in mappings:
+            mapping_lu = int(mapping['lun'])
+            mapping_hg = mapping['host_group']
+            mapping_tg = mapping['target_group']
+            mapping_id = mapping['entry_number']
+            if mapping_tg == 'All':
+                LOG.debug('Delete LUN mapping %(id)s for target group %(tg)s',
+                          {'id': mapping_id, 'tg': mapping_tg})
+                self.nms.scsidisk.remove_lun_mapping_entry(volume_path,
+                                                           mapping_id)
+                continue
+            if mapping_hg not in host_groups:
+                LOG.debug('Skip LUN mapping %(id)s for host group %(hg)s',
+                          {'id': mapping_id, 'hg': mapping_hg})
+                continue
+            group_props = self._target_group_props(mapping_tg,
+                                                   host_targets)
+            if not group_props:
+                LOG.debug('Skip LUN mapping %(id)s for target group %(tg)s',
+                          {'id': mapping_id, 'tg': mapping_tg})
+                continue
+            for target_iqn in group_props:
+                target_portals = group_props[target_iqn]
+                props_portals += target_portals
+                props_iqns += [target_iqn] * len(target_portals)
+                props_luns += [mapping_lu] * len(target_portals)
+
+        props = {}
+        props['discard'] = True
+        props['target_discovered'] = False
+        props['encrypted'] = False
+        props['qos_specs'] = None
+        props['volume_id'] = volume['id']
+        props['access_mode'] = 'rw'
+        multipath = connector.get('multipath', False)
+        if props_luns:
+            if multipath:
+                props['target_portals'] = props_portals
+                props['target_iqns'] = props_iqns
+                props['target_luns'] = props_luns
+            else:
+                index = random.randrange(len(props_luns))
+                props['target_portal'] = props_portals[index]
+                props['target_iqn'] = props_iqns[index]
+                props['target_lun'] = props_luns[index]
+            LOG.debug('Use existing LUN mapping %(props)s',
+                      {'props': props})
+            return {'driver_volume_type': self.driver_volume_type,
+                    'data': props}
+
+        if host_group is None:
+            host_group = '%s-%s' % (self.host_group_prefix, suffix)
+            self._create_host_group(host_group, host_iqn)
+        else:
+            LOG.debug('Use existing host group %(group)s',
+                      {'group': host_group})
+
+        mappings_stat = {}
+        group_targets = {}
+        target_groups = self.nms.stmf.list_targetgroups()
+        for target_group in target_groups:
+            if (target_group in self.mappings and
+                    self.mappings[target_group] >= self.lpt):
+                LOG.debug('Skip existing target group %(group)s: '
+                          '%(count)s LUN mappings limit reached',
+                          {'group': target_group,
+                           'count': self.mappings[target_group]})
+                continue
+            group_props = self._target_group_props(target_group,
+                                                   host_targets)
+            if not group_props:
+                LOG.debug('Skip unsuitable target group %(group)s',
+                          {'group': target_group})
+                continue
+            group_targets[target_group] = group_props
+            if target_group in self.mappings:
+                mappings_stat[target_group] = self.mappings[target_group]
+            else:
+                mappings_stat[target_group] = self.mappings[target_group] = 0
+
+        if mappings_stat:
+            target_group = min(mappings_stat, key=mappings_stat.get)
+            LOG.debug('Use existing target group %(group)s with '
+                      '%(count)s LUN mappings created',
+                      {'group': target_group,
+                       'count': mappings_stat[target_group]})
+        else:
+            target = '%s:%s' % (self.target_prefix, suffix)
+            target_group = '%s-%s' % (self.target_group_prefix, suffix)
+            self._create_target_group(target_group, target)
+            host_targets = self._get_host_targets()
+            group_props = self._target_group_props(target_group, host_targets)
+            group_targets[target_group] = group_props
+            self.mappings[target_group] = 0
+        if not self._lu_exists(volume_path):
+            payload = {'serial': volume['id']}
+            self.nms.scsidisk.create_lu(volume_path, payload)
+        if not self.configuration.nexenta_lu_writebackcache_disabled:
+            self.nms.scsidisk.writeback_cache_enable(volume_path)
+        payload = {
+            'target_group': target_group,
+            'host_group': host_group
+        }
+        entry = self.nms.scsidisk.add_lun_mapping_entry(volume_path, payload)
+        self.mappings[target_group] += 1
+        lun = int(entry['lun'])
+        targets = group_targets[target_group]
+        for target in targets:
+            portals = targets[target]
+            props_portals += portals
+            props_iqns += [target] * len(portals)
+            props_luns += [lun] * len(portals)
+
+        if multipath:
+            props['target_portals'] = props_portals
+            props['target_iqns'] = props_iqns
+            props['target_luns'] = props_luns
+        else:
+            index = random.randrange(len(props_luns))
+            props['target_portal'] = props_portals[index]
+            props['target_iqn'] = props_iqns[index]
+            props['target_lun'] = props_luns[index]
+        LOG.debug('Created new LUN mapping: %(props)s',
+                  {'props': props})
+        return {'driver_volume_type': self.driver_volume_type,
+                'data': props}
+
+    def _get_host_group(self, member):
+        """Find existing host group by group member.
+
+        :param member: host group member
+        :returns: host group name
+        """
+        groups = self.nms.stmf.list_hostgroups()
+        for group in groups:
+            members = self.nms.stmf.list_hostgroup_members(group)
+            if member in members:
+                LOG.debug('Found host group %(group)s for member %(member)s',
+                          {'group': group, 'member': member})
+                return group
+        return None
+
+    def _create_host_group(self, group, member):
+        """Create a new host group.
+
+        :param group: host group name
+        :param member: host group member
+        """
+        LOG.debug('Create new host group %(group)s',
+                  {'group': group})
+        self.nms.stmf.create_hostgroup(group)
+        LOG.debug('Add member %(member)s to host group %(group)s',
+                  {'member': member, 'group': group})
+        self.nms.stmf.add_hostgroup_member(group, member)
+
+    def terminate_connection(self, volume, connector, **kwargs):
+        """Terminate a connection to a volume.
+
+        :param volume: a volume object
+        :param connector: a connector object
+        :returns: dictionary of connection information
+        """
+        info = {'driver_volume_type': self.driver_volume_type, 'data': {}}
+        volume_path = self._get_volume_path(volume)
+        host_groups = []
+        host_iqn = None
+        if isinstance(connector, dict) and 'initiator' in connector:
+            connectors = []
+            if 'volume_attachment' in volume:
+                if isinstance(volume['volume_attachment'], list):
+                    for attachment in volume['volume_attachment']:
+                        if not isinstance(attachment, dict):
+                            continue
+                        if 'connector' not in attachment:
+                            continue
+                        connectors.append(attachment['connector'])
+            if connectors.count(connector) > 1:
+                LOG.debug('Detected %(count)s connections from host '
+                          '%(host_name)s (IP:%(host_ip)s) to volume '
+                          '%(volume)s, skip terminating connection',
+                          {'count': connectors.count(connector),
+                           'host_name': connector.get('host', 'unknown'),
+                           'host_ip': connector.get('ip', 'unknown'),
+                           'volume': volume['name']})
+                return True
+            host_iqn = connector['initiator']
+            host_groups.append('All')
+            host_group = self._get_host_group(host_iqn)
+            if host_group is not None:
+                host_groups.append(host_group)
+            LOG.debug('Terminate connection for volume %(volume)s and '
+                      'initiator %(initiator)s',
+                      {'volume': volume['name'],
+                       'initiator': host_iqn})
+        else:
+            LOG.debug('Terminate all connections for volume %(volume)s',
+                      {'volume': volume['name']})
+
+        if not self._is_lu_shared(volume_path):
+            LOG.debug('No LUN mappings found for volume %(volume)s',
+                      {'volume': volume['name']})
+            return info
+        mappings = self.nms.scsidisk.list_lun_mapping_entries(volume_path)
+        for mapping in mappings:
+            mapping_hg = mapping['host_group']
+            mapping_tg = mapping['target_group']
+            mapping_id = mapping['entry_number']
+            if host_iqn is None or mapping_hg in host_groups:
+                LOG.debug('Delete LUN mapping %(id)s for volume %(volume)s, '
+                          'arget group %(tg)s and host group %(hg)s',
+                          {'id': mapping_id, 'volume': volume['name'],
+                           'tg': mapping_tg, 'hg': mapping_hg})
+                if (mapping_tg in self.mappings and
+                        self.mappings[mapping_tg] > 0):
+                    self.mappings[mapping_tg] -= 1
+                else:
+                    self.mappings[mapping_tg] = 0
+                self.nms.scsidisk.remove_lun_mapping_entry(volume_path,
+                                                           mapping_id)
+            else:
+                LOG.debug('Keep LUN mapping %(id)s for volume %(volume)s, '
+                          'target group %(tg)s and host group %(hg)s',
+                          {'id': mapping_id, 'volume': volume['name'],
+                           'tg': mapping_tg, 'hg': mapping_hg})
+        return info
+
+    def update_migrated_volume(self, context, volume, new_volume,
+                               original_volume_status):
+        """Return model update for migrated volume.
+
+        This method should rename the back-end volume name on the
+        destination host back to its original name on the source host.
+
+        :param context: The context of the caller
+        :param volume: The original volume that was migrated to this backend
+        :param new_volume: The migration volume object that was created on
+                           this backend as part of the migration process
+        :param original_volume_status: The status of the original volume
+        :returns: model_update to update DB with any needed changes
+        """
+        name_id = None
+        volume_path = self._get_volume_path(volume)
+        new_volume_path = self._get_volume_path(new_volume)
+        try:
+            self.terminate_connection(new_volume, None)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to terminate all connections '
+                      'to migrated volume %(volume)s before '
+                      'renaming: %(error)s',
+                      {'volume': new_volume['name'],
+                       'error': error})
+        payload = 'zfs rename %(new_volume)s %(volume)s' % {
+            'new_volume': new_volume_path,
+            'volume': volume_path
+        }
+        try:
+            self.nms.appliance.execute(payload)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to rename volume %(new_volume)s '
+                      'to %(volume)s after migration: %(error)s',
+                      {'new_volume': new_volume['name'],
+                       'volume': volume['name'],
+                       'error': error})
+            name_id = new_volume._name_id or new_volume.id
+        model_update = {'_name_id': name_id}
         return model_update
-
-    def ensure_export(self, _ctx, volume):
-        self._do_export(_ctx, volume)
-
-    def _do_export(self, _ctx, volume):
-        """Recreate parts of export if necessary.
-
-        :param volume: reference of volume to be exported
-        """
-        zvol_name = self._get_zvol_name(volume['name'])
-        target_name = self._get_target_name(volume)
-        target_group_name = self._get_target_group_name(target_name)
-
-        entry = None
-        if not self._lu_exists(zvol_name):
-            try:
-                entry = self.nms.scsidisk.create_lu(zvol_name, {})
-            except exception.NexentaException as exc:
-                if 'in use' not in exc.args[0]:
-                    raise
-                LOG.info('Ignored LU creation error %s while ensuring '
-                         'export.', exc)
-        if not self._is_lu_shared(zvol_name):
-            try:
-                entry = self.nms.scsidisk.add_lun_mapping_entry(zvol_name, {
-                    'target_group': target_group_name})
-            except exception.NexentaException as exc:
-                if 'view entry exists' not in exc.args[0]:
-                    raise
-                LOG.info('Ignored LUN mapping entry addition error %s '
-                         'while ensuring export.', exc)
-        model_update = {}
-        if entry:
-            provider_location = '%(host)s:%(port)s,1 %(name)s %(lun)s' % {
-                'host': self.nms_host,
-                'port': self.configuration.nexenta_iscsi_target_portal_port,
-                'name': target_name,
-                'lun': entry['lun'],
-            }
-            model_update = {'provider_location': provider_location}
-        return model_update
-
-    def remove_export(self, _ctx, volume):
-        """Destroy all resources created to export zvol.
-
-        :param volume: reference of volume to be unexported
-        """
-        target_name = self._get_target_name(volume)
-        self.targets[target_name].remove(volume['name'])
-        zvol_name = self._get_zvol_name(volume['name'])
-        self.nms.scsidisk.delete_lu(zvol_name)
 
     def get_volume_stats(self, refresh=False):
         """Get volume stats.
 
         If 'refresh' is True, run update the stats first.
         """
-        if refresh:
+        if refresh or not self._stats:
             self._update_volume_stats()
 
         return self._stats
 
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor appliance."""
-        LOG.debug('Updating volume stats')
-
-        stats = self.nms.volume.get_child_props(
-            self.configuration.nexenta_volume, 'health|size|used|available')
-
-        total_amount = utils.str2gib_size(stats['size'])
-        free_amount = utils.str2gib_size(stats['available'])
-
-        location_info = '%(driver)s:%(host)s:%(volume)s' % {
-            'driver': self.__class__.__name__,
-            'host': self.nms_host,
-            'volume': self.volume
+        stats = {'available': None, 'used': None}
+        payload = '|'.join(stats.keys())
+        props = self.nms.folder.get_child_props(self.root_path, payload)
+        for key in stats:
+            if not props.get(key):
+                LOG.error('Unable to get %(key)s statistics for %(path)s '
+                          'from properties %(props)s',
+                          {'path': self.root_path, 'props': props})
+                continue
+            text = '%sB' % props[key]
+            try:
+                value = strutils.string_to_bytes(text, return_int=True)
+                stats[key] = value
+            except ValueError as error:
+                LOG.error('Failed to convert text value %(text)s to '
+                          'bytes for the %(key)s property: %(error)s',
+                          {'text': text, 'key': key, 'error': error})
+        if None in stats.values():
+            allocated_capacity_gb = 'unknown'
+            free_capacity_gb = 'unknown'
+            total_capacity_gb = 'unknown'
+        else:
+            free_capacity_gb = stats['available'] // units.Gi
+            allocated_capacity_gb = stats['used'] // units.Gi
+            total_capacity_gb = free_capacity_gb + allocated_capacity_gb
+        provisioned_capacity_gb = total_volumes = 0
+        ctxt = context.get_admin_context()
+        volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        for volume in volumes:
+            provisioned_capacity_gb += volume['size']
+            total_volumes += 1
+        volume_backend_name = (
+            self.configuration.safe_get('volume_backend_name'))
+        if not volume_backend_name:
+            LOG.error('Failed to get configured volume backend name')
+            volume_backend_name = '%(product)s_%(protocol)s' % {
+                'product': self.product_name,
+                'protocol': self.storage_protocol
+            }
+        description = (
+            self.configuration.safe_get('nexenta_dataset_description'))
+        if not description:
+            description = '%(product)s %(host)s:%(pool)s/%(group)s' % {
+                'product': self.product_name,
+                'host': self.configuration.nexenta_host,
+                'pool': self.configuration.nexenta_volume,
+                'group': self.configuration.nexenta_folder
+            }
+        max_over_subscription_ratio = (
+            self.configuration.safe_get('max_over_subscription_ratio'))
+        reserved_percentage = (
+            self.configuration.safe_get('reserved_percentage'))
+        if reserved_percentage is None:
+            reserved_percentage = 0
+        location_info = '%(driver)s:%(host)s:%(path)s' % {
+            'driver': self.driver_name,
+            'host': self.configuration.nexenta_host,
+            'path': self.root_path
         }
+        display_name = 'Capabilities of %(product)s %(protocol)s driver' % {
+            'product': self.product_name,
+            'protocol': self.storage_protocol
+        }
+        visibility = 'public'
         self._stats = {
-            'vendor_name': 'Nexenta',
-            'dedup': self.volume_deduplication,
-            'compression': self.volume_compression,
-            'description': self.volume_description,
             'driver_version': self.VERSION,
-            'storage_protocol': 'iSCSI',
-            'total_capacity_gb': total_amount,
-            'free_capacity_gb': free_amount,
-            'reserved_percentage': self.configuration.reserved_percentage,
-            'QoS_support': False,
-            'volume_backend_name': self.backend_name,
+            'vendor_name': self.vendor_name,
+            'storage_protocol': self.storage_protocol,
+            'volume_backend_name': volume_backend_name,
             'location_info': location_info,
-            'iscsi_target_portal_port': self.iscsi_target_portal_port,
+            'description': description,
+            'display_name': display_name,
+            'pool_name': self.configuration.nexenta_volume,
+            'multiattach': True,
+            'QoS_support': False,
+            'consistencygroup_support': False,
+            'consistent_group_snapshot_enabled': False,
+            'online_extend_support': True,
+            'sparse_copy_volume': True,
+            'thin_provisioning_support': True,
+            'thick_provisioning_support': True,
+            'total_capacity_gb': total_capacity_gb,
+            'allocated_capacity_gb': allocated_capacity_gb,
+            'free_capacity_gb': free_capacity_gb,
+            'provisioned_capacity_gb': provisioned_capacity_gb,
+            'total_volumes': total_volumes,
+            'max_over_subscription_ratio': max_over_subscription_ratio,
+            'reserved_percentage': reserved_percentage,
+            'visibility': visibility,
+            'dedup': self.configuration.nexenta_dataset_dedup,
+            'compression': self.configuration.nexenta_dataset_compression,
+            'iscsi_target_portal_port': self.portal_port,
             'nms_url': self.nms.url
         }
+        LOG.debug('Updated volume backend statistics for host %(host)s '
+                  'and volume backend %(volume_backend_name)s: %(stats)s',
+                  {'host': self.host,
+                   'volume_backend_name': volume_backend_name,
+                   'stats': self._stats})

--- a/cinder/volume/drivers/nexenta/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/jsonrpc.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -13,81 +13,367 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import hashlib
+import json
+
 from oslo_log import log as logging
-from oslo_serialization import jsonutils
 import requests
-from requests.packages.urllib3 import exceptions
+import six
+from six.moves import html_parser
 
 from cinder import exception
-from cinder.utils import retry
+from cinder.i18n import _
+from cinder import utils
 
 LOG = logging.getLogger(__name__)
-TIMEOUT = 60
-
-requests.packages.urllib3.disable_warnings(exceptions.InsecureRequestWarning)
-requests.packages.urllib3.disable_warnings(
-    exceptions.InsecurePlatformWarning)
 
 
-class NexentaJSONProxy(object):
+def synchronized(method):
+    def wrapper(instance, *args, **kwargs):
+        lock = instance.nms.proxy.lock
+        LOG.debug('Synchronized call for %(instance)s '
+                  '%(method)s(%(args)s, %(kwargs)s) '
+                  'and coordination lock: %(lock)s',
+                  {'instance': instance,
+                   'method': method,
+                   'args': args,
+                   'kwargs': kwargs,
+                   'lock': lock})
 
-    retry_exc_tuple = (requests.exceptions.ConnectionError,)
+        @utils.synchronized(lock, external=True)
+        def wrapped():
+            return method(instance, *args, **kwargs)
+        return wrapped()
+    return wrapper
 
-    def __init__(self, scheme, host, port, path, user, password, verify,
-                 auto=False, obj=None, method=None, session=None):
-        if session:
-            self.session = session
-        else:
-            self.session = requests.Session()
-            self.session.auth = (user, password)
-            self.session.headers.update({'Content-Type': 'application/json'})
-        self.scheme = scheme.lower()
-        self.host = host
-        self.port = port
-        self.verify = verify
-        self.path = path
-        self.user = user
-        self.password = password
-        self.auto = auto
-        self.obj = obj
+
+class NmsException(exception.VolumeDriverException):
+
+    def __init__(self, data=None, **kwargs):
+        defaults = {
+            'name': 'Nexenta Error',
+            'code': 'EPROTO',
+            'source': 'Nexenta Cinder Driver',
+            'message': 'Unknown Error'
+        }
+        if isinstance(data, dict):
+            for key in defaults:
+                if key in kwargs:
+                    continue
+                if key in data:
+                    kwargs[key] = data[key]
+                else:
+                    kwargs[key] = defaults[key]
+        elif isinstance(data, six.string_types):
+            if 'message' not in kwargs:
+                kwargs['message'] = data
+        for key in defaults:
+            if key not in kwargs:
+                kwargs[key] = defaults[key]
+        message = (_('%(message)s (source: %(source)s, '
+                     'name: %(name)s, code: %(code)s)')
+                   % kwargs)
+        del kwargs['message']
+        self.code = kwargs['code']
+        super(NmsException, self).__init__(message, **kwargs)
+
+
+class NmsParser(html_parser.HTMLParser, object):
+
+    def __init__(self):
+        super(NmsParser, self).__init__()
+        self.data = []
+
+    def handle_data(self, data):
+        data = data.strip()
+        data = data.replace('\n', ' ')
+        if data:
+            self.data.append(data)
+
+
+class NmsRequest(object):
+
+    def __init__(self, nms, method):
+        self.nms = nms
         self.method = method
 
-    def __getattr__(self, name):
-        if not self.obj:
-            obj, method = name, None
-        elif not self.method:
-            obj, method = self.obj, name
+    @synchronized
+    def __call__(self, *args):
+        timeout = self.nms.proxy.timeout
+        url = self.nms.proxy.url
+        payload = {
+            self.nms.kind: self.nms.name,
+            'method': self.method,
+            'params': args
+        }
+        LOG.debug('NMS request start: post %(url)s %(payload)s',
+                  {'url': url, 'payload': payload})
+        data = json.dumps(payload)
+        try:
+            response = self.nms.proxy.session.post(url, data=data,
+                                                   timeout=timeout)
+        except requests.exceptions.ConnectionError as error:
+            if not self.nms.proxy.auto:
+                raise
+            if self.nms.proxy.scheme == 'http':
+                self.nms.proxy.scheme == 'https'
+            else:
+                self.nms.proxy.scheme == 'http'
+            url = self.nms.proxy.url
+            LOG.error('Try to failover to %(scheme)s scheme: %(url)s',
+                      {'scheme': self.nms.proxy.scheme, 'url': url})
+            response = self.nms.proxy.session.post(url, data=data,
+                                                   timeout=timeout)
+        LOG.debug('NMS request done: post %(url)s %(payload)s, '
+                  'response status: %(status)s, response reason: '
+                  '%(reason)s, response time: %(time)s seconds, '
+                  'response content: %(content)s',
+                  {'url': url, 'payload': payload,
+                   'status': response.status_code,
+                   'reason': response.reason,
+                   'time': response.elapsed.total_seconds(),
+                   'content': response.content})
+
+        if not response.content:
+            message = 'No content %(status)s %(reason)s' % {
+                'status': response.status_code,
+                'reason': response.reason
+            }
+            raise NmsException(code='EPROTO', source=url, message=message)
+
+        try:
+            content = json.loads(response.content)
+        except (TypeError, ValueError) as error:
+            LOG.debug('Failed to parse JSON %(content)s: %(error)s',
+                      {'content': response.content, 'error': error})
+            try:
+                parser = NmsParser()
+                parser.feed(response.content)
+                message = ', '.join(parser.data)
+            except html_parser.HTMLParseError as error:
+                LOG.debug('Failed to parse HTML %(content)s: %(error)s',
+                          {'content': response.content, 'error': error})
+                message = response.content
+            raise NmsException(code='EBADMSG', source=url, message=message)
+
+        if not (response.ok and isinstance(content, dict)):
+            message = '%(status)s %(reason)s %(content)s' % {
+                'status': response.status_code,
+                'reason': response.reason,
+                'content': content
+            }
+            raise NmsException(code='EPROTO', source=url, message=message)
+
+        if 'error' in content and content['error'] is not None:
+            error = content['error']
+            if isinstance(error, dict) and 'message' in error:
+                message = error['message']
+            else:
+                message = error
+            self.check_error(url, message)
+
+        if 'result' in content and content['result'] is not None:
+            result = content['result']
         else:
-            obj, method = '%s.%s' % (self.obj, self.method), name
-        return NexentaJSONProxy(self.scheme, self.host, self.port, self.path,
-                                self.user, self.password, self.verify,
-                                self.auto, obj, method, self.session)
+            result = None
+
+        LOG.debug('NMS request result for %(payload)s: %(result)s',
+                  {'payload': payload, 'result': result})
+        return result
+
+    def check_error(self, url, message):
+        if 'already exists' in message:
+            code = 'EEXIST'
+        elif 'already configured' in message:
+            code = 'EEXIST'
+        elif 'has children' in message:
+            code = 'EEXIST'
+        elif 'in use' in message:
+            code = 'EBUSY'
+        elif 'does not exist' in message:
+            code = 'ENOENT'
+        else:
+            code = 'EPROTO'
+        ignored = {
+            'EEXIST': [
+                'add_hostgroup_member',
+                'add_lun_mapping_entry',
+                'add_targetgroup_member',
+                'clone',
+                'create',
+                'create_hostgroup',
+                'create_lu',
+                'create_snapshot',
+                'create_target',
+                'create_targetgroup',
+                'create_with_props'
+            ],
+            'ENOENT': [
+                'delete_lu',
+                'destroy',
+                'remove_lun_mapping_entry'
+            ]
+        }
+        if code in ignored and self.method in ignored[code]:
+            LOG.debug('Ignore %(kind)s %(name)s %(method)s error: %(error)s',
+                      {'kind': self.nms.kind, 'name': self.nms.name,
+                       'method': self.method, 'error': message})
+            return
+        raise NmsException(code=code, source=url, message=message)
+
+
+class NmsObject(object):
+
+    def __init__(self, proxy, name):
+        self.kind = 'object'
+        self.proxy = proxy
+        self.name = name
+        plugins = {
+            'autosync_plugin': 'nms-autosync',
+            'rrdaemon_plugin': 'nms-rrdaemon',
+            'rsf_plugin': 'nms-rsf-cluster'
+        }
+        if name in plugins:
+            self.kind = 'plugin'
+            self.name = plugins[name]
+
+    def __getattr__(self, method):
+        return NmsRequest(self, method)
+
+
+class NmsProxy(object):
+
+    def __init__(self, proto, path, conf):
+        self.path = path
+        self.lock = 'nms'
+        self.auto = False
+        self.scheme = conf.nexenta_rest_protocol
+        if self.scheme == 'auto':
+            self.auto = True
+            self.scheme = 'http'
+        if conf.nexenta_rest_address:
+            self.host = conf.nexenta_rest_address
+        elif conf.nexenta_host:
+            self.host = conf.nexenta_host
+        elif proto == 'nfs' and conf.nas_host:
+            self.host = conf.nas_host
+        else:
+            message = (_('NexentaStor Rest API address is not defined, '
+                         'please check the Cinder configuration file for '
+                         'NexentaStor backend and nexenta_rest_address, '
+                         'nexenta_host or nas_host configuration options'))
+            raise NmsException(code='EINVAL', message=message)
+        if conf.nexenta_rest_port:
+            self.port = conf.nexenta_rest_port
+        else:
+            self.port = 8457
+        self.headers = {
+            'Content-Type': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+        self.timeout = (conf.nexenta_rest_connect_timeout,
+                        conf.nexenta_rest_read_timeout)
+        max_retries = requests.packages.urllib3.util.retry.Retry(
+            total=conf.nexenta_rest_retry_count,
+            backoff_factor=conf.nexenta_rest_backoff_factor)
+        adapter = requests.adapters.HTTPAdapter(max_retries=max_retries)
+        self.session = requests.Session()
+        self.session.auth = (conf.nexenta_user, conf.nexenta_password)
+        self.session.verify = conf.driver_ssl_cert_verify
+        self.session.headers.update(self.headers)
+        self.session.mount('http://', adapter)
+        self.session.mount('https://', adapter)
+        if not conf.driver_ssl_cert_verify:
+            requests.packages.urllib3.disable_warnings()
+        self.update_lock()
+
+    def __getattr__(self, name):
+        return NmsObject(self, name)
+
+    def update_lock(self):
+        signature = None
+        license_info = {}
+        try:
+            license_info = self.appliance.get_license_info()
+        except NmsException as error:
+            LOG.error('Unable to get license information: %(error)s',
+                      {'error': error})
+        key = 'machine_sig'
+        if isinstance(license_info, dict) and key in license_info:
+            signature = license_info[key]
+            LOG.debug('Host signature: %(signature)s',
+                      {'signature': signature})
+        plugins = {}
+        try:
+            plugins = self.plugin.get_names('')
+        except NmsException as error:
+            LOG.error('Unable to get installed plugins: %(error)s',
+                      {'error': error})
+        plugin = 'nms-rsf-cluster'
+        if isinstance(plugins, list) and plugin in plugins:
+            names = []
+            try:
+                names = self.rsf_plugin.get_names('')
+            except NmsException as error:
+                LOG.error('Unable to get HA cluster name: %(error)s',
+                          {'error': error})
+            if isinstance(names, list) and len(names) == 1:
+                name = names.pop()
+                conf = {}
+                try:
+                    conf = self.rsf_plugin.get_child_props(name, '')
+                except NmsException as error:
+                    LOG.error('Unable to get HA cluster %(name)s '
+                              'configuration: %(error)s',
+                              {'name': name, 'error': error})
+                key = 'machinesigs'
+                if isinstance(conf, dict) and key in conf:
+                    data = conf[key]
+                    nodes = {}
+                    try:
+                        nodes = json.loads(data)
+                    except (TypeError, ValueError) as error:
+                        LOG.error('Unable to parse HA cluster %(name)s '
+                                  'configuration %(data)s: %(error)s',
+                                  {'name': name, 'data': data,
+                                   'error': error})
+                    if nodes and isinstance(nodes, dict):
+                        signatures = nodes.values()
+                        if signature and signature in signatures:
+                            signature = ':'.join(sorted(signatures))
+                            LOG.debug('HA cluster %(name)s hosts '
+                                      'signatures: %(signatures)s',
+                                      {'name': name,
+                                       'signatures': signatures})
+                        else:
+                            LOG.debug('HA cluster %(name)s configuration '
+                                      '%(conf)s does not contain signature '
+                                      'for configured host %(host)s',
+                                      {'name': name, 'conf': conf,
+                                       'host': self.host})
+                    else:
+                        LOG.debug('HA cluster %(name)s configuration %(conf)s '
+                                  'does not contain valid hosts signatures',
+                                  {'name': name, 'conf': conf})
+                else:
+                    LOG.debug('Hosts signatures unavailable for HA cluster '
+                              '%(name)s and cluster configuration %(conf)s',
+                              {'name': name, 'conf': conf})
+            else:
+                LOG.debug('HA cluster plugin %(plugin)s is not configured',
+                          {'plugin': plugin})
+        else:
+            LOG.debug('HA cluster plugin %(plugin)s is not installed',
+                      {'plugin': plugin})
+        if not signature:
+            signature = self.host
+        lock = '%s:%s' % (signature, self.path)
+        if six.PY3:
+            lock = lock.encode('utf-8')
+        self.lock = hashlib.md5(lock).hexdigest()
+        LOG.debug('NMS coordination lock: %(lock)s',
+                  {'lock': self.lock})
 
     @property
     def url(self):
-        return '%s://%s:%s%s' % (self.scheme, self.host, self.port, self.path)
-
-    def __hash__(self):
-        return self.url.__hash__()
-
-    def __repr__(self):
-        return 'NMS proxy: %s' % self.url
-
-    @retry(retry_exc_tuple, retries=6)
-    def __call__(self, *args):
-        data = jsonutils.dumps({
-            'object': self.obj,
-            'method': self.method,
-            'params': args
-        })
-
-        LOG.debug('Sending JSON data: %s', data)
-        r = self.session.post(self.url, data=data, timeout=TIMEOUT,
-                              verify=self.verify)
-        response = r.json()
-
-        LOG.debug('Got response: %s', response)
-        if response.get('error') is not None:
-            message = response['error'].get('message', '')
-            raise exception.NexentaException(message)
-        return response.get('result')
+        return '%s://%s:%s/rest/nms' % (self.scheme, self.host, self.port)

--- a/cinder/volume/drivers/nexenta/nfs.py
+++ b/cinder/volume/drivers/nexenta/nfs.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -13,29 +13,31 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import datetime
+import difflib
 import hashlib
+import ipaddress
 import os
-import re
-import six
+import posixpath
 
 from eventlet import greenthread
 from oslo_log import log as logging
+from oslo_utils import strutils
+from oslo_utils import timeutils
 from oslo_utils import units
+import six
 
 from cinder import context
-from cinder import db
-from cinder import exception
 from cinder.i18n import _
+from cinder import objects
 from cinder.volume.drivers.nexenta import jsonrpc
 from cinder.volume.drivers.nexenta import options
-from cinder.volume.drivers.nexenta import utils
 from cinder.volume.drivers import nfs
 
-VERSION = '1.3.2'
 LOG = logging.getLogger(__name__)
 
 
-class NexentaNfsDriver(nfs.NfsDriver):  # pylint: disable=R0921
+class NexentaNfsDriver(nfs.NfsDriver):
     """Executes volume driver commands on Nexenta Appliance.
 
     Version history:
@@ -54,427 +56,148 @@ class NexentaNfsDriver(nfs.NfsDriver):  # pylint: disable=R0921
         1.3.1 - Cache capacity info and check shared folders on setup.
         1.3.2 - Pass mount_point_base in init_conn to support host-based
                 migration.
+        1.4.0 - Refactored NFS driver.
+              - Improved storage assisted volume migration.
+              - Added volume multi-attach.
+              - Fixed automatic mode for nexenta_rest_protocol.
+              - Added deferred deletion for snapshots.
+              - Added synchronization for NMS REST API calls.
+              - Added configuration parameters for REST API connect/read
+                timeouts, connection retries and backoff factor.
+              - Disabled non-blocking mandatory locks.
+              - Added informative exception messages for REST API.
+              - Improved collection of backend statistics.
     """
 
-    driver_prefix = 'nexenta'
-    volume_backend_name = 'NexentaNfsDriver'
-    VERSION = VERSION
-    VOLUME_FILE_NAME = 'volume'
+    VERSION = '1.4.0'
+    CI_WIKI_NAME = 'Nexenta_CI'
 
-    # ThirdPartySystems wiki page
-    CI_WIKI_NAME = "Nexenta_CI"
+    vendor_name = 'Nexenta'
+    product_name = 'NexentaStor4'
+    storage_protocol = 'NFS'
+    driver_volume_type = 'nfs'
 
     def __init__(self, *args, **kwargs):
         super(NexentaNfsDriver, self).__init__(*args, **kwargs)
-        if self.configuration:
-            self.configuration.append_config_values(
-                options.NEXENTA_CONNECTION_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_NFS_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_DATASET_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_RRMGR_OPTS)
-
-        self.verify_ssl = self.configuration.driver_ssl_cert_verify
-        self.nms_cache_volroot = self.configuration.nexenta_nms_cache_volroot
-        self.rrmgr_compression = self.configuration.nexenta_rrmgr_compression
-        self.rrmgr_tcp_buf_size = self.configuration.nexenta_rrmgr_tcp_buf_size
-        self.rrmgr_connections = self.configuration.nexenta_rrmgr_connections
-        self.nfs_mount_point_base = self.configuration.nexenta_mount_point_base
+        if not self.configuration:
+            message = (_('%(product_name)s %(storage_protocol)s '
+                         'backend configuration not found')
+                       % {'product_name': self.product_name,
+                          'storage_protocol': self.storage_protocol})
+            raise jsonrpc.NmsException(code='ENODATA', message=message)
+        self.configuration.append_config_values(
+            options.NEXENTA_CONNECTION_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_NFS_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_DATASET_OPTS)
+        self.configuration.append_config_values(options.NEXENTA_RRMGR_OPTS)
+        self.nms = None
+        self.driver_name = self.__class__.__name__
+        self.nas_host = self.configuration.nas_host
+        self.root_path = self.configuration.nas_share_path
+        self.mount_point_base = self.configuration.nexenta_mount_point_base
         self.volume_compression = (
             self.configuration.nexenta_dataset_compression)
-        self.volume_deduplication = self.configuration.nexenta_dataset_dedup
-        self.volume_description = (
-            self.configuration.nexenta_dataset_description)
         self.sparsed_volumes = self.configuration.nexenta_sparsed_volumes
-        self._nms2volroot = {}
-        self.share2nms = {}
-        self.nfs_versions = {}
-        self.shares_with_capacities = {}
-
-    @property
-    def backend_name(self):
-        backend_name = None
-        if self.configuration:
-            backend_name = self.configuration.safe_get('volume_backend_name')
-        if not backend_name:
-            backend_name = self.__class__.__name__
-        return backend_name
+        self.origin_snapshot_template = (
+            self.configuration.nexenta_origin_snapshot_template)
+        self.migration_snapshot_prefix = (
+            self.configuration.nexenta_migration_snapshot_prefix)
+        self.migration_service_prefix = (
+            self.configuration.nexenta_migration_service_prefix)
+        self.migration_throttle = (
+            self.configuration.nexenta_migration_throttle)
 
     def do_setup(self, context):
-        shares_config = getattr(self.configuration, self.driver_prefix +
-                                '_shares_config')
-        if shares_config:
-            self.configuration.nfs_shares_config = shares_config
-        super(NexentaNfsDriver, self).do_setup(context)
-        self._load_shares_config(shares_config)
-        self._mount_subfolders()
+        self.nms = jsonrpc.NmsProxy(self.driver_volume_type,
+                                    self.root_path,
+                                    self.configuration)
 
     def check_for_setup_error(self):
-        """Verify that the volume for our folder exists.
+        """Check root filesystem, NFS service and NFS share."""
+        if not self.nms.folder.object_exists(self.root_path):
+            message = (_('NFS root filesystem %(path)s not found')
+                       % {'path': self.root_path})
+            raise jsonrpc.NmsException(code='ENOENT', message=message)
+        filesystem = self.nms.folder.get_child_props(self.root_path, '')
+        if filesystem['mountpoint'] == 'none':
+            message = (_('NFS root filesystem %(path)s is not writable')
+                       % {'path': self.root_path})
+            raise jsonrpc.NefException(code='ENOENT', message=message)
+        if filesystem['mounted'] == 'no':
+            message = (_('NFS root filesystem %(path)s is not mounted')
+                       % {'path': self.root_path})
+            raise jsonrpc.NefException(code='ENOTDIR', message=message)
+        if filesystem['nbmand'] == 'on':
+            self.nms.folder.set_child_prop(self.root_path, 'nbmand', 'off')
+        fmri = 'svc:/network/nfs/server:default'
+        state = self.nms.netsvc.get_state(fmri)
+        if state != 'online':
+            message = (_('NFS service is not online: %(state)s')
+                       % {'state': state})
+            raise jsonrpc.NmsException(code='ESRCH', message=message)
+        shared = self.nms.netstorsvc.is_folder_shared(fmri, self.root_path)
+        if not shared:
+            message = (_('NFS root filesystem %(path)s is not shared')
+                       % {'path': self.root_path})
+            raise jsonrpc.NmsException(code='ENOENT', message=message)
 
-        :raise: :py:exc:`LookupError`
-        """
-        if self.share2nms:
-            for nfs_share in self.share2nms:
-                nms = self.share2nms[nfs_share]
-                volume_name, dataset = self._get_share_datasets(nfs_share)
-                if not nms.volume.object_exists(volume_name):
-                    raise LookupError(_("Volume %s does not exist in Nexenta "
-                                        "Store appliance"), volume_name)
-                folder = '%s/%s' % (volume_name, dataset)
-                if not nms.folder.object_exists(folder):
-                    raise LookupError(_("Folder %s does not exist in Nexenta "
-                                        "Store appliance"), folder)
-                if (folder not in nms.netstorsvc.get_shared_folders(
-                        'svc:/network/nfs/server:default', '')):
-                    self._share_folder(nms, volume_name, dataset)
-                self._get_capacity_info(nfs_share)
-
-    def migrate_volume(self, ctxt, volume, host):
-        """Migrate if volume and host are managed by Nexenta appliance.
-
-        :param ctxt: context
-        :param volume: a dictionary describing the volume to migrate
-        :param host: a dictionary describing the host to migrate to
-        """
-        LOG.debug('Enter: migrate_volume: id=%(id)s, host=%(host)s',
-                  {'id': volume['id'], 'host': host})
-
-        false_ret = (False, None)
-
-        if volume['status'] not in ('available', 'retyping'):
-            LOG.warning("Volume status must be 'available' or 'retyping'."
-                        " Current volume status: %s", volume['status'])
-            return false_ret
-
-        if 'capabilities' not in host:
-            LOG.warning("Unsupported host. No capabilities found")
-            return false_ret
-
-        capabilities = host['capabilities']
-        ns_shares = capabilities['ns_shares']
-        dst_parts = capabilities['location_info'].split(':')
-        dst_host, dst_volume = dst_parts[1:]
-
-        if (capabilities.get('vendor_name') != 'Nexenta' or
-                dst_parts[0] != self.__class__.__name__ or
-                capabilities['free_capacity_gb'] < volume['size']):
-            return false_ret
-
-        nms = self.share2nms[volume['provider_location']]
-        ssh_bindings = nms.appliance.ssh_list_bindings()
-        shares = []
-        for bind in ssh_bindings:
-            for share in ns_shares:
-                if (share.startswith(bind.split('@')[1].split(':')[0]) and
-                        ns_shares[share] >= volume['size']):
-                    shares.append(share)
-        if len(shares) == 0:
-            LOG.warning("Remote NexentaStor appliance at %s should be "
-                        "SSH-bound.", share)
-            return false_ret
-        share = sorted(shares, key=ns_shares.get, reverse=True)[0]
-        snapshot = {
-            'volume_name': volume['name'],
-            'volume_id': volume['id'],
-            'name': utils.get_migrate_snapshot_name(volume)
-        }
-        self.create_snapshot(snapshot)
-        location = volume['provider_location']
-        src = '%(share)s/%(volume)s@%(snapshot)s' % {
-            'share': location.split(':')[1].split('volumes/')[1],
-            'volume': volume['name'],
-            'snapshot': snapshot['name']
-        }
-        dst = ':'.join([dst_host, dst_volume.split('/volumes/')[1]])
-        try:
-            nms.appliance.execute(self._get_zfs_send_recv_cmd(src, dst))
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot send source snapshot %(src)s to "
-                        "destination %(dst)s. Reason: %(exc)s",
-                        {'src': src, 'dst': dst, 'exc': exc})
-            return false_ret
-        finally:
-            try:
-                self.delete_snapshot(snapshot)
-            except exception.NexentaException as exc:
-                LOG.warning("Cannot delete temporary source snapshot "
-                            "%(src)s on NexentaStor Appliance: %(exc)s",
-                            {'src': src, 'exc': exc})
-        try:
-            self.delete_volume(volume)
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot delete source volume %(volume)s on "
-                        "NexentaStor Appliance: %(exc)s",
-                        {'volume': volume['name'], 'exc': exc})
-
-        dst_nms = self._get_nms_for_url(capabilities['nms_url'])
-        dst_snapshot = '%s/%s@%s' % (dst_volume.split('volumes/')[1],
-                                     volume['name'], snapshot['name'])
-        try:
-            dst_nms.snapshot.destroy(dst_snapshot, '')
-        except exception.NexentaException as exc:
-            LOG.warning("Cannot delete temporary destination snapshot "
-                        "%(dst)s on NexentaStor Appliance: %(exc)s",
-                        {'dst': dst_snapshot, 'exc': exc})
-        return True, {'provider_location': share}
-
-    def _get_zfs_send_recv_cmd(self, src, dst):
-        """Returns rrmgr command for source and destination."""
-        return utils.get_rrmgr_cmd(src, dst,
-                                   compression=self.rrmgr_compression,
-                                   tcp_buf_size=self.rrmgr_tcp_buf_size,
-                                   connections=self.rrmgr_connections)
-
-    def initialize_connection(self, volume, connector):
-        """Allow connection to connector and return connection info.
+    def create_volume(self, volume):
+        """Creates a volume.
 
         :param volume: volume reference
-        :param connector: connector reference
+        :return: model update dict for volume reference
         """
-        export = '%s/%s' % (volume['provider_location'], volume['name'])
-        data = {'export': export, 'name': 'volume'}
-        if volume['provider_location'] in self.shares:
-            data['options'] = self.shares[volume['provider_location']]
-        return {
-            'driver_volume_type': self.driver_volume_type,
-            'data': data,
-            'mount_point_base': self.nfs_mount_point_base
+        volume_path = self._get_volume_path(volume)
+        volume_options = {
+            'compression': self.volume_compression
         }
-
-    def retype(self, context, volume, new_type, diff, host):
-        """Convert the volume to be of the new type.
-
-        :param ctxt: Context
-        :param volume: A dictionary describing the volume to migrate
-        :param new_type: A dictionary describing the volume type to convert to
-        :param diff: A dictionary with the difference between the two types
-        :param host: A dictionary describing the host to migrate to, where
-                     host['host'] is its name, and host['capabilities'] is a
-                     dictionary of its reported capabilities.
-        """
-        LOG.debug('Retype volume request %(vol)s to be %(type)s '
-                  '(host: %(host)s), diff %(diff)s.',
-                  {'vol': volume['name'],
-                   'type': new_type,
-                   'host': host,
-                   'diff': diff})
-
-        options = dict(
-            compression='compression',
-            dedup='dedup',
-            description='nms:description'
-        )
-
-        retyped = False
-        migrated = False
-        model_update = None
-
-        src_backend = self.__class__.__name__
-        dst_backend = host['capabilities']['location_info'].split(':')[0]
-        if src_backend != dst_backend:
-            LOG.warning('Cannot retype from %(src_backend)s to '
-                        '%(dst_backend)s.',
-                        {
-                            'src_backend': src_backend,
-                            'dst_backend': dst_backend
-                        })
-            return False
-
-        hosts = (volume['host'], host['host'])
-        old, new = hosts
-        if old != new:
-            migrated, provider_location = self.migrate_volume(
-                context, volume, host)
-
-        if not migrated:
-            provider_location = volume['provider_location']
-            nms = self.share2nms[provider_location]
-        else:
-            nms_url = host['capabilities']['nms_url']
-            nms = self._get_nms_for_url(nms_url)
-            model_update = provider_location
-            provider_location = provider_location['provider_location']
-
-        share = provider_location.split(':')[1].split('volumes/')[1]
-        folder = '%(share)s/%(volume)s' % {
-            'share': share,
-            'volume': volume['name']
-        }
-
-        for opt in options:
-            old, new = diff.get('extra_specs').get(opt, (False, False))
-            if old != new:
-                LOG.debug('Changing %(opt)s from %(old)s to %(new)s.',
-                          {'opt': opt, 'old': old, 'new': new})
-                try:
-                    nms.folder.set_child_prop(
-                        folder, options[opt], new)
-                    retyped = True
-                except exception.NexentaException:
-                    LOG.error('Error trying to change %(opt)s'
-                              ' from %(old)s to %(new)s',
-                              {'opt': opt, 'old': old, 'new': new})
-                    return False, None
-        return retyped or migrated, model_update
-
-    def _do_create_volume(self, volume):
-        nfs_share = volume['provider_location']
-        nms = self.share2nms[nfs_share]
-
-        vol, dataset = self._get_share_datasets(nfs_share)
-        folder = '%s/%s' % (dataset, volume['name'])
-        LOG.debug('Creating folder on Nexenta Store %s', folder)
-        nms.folder.create_with_props(
-            vol, folder,
-            {'compression': self.configuration.nexenta_dataset_compression}
-        )
-
-        volume_path = self.remote_path(volume)
-        volume_size = volume['size']
+        self.nms.folder.create_with_props(self.root_path,
+                                          volume['name'],
+                                          volume_options)
         try:
-            self._share_folder(nms, vol, folder)
-
-            if getattr(self.configuration,
-                       self.driver_prefix + '_sparsed_volumes'):
-                self._create_sparsed_file(nms, volume_path, volume_size)
+            self._set_volume_acl(volume)
+            self._mount_volume(volume)
+            volume_file = self.local_path(volume)
+            volume_size = volume['size']
+            if self.sparsed_volumes:
+                self._create_sparsed_file(volume_file, volume_size)
             else:
-                folder_path = '%s/%s' % (vol, folder)
-                compression = nms.folder.get_child_prop(
-                    folder_path, 'compression')
+                compression = self.nms.folder.get_child_prop(volume_path,
+                                                             'compression')
                 if compression != 'off':
-                    # Disable compression, because otherwise will not use space
-                    # on disk.
-                    nms.folder.set_child_prop(
-                        folder_path, 'compression', 'off')
-                try:
-                    self._create_regular_file(nms, volume_path, volume_size)
-                finally:
-                    if compression != 'off':
-                        # Backup default compression value if it was changed.
-                        nms.folder.set_child_prop(
-                            folder_path, 'compression', compression)
-
-            self._set_rw_permissions_for_all(nms, volume_path)
-
-            if self._get_nfs_server_version(nfs_share) < 4:
-                sub_share, mnt_path = self._get_subshare_mount_point(nfs_share,
-                                                                     volume)
-                self._ensure_share_mounted(sub_share, mnt_path)
-            self._get_capacity_info(nfs_share)
-        except exception.NexentaException:
+                    self.nms.folder.set_child_prop(volume_file,
+                                                   'compression',
+                                                   'off')
+                self._create_regular_file(volume_file, volume_size)
+                if compression != 'off':
+                    self.nms.folder.set_child_prop(volume_path,
+                                                   'compression',
+                                                   compression)
+        except jsonrpc.NmsException as create_error:
             try:
-                nms.folder.destroy('%s/%s' % (vol, folder))
-            except exception.NexentaException:
-                LOG.warning("Cannot destroy created folder: "
-                            "%(vol)s/%(folder)s",
-                            {'vol': vol, 'folder': folder})
-            raise
+                self.nms.folder.destroy(volume_path, '-rf')
+            except jsonrpc.NmsException as delete_error:
+                LOG.debug('Failed to delete volume %(path)s: %(error)s',
+                          {'path': volume_path, 'error': delete_error})
+            raise create_error
+        finally:
+            self._unmount_volume(volume)
 
-    def create_volume_from_snapshot(self, volume, snapshot):
-        """Create new volume from other's snapshot on appliance.
+    def copy_image_to_volume(self, context, volume, image_service, image_id):
+        LOG.debug('Copy image %(image)s to volume %(volume)s',
+                  {'image': image_id, 'volume': volume['name']})
+        self._mount_volume(volume)
+        super(NexentaNfsDriver, self).copy_image_to_volume(
+            context, volume, image_service, image_id)
+        self._unmount_volume(volume)
 
-        :param volume: reference of volume to be created
-        :param snapshot: reference of source snapshot
-        """
-        self._ensure_shares_mounted()
-
-        snapshot_vol = self._get_snapshot_volume(snapshot)
-        nfs_share = snapshot_vol['provider_location']
-        volume['provider_location'] = nfs_share
-        nms = self.share2nms[nfs_share]
-
-        vol, dataset = self._get_share_datasets(nfs_share)
-        snapshot_name = '%s/%s/%s@%s' % (vol, dataset, snapshot['volume_name'],
-                                         snapshot['name'])
-        folder = '%s/%s' % (dataset, volume['name'])
-        nms.folder.clone(snapshot_name, '%s/%s' % (vol, folder))
-
-        try:
-            self._share_folder(nms, vol, folder)
-        except exception.NexentaException:
-            try:
-                nms.folder.destroy('%s/%s' % (vol, folder), '')
-            except exception.NexentaException:
-                LOG.warning("Cannot destroy cloned folder: "
-                            "%(vol)s/%(folder)s",
-                            {'vol': vol, 'folder': folder})
-            raise
-
-        if self._get_nfs_server_version(nfs_share) < 4:
-            sub_share, mnt_path = self._get_subshare_mount_point(nfs_share,
-                                                                 volume)
-            self._ensure_share_mounted(sub_share, mnt_path)
-
-        if (('size' in volume) and (
-                volume['size'] > snapshot['volume_size'])):
-            self.extend_volume(volume, volume['size'])
-
-        return {'provider_location': volume['provider_location']}
-
-    def create_cloned_volume(self, volume, src_vref):
-        """Creates a clone of the specified volume.
-
-        :param volume: new volume reference
-        :param src_vref: source volume reference
-        """
-        LOG.info('Creating clone of volume: %s', src_vref['id'])
-        snapshot = {'volume_name': src_vref['name'],
-                    'volume_id': src_vref['id'],
-                    'volume_size': src_vref['size'],
-                    'name': self._get_clone_snapshot_name(volume)}
-        # We don't delete this snapshot, because this snapshot will be origin
-        # of new volume. This snapshot will be automatically promoted by NMS
-        # when user will delete its origin.
-        self.create_snapshot(snapshot)
-        try:
-            return self.create_volume_from_snapshot(volume, snapshot)
-        except exception.NexentaException:
-            LOG.error('Volume creation failed, deleting created snapshot '
-                      '%(volume_name)s@%(name)s', snapshot)
-            try:
-                self.delete_snapshot(snapshot)
-            except (exception.NexentaException, exception.SnapshotIsBusy):
-                LOG.warning('Failed to delete zfs snapshot '
-                            '%(volume_name)s@%(name)s', snapshot)
-            raise
-
-    def delete_volume(self, volume):
-        """Deletes a logical volume.
-
-        :param volume: volume reference
-        """
-        nfs_share = volume.get('provider_location')
-        if nfs_share:
-            nms = self.share2nms[nfs_share]
-            vol, parent_folder = self._get_share_datasets(nfs_share)
-            folder = '%s/%s/%s' % (vol, parent_folder, volume['name'])
-            mount_path = self.remote_path(volume).strip(
-                '/%s' % self.VOLUME_FILE_NAME)
-            if mount_path in self._remotefsclient._read_mounts():
-                self._execute('umount', mount_path, run_as_root=True)
-            try:
-                props = nms.folder.get_child_props(folder, 'origin') or {}
-                nms.folder.destroy(folder, '-r')
-            except exception.NexentaException as exc:
-                if 'does not exist' in exc.args[0]:
-                    LOG.info('Folder %s does not exist, it was '
-                             'already deleted.', folder)
-                    return
-                raise
-            self._get_capacity_info(nfs_share)
-            origin = props.get('origin')
-            if origin and self._is_clone_snapshot_name(origin):
-                try:
-                    nms.snapshot.destroy(origin, '')
-                except exception.NexentaException as exc:
-                    if 'does not exist' in exc.args[0]:
-                        LOG.info('Snapshot %s does not exist, it was '
-                                 'already deleted.', origin)
-                        return
-                    raise
+    def copy_volume_to_image(self, context, volume, image_service, image_meta):
+        LOG.debug('Copy volume %(volume)s to image %(image)s',
+                  {'volume': volume['name'], 'image': image_meta['id']})
+        self._mount_volume(volume)
+        super(NexentaNfsDriver, self).copy_volume_to_image(
+            context, volume, image_service, image_meta)
+        self._unmount_volume(volume)
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -482,353 +205,885 @@ class NexentaNfsDriver(nfs.NfsDriver):  # pylint: disable=R0921
         :param volume: volume reference
         :param new_size: volume new size in GB
         """
-        LOG.info('Extending volume: %(id)s New size: %(size)s GB',
-                 {'id': volume['id'], 'size': new_size})
-        nfs_share = volume['provider_location']
-        nms = self.share2nms[nfs_share]
-        volume_path = self.remote_path(volume)
-        if getattr(self.configuration,
-                   self.driver_prefix + '_sparsed_volumes'):
-            self._create_sparsed_file(nms, volume_path, new_size)
+        LOG.debug('Extend volume %(volume)s, new size: %(size)sGB',
+                  {'volume': volume['name'], 'size': new_size})
+        self._mount_volume(volume)
+        volume_file = self.local_path(volume)
+        if self.sparsed_volumes:
+            self._execute('truncate', '-s',
+                          '%dG' % new_size,
+                          volume_file,
+                          run_as_root=True)
         else:
-            block_size_mb = 1
-            block_count = ((new_size - volume['size']) * units.Gi /
-                           (block_size_mb * units.Mi))
+            seek = volume['size'] * units.Ki
+            count = (new_size - volume['size']) * units.Ki
+            self._execute('dd',
+                          'if=/dev/zero',
+                          'of=%s' % volume_file,
+                          'bs=%d' % units.Mi,
+                          'seek=%d' % seek,
+                          'count=%d' % count,
+                          run_as_root=True)
+        self._unmount_volume(volume)
 
-            nms.appliance.execute(
-                'dd if=/dev/zero seek=%(seek)d of=%(path)s'
-                ' bs=%(bs)dM count=%(count)d' % {
-                    'seek': volume['size'] * units.Gi / block_size_mb,
-                    'path': volume_path,
-                    'bs': block_size_mb,
-                    'count': block_count
-                }
-            )
+    def delete_volume(self, volume):
+        """Deletes a logical volume.
+
+        :param volume: volume reference
+        """
+        volume_path = self._get_volume_path(volume)
+        try:
+            origin = self.nms.folder.get_child_prop(volume_path, 'origin')
+        except jsonrpc.NmsException as error:
+            if error.code == 'ENOENT':
+                return
+            raise
+        self.nms.folder.destroy(volume_path, '-rf')
+        if not origin:
+            return
+        template = self.origin_snapshot_template
+        parent_path, snapshot_name = origin.split('@')
+        if not self._match_template(template, snapshot_name):
+            return
+        try:
+            self.nms.snapshot.destroy(origin, '-d')
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to delete origin snapshot %(origin)s '
+                      'of volume %(volume)s: %(error)s',
+                      {'origin': origin,
+                       'volume': volume['name'],
+                       'error': error})
+
+    def create_volume_from_snapshot(self, volume, snapshot):
+        """Create new volume from other's snapshot on appliance.
+
+        :param volume: reference of volume to be created
+        :param snapshot: reference of source snapshot
+        """
+        LOG.debug('Create volume %(volume)s from snapshot %(snapshot)s',
+                  {'volume': volume['name'], 'snapshot': snapshot['name']})
+        snapshot_path = self._get_snapshot_path(snapshot)
+        clone_path = self._get_volume_path(volume)
+        self.nms.folder.clone(snapshot_path, clone_path)
+        if volume['size'] > snapshot['volume_size']:
+            new_size = volume['size']
+            volume['size'] = snapshot['volume_size']
+            self.extend_volume(volume, new_size)
+            volume['size'] = new_size
+
+    def create_cloned_volume(self, volume, src_vref):
+        """Creates a clone of the specified volume.
+
+        :param volume: new volume reference
+        :param src_vref: source volume reference
+        """
+        snapshot = {
+            'name': self.origin_snapshot_template % volume['id'],
+            'volume_id': src_vref['id'],
+            'volume_name': src_vref['name'],
+            'volume_size': src_vref['size']
+        }
+        self.create_snapshot(snapshot)
+        try:
+            self.create_volume_from_snapshot(volume, snapshot)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to create clone %(clone)s '
+                      'from volume %(volume)s: %(error)s',
+                      {'clone': volume['name'],
+                       'volume': src_vref['name'],
+                       'error': error})
+            raise
+        finally:
+            try:
+                self.delete_snapshot(snapshot)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to delete temporary snapshot '
+                          '%(volume)s@%(snapshot)s: %(error)s',
+                          {'volume': src_vref['name'],
+                           'snapshot': snapshot['name'],
+                           'error': error})
+
+    def _ensure_share_unmounted(self, share):
+        """Ensure that NFS share is unmounted on the host.
+
+        :param share: share path
+        """
+        attempts = max(1, self.configuration.nfs_mount_attempts)
+        path = self._get_mount_point_for_share(share)
+        if path not in self._remotefsclient._read_mounts():
+            LOG.debug('NFS share %(share)s is not mounted at %(path)s',
+                      {'share': share, 'path': path})
+            return
+        for attempt in range(attempts):
+            try:
+                self._execute('umount', path, run_as_root=True)
+                LOG.debug('NFS share %(share)s has been unmounted at %(path)s',
+                          {'share': share, 'path': path})
+                break
+            except Exception as error:
+                if attempt == (attempts - 1):
+                    LOG.error('Failed to unmount NFS share %(share)s '
+                              'after %(attempts)s attempts',
+                              {'share': share, 'attempts': attempts})
+                    raise
+                LOG.debug('Unmount attempt %(attempt)s failed: %(error)s, '
+                          'retrying unmount %(share)s from %(path)s',
+                          {'attempt': attempt, 'error': error,
+                           'share': share, 'path': path})
+                greenthread.sleep(1)
+        self._delete(path)
+
+    def _delete(self, path):
+        """Override parent method for safe remove mountpoint."""
+        try:
+            os.rmdir(path)
+            LOG.debug('The mountpoint %(path)s has been successfully removed',
+                      {'path': path})
+        except OSError as error:
+            LOG.debug('Failed to remove mountpoint %(path)s: %(error)s',
+                      {'path': path, 'error': error.strerror})
+
+    def _mount_volume(self, volume):
+        """Ensure that volume is activated and mounted on the host."""
+        share = self._get_volume_share(volume)
+        self._ensure_share_mounted(share)
+
+    def _unmount_volume(self, volume):
+        """Ensure that volume is unmounted on the host."""
+        try:
+            share = self._get_volume_share(volume)
+        except jsonrpc.NmsException as error:
+            if error.code == 'ENOENT':
+                return
+        self._ensure_share_unmounted(share)
+
+    def create_export(self, context, volume, connector):
+        """Driver entry point to get the export info for a new volume."""
+        pass
+
+    def ensure_export(self, context, volume):
+        """Driver entry point to get the export info for an existing volume."""
+        pass
+
+    def remove_export(self, context, volume):
+        """Driver entry point to remove an export for a volume."""
+        pass
+
+    def terminate_connection(self, volume, connector, **kwargs):
+        """Terminate a connection to a volume.
+
+        :param volume: a volume object
+        :param connector: a connector object
+        :returns: dictionary of connection information
+        """
+        LOG.debug('Terminate volume connection for %(volume)s',
+                  {'volume': volume['name']})
+        self._unmount_volume(volume)
+
+    def initialize_connection(self, volume, connector):
+        """Allow connection to connector and return connection info.
+
+        :param volume: volume reference
+        :param connector: connector reference
+        :returns: dictionary of connection information
+        """
+        LOG.debug('Initialize volume connection for %(volume)s',
+                  {'volume': volume['name']})
+        share = self._get_volume_share(volume)
+        data = {
+            'export': share,
+            'name': 'volume'
+        }
+        nfs_options = self.configuration.safe_get('nfs_mount_options')
+        nas_options = self.configuration.safe_get('nas_mount_options')
+        if nfs_options and nas_options:
+            LOG.debug('Overriding NFS mount options for volume %(volume)s: '
+                      'nfs_mount_options = "%(nfs_options)s" with '
+                      'nas_mount_options = "%(nas_options)s"',
+                      {'volume': volume['name'],
+                       'nfs_options': nfs_options,
+                       'nas_options': nas_options})
+        if nas_options:
+            data['options'] = '-o %s' % nas_options
+        elif nfs_options:
+            data['options'] = '-o %s' % nfs_options
+        info = {
+            'driver_volume_type': self.driver_volume_type,
+            'mount_point_base': self.mount_point_base,
+            'data': data
+        }
+        return info
+
+    def _get_bound_host(self, host):
+        """Get user@host:port from SSH bindings."""
+        try:
+            bindings = self.nms.appliance.ssh_list_bindings()
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get SSH bindings: %(error)s',
+                      {'error': error})
+            return None
+        for user_host_port in bindings:
+            binding = bindings[user_host_port]
+            if not (isinstance(binding, list) and len(binding) == 4):
+                LOG.warning('Skip incompatible SSH binding: %(binding)s',
+                            {'binding': binding})
+                continue
+            data = binding[2]
+            items = data.split(',')
+            for item in items:
+                if host == item.strip():
+                    return user_host_port
+        return None
+
+    def _svc_state(self, fmri, state):
+        retries = 10
+        delay = 30
+        while retries:
+            greenthread.sleep(delay)
+            retries -= 1
+            try:
+                status = self.nms.autosvc.get_state(fmri)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to get state of migration '
+                          'service %(fmri)s: %(error)s',
+                          {'fmri': fmri, 'error': error})
+                continue
+            if status == 'uninitialized':
+                continue
+            elif status == state:
+                return True
+            if state == 'online':
+                method = getattr(self.nms.autosvc, 'enable')
+            elif state == 'disabled':
+                method = getattr(self.nms.autosvc, 'disable')
+            else:
+                LOG.error('Request unknown service state: %(state)s',
+                          {'state': state})
+                return False
+            try:
+                method(fmri)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to change state of migration service '
+                          '%(fmri)s to %(state)s: %(error)s',
+                          {'fmri': fmri, 'state': state, 'error': error})
+        LOG.error('Unable to change state of migration service %(fmri)s '
+                  'to %(state)s: maximum retries exceeded',
+                  {'fmri': fmri, 'state': state})
+        return False
+
+    def _svc_progress(self, fmri):
+        """Get progress for SMF service."""
+        progress = 0
+        try:
+            estimations = self.nms.autosync.get_estimations(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get estimations for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return progress
+        size = estimations.get('curt_siz')
+        sent = estimations.get('curt_sen')
+        try:
+            size = float(size)
+            sent = float(sent)
+            if size > 0:
+                progress = int(100 * sent / size)
+        except (TypeError, ValueError) as error:
+            LOG.error('Failed to parse estimations statistics '
+                      '%(estimations)s for migration service '
+                      '%(fmri)s: %(error)s',
+                      {'estimations': estimations,
+                       'fmri': fmri, 'error': error})
+        return progress
+
+    def _svc_result(self, fmri):
+        try:
+            props = self.nms.autosvc.get_child_props(fmri, '')
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get properties of migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return False
+        history = props.get('zfs/run_history')
+        if not history:
+            LOG.error('Failed to get history of migration service '
+                      '%(fmri)s: %(props)s',
+                      {'fmri': fmri, 'props': props})
+            return False
+        results = history.split()
+        if len(results) > 1:
+            LOG.warning('Found unexpected replication sessions for '
+                        'migration service %(fmri)s: %(history)s',
+                        {'fmri': fmri, 'history': history})
+        latest = results.pop()
+        start, stop, code = latest.split('::')
+        try:
+            start = int(start)
+            stop = int(stop)
+            code = int(code)
+        except (TypeError, ValueError) as error:
+            LOG.error('Failed to parse history %(history)s for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'history': history, 'fmri': fmri, 'error': error})
+            return False
+        delta = stop - start
+        if code != 1:
+            LOG.error('Migration service %(fmri)s failed after %(delta)s '
+                      'seconds, please check the service log below',
+                      {'fmri': fmri, 'delta': delta})
+            return False
+        LOG.info('Migration service %(fmri)s successfully finished in '
+                 '%(delta)s seconds',
+                 {'fmri': fmri, 'delta': delta})
+        return True
+
+    def _svc_cleanup(self, fmri, migrated=False):
+        props = None
+        flags = {
+            'src_properties': '1',
+            'dst_properties': '1',
+            'src_snapshots': '1',
+            'dst_snapshots': '1'
+        }
+        if not migrated:
+            flags['dst_datasets'] = '1'
+        try:
+            props = self.nms.autosvc.get_child_props(fmri, '')
+            props['zfs/sync-recursive'] = '1'
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get properties of migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        try:
+            self.nms.autosvc.unschedule(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to unschedule migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        self._svc_state(fmri, 'disabled')
+        try:
+            self.nms.autosvc.destroy(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to destroy migration service '
+                      '%(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        if not props:
+            return
+        try:
+            src_pid, dst_pid = self.nms.autosync.cleanup(props, flags)
+        except jsonrpc.NmsException as error:
+            src_pid = dst_pid = 0
+            LOG.error('Failed to cleanup migration service %(fmri)s: '
+                      '%(error)s',
+                      {'fmri': fmri, 'error': error})
+        for pid in [src_pid, dst_pid]:
+            while pid:
+                try:
+                    self.nms.job.get_jobparams(pid)
+                except jsonrpc.NmsException as error:
+                    if error.code == 'ENOENT':
+                        break
+                greenthread.sleep(30)
+        if migrated:
+            return
+        path = props.get('restarter/logfile')
+        if not path:
+            return
+        try:
+            content = self.nms.logviewer.get_tail(path, units.Mi)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get log file content for migration '
+                      'service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+            return
+        log = '\n'.join(content)
+        LOG.error('Migration service %(fmri)s log: %(log)s',
+                  {'fmri': fmri, 'log': log})
+
+    def _migrate_volume(self, volume, host, path):
+        delay = 30
+        retries = 10
+        src_path = self._get_volume_path(volume)
+        dst_path = posixpath.join(path, volume['name'])
+        hosts = self._get_host_addresses()
+        if host in hosts:
+            dst_host = 'localhost'
+            service_direction = '0'
+            service_proto = 'zfs'
+            if src_path == dst_path:
+                LOG.info('Skip local to local replication: source '
+                         'volume %(src_path)s and destination volume '
+                         '%(dst_path)s are the same local volume',
+                         {'src_path': src_path, 'dst_path': dst_path})
+                return True
+        else:
+            service_direction = '1'
+            service_proto = 'zfs+rr'
+            dst_host = self._get_bound_host(host)
+            if not dst_host:
+                LOG.error('Storage assisted volume migration is '
+                          'unavailable: the destination host '
+                          '%(host)s should be SSH bound',
+                          {'host': host})
+                return False
+        service_name = '%(prefix)s-%(volume)s' % {
+            'prefix': self.migration_service_prefix,
+            'volume': volume['name']
+        }
+        comment = 'Migrate %(src)s to %(host)s:%(dst)s' % {
+            'src': src_path,
+            'host': dst_host,
+            'dst': dst_path
+        }
+        yesterday = timeutils.utcnow() - datetime.timedelta(days=1)
+        dst_path = path
+        rate_limit = 0
+        if self.migration_throttle:
+            rate_limit = self.migration_throttle * units.Ki
+        payload = {
+            'comment': comment,
+            'custom_name': service_name,
+            'from-fs': src_path,
+            'to-host': dst_host,
+            'to-fs': dst_path,
+            'direction': service_direction,
+            'marker_name': self.migration_snapshot_prefix,
+            'proto': service_proto,
+            'day': six.text_type(yesterday.day),
+            'rate_limit': six.text_type(rate_limit),
+            '_unique': 'type from-host from-fs to-host to-fs',
+            'method': 'sync',
+            'from-host': 'localhost',
+            'period_multiplier': '1',
+            'keep_src': '1',
+            'keep_dst': '1',
+            'trace_level': '30',
+            'type': 'monthly',
+            'nconn': '2',
+            'period': '12',
+            'mbuffer_size': '16',
+            'minute': '0',
+            'hour': '0',
+            'flags': '0',
+            'estimations': '0',
+            'force': '0',
+            'reverse_capable': '0',
+            'sync-recursive': '0',
+            'auto-clone': '0',
+            'flip_options': '0',
+            'direction_flipped': '0',
+            'retry': '0',
+            'success_counter': '0',
+            'dircontent': '0',
+            'zip_level': '0',
+            'auto-mount': '0',
+            'marker': '',
+            'exclude': '',
+            'run_history': '',
+            'progress-marker': '',
+            'from-snapshot': '',
+            'latest-suffix': '',
+            'trunk': '',
+            'options': ''
+        }
+        try:
+            fmri = self.nms.autosvc.fmri_create('auto-sync', comment,
+                                                src_path, 0, payload)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to create migration service '
+                      'with payload %(payload)s: %(error)s',
+                      {'payload': payload, 'error': error})
+            return False
+        if not self._svc_state(fmri, 'online'):
+            self._svc_cleanup(fmri)
+            return False
+        service_running = False
+        try:
+            self.nms.autosvc.execute(fmri)
+            service_running = True
+            LOG.info('Migration service %(fmri)s successfully started',
+                     {'fmri': fmri})
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to start migration service %(fmri)s: %(error)s',
+                      {'fmri': fmri, 'error': error})
+        if not service_running:
+            LOG.error('Migration service %(fmri)s is offline',
+                      {'fmri': fmri})
+            self._svc_cleanup(fmri)
+            return False
+        service_history = None
+        service_retries = retries
+        service_progress = 0
+        while service_retries and not service_history:
+            greenthread.sleep(delay)
+            service_retries -= 1
+            try:
+                service_props = self.nms.autosvc.get_child_props(fmri, '')
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to get properties of migration service '
+                          '%(fmri)s: %(error)s',
+                          {'fmri': fmri, 'error': error})
+                continue
+            service_history = service_props.get('zfs/run_history')
+            service_started = service_props.get('zfs/time_started')
+            if service_started == 'N/A':
+                continue
+            progress = self._svc_progress(fmri)
+            if progress > service_progress:
+                service_progress = progress
+                service_retries = retries
+            LOG.info('Migration service %(fmri)s replication progress: '
+                     '%(service_progress)s%%',
+                     {'fmri': fmri, 'service_progress': service_progress})
+        if not service_history:
+            self._svc_cleanup(fmri)
+            return False
+        volume_migrated = self._svc_result(fmri)
+        self._svc_cleanup(fmri, volume_migrated)
+        if volume_migrated:
+            try:
+                self.delete_volume(volume)
+            except jsonrpc.NmsException as error:
+                LOG.error('Failed to delete source volume %(volume)s '
+                          'after successful migration: %(error)s',
+                          {'volume': volume['name'], 'error': error})
+        return volume_migrated
+
+    def migrate_volume(self, context, volume, host):
+        """Migrate the volume to the specified host.
+
+        Returns a boolean indicating whether the migration occurred,
+        as well as model_update.
+
+        :param context: Security context
+        :param volume: A dictionary describing the volume to migrate
+        :param host: A dictionary describing the host to migrate to, where
+                     host['host'] is its name, and host['capabilities'] is a
+                     dictionary of its reported capabilities.
+        """
+        LOG.info('Start storage assisted volume migration '
+                 'for volume %(volume)s to host %(host)s',
+                 {'volume': volume['name'],
+                  'host': host['host']})
+        false_ret = (False, None)
+        if 'capabilities' not in host:
+            LOG.error('No host capabilities found for '
+                      'the destination host %(host)s',
+                      {'host': host['host']})
+            return false_ret
+        capabilities = host['capabilities']
+        required_capabilities = [
+            'vendor_name',
+            'location_info',
+            'storage_protocol',
+            'free_capacity_gb'
+        ]
+        for capability in required_capabilities:
+            if capability not in capabilities:
+                LOG.error('Required host capability %(capability)s not '
+                          'found for the destination host %(host)s',
+                          {'capability': capability, 'host': host['host']})
+                return false_ret
+        vendor = capabilities['vendor_name']
+        if vendor != self.vendor_name:
+            LOG.error('Unsupported vendor %(vendor)s found '
+                      'for the destination host %(host)s',
+                      {'vendor': vendor, 'host': host['host']})
+            return false_ret
+        location = capabilities['location_info']
+        try:
+            driver, nas_host, nas_path = location.split(':')
+        except ValueError as error:
+            LOG.error('Failed to parse location info %(location)s '
+                      'for the destination host %(host)s: %(error)s',
+                      {'location': location, 'host': host['host'],
+                       'error': error})
+            return false_ret
+        if not (driver and nas_host and nas_path):
+            LOG.error('Incomplete location info %(location)s '
+                      'found for the destination host %(host)s',
+                      {'location': location, 'host': host['host']})
+            return false_ret
+        if driver != self.driver_name:
+            LOG.error('Unsupported storage driver %(driver)s '
+                      'found for the destination host %(host)s',
+                      {'driver': driver, 'host': host['host']})
+            return false_ret
+        storage_protocol = capabilities['storage_protocol']
+        if storage_protocol != self.storage_protocol:
+            LOG.error('Unsupported storage protocol %(protocol)s '
+                      'found for the destination host %(host)s',
+                      {'protocol': storage_protocol,
+                       'host': host['host']})
+            return false_ret
+        free_capacity_gb = capabilities['free_capacity_gb']
+        if free_capacity_gb < volume['size']:
+            LOG.error('There is not enough space available on the '
+                      'destination host %(host)s to migrate volume '
+                      '%(volume)s, available space: %(free)sG, '
+                      'required space: %(required)sG',
+                      {'host': host['host'], 'volume': volume['name'],
+                       'free': free_capacity_gb,
+                       'required': volume['size']})
+            return false_ret
+        if self._migrate_volume(volume, nas_host, nas_path):
+            return (True, None)
+        return false_ret
+
+    def update_migrated_volume(self, context, volume, new_volume,
+                               original_volume_status):
+        """Return model update for migrated volume.
+
+        This method should rename the back-end volume name on the
+        destination host back to its original name on the source host.
+
+        :param context: The context of the caller
+        :param volume: The original volume that was migrated to this backend
+        :param new_volume: The migration volume object that was created on
+                           this backend as part of the migration process
+        :param original_volume_status: The status of the original volume
+        :returns: model_update to update DB with any needed changes
+        """
+        name_id = None
+        volume_path = self._get_volume_path(volume)
+        new_volume_path = self._get_volume_path(new_volume)
+        try:
+            self.terminate_connection(new_volume, None)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to terminate all connections '
+                      'to migrated volume %(volume)s before '
+                      'renaming: %(error)s',
+                      {'volume': new_volume['name'],
+                       'error': error})
+        cmd = 'zfs rename %(new_volume)s %(volume)s' % {
+            'new_volume': new_volume_path,
+            'volume': volume_path
+        }
+        try:
+            self.nms.appliance.execute(cmd)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to rename volume %(new_volume)s '
+                      'to %(volume)s after migration: %(error)s',
+                      {'new_volume': new_volume['name'],
+                       'volume': volume['name'],
+                       'error': error})
+            name_id = new_volume._name_id or new_volume.id
+        model_update = {'_name_id': name_id}
+        return model_update
+
+    def retype(self, context, volume, new_type, diff, host):
+        """Convert the volume to be of the new type."""
+        pass
 
     def create_snapshot(self, snapshot):
         """Creates a snapshot.
 
         :param snapshot: snapshot reference
         """
-        volume = self._get_snapshot_volume(snapshot)
-        nfs_share = volume['provider_location']
-        nms = self.share2nms[nfs_share]
-        vol, dataset = self._get_share_datasets(nfs_share)
-        folder = '%s/%s/%s' % (vol, dataset, volume['name'])
-        nms.folder.create_snapshot(folder, snapshot['name'], '-r')
+        snapshot_path = self._get_snapshot_path(snapshot)
+        volume_path, snapshot_name = snapshot_path.split('@')
+        self.nms.folder.create_snapshot(volume_path, snapshot_name, '')
 
     def delete_snapshot(self, snapshot):
         """Deletes a snapshot.
 
         :param snapshot: snapshot reference
         """
-        volume = self._get_snapshot_volume(snapshot)
-        nfs_share = volume['provider_location']
-        nms = self.share2nms[nfs_share]
-        vol, dataset = self._get_share_datasets(nfs_share)
-        folder = '%s/%s/%s' % (vol, dataset, volume['name'])
-        try:
-            nms.snapshot.destroy('%s@%s' % (folder, snapshot['name']), '')
-        except exception.NexentaException as exc:
-            if 'does not exist' in exc.args[0]:
-                LOG.info('Snapshot %(folder)s@%(snapshot)s does not '
-                         'exist, it was already deleted.',
-                         {
-                             'folder': folder,
-                             'snapshot': snapshot,
-                         })
-                return
-            elif 'has dependent clones' in exc.args[0]:
-                LOG.info('Snapshot %(folder)s@%(snapshot)s has dependent '
-                         'clones, it will be deleted later.',
-                         {
-                             'folder': folder,
-                             'snapshot': snapshot,
-                         })
-                return
+        snapshot_path = self._get_snapshot_path(snapshot)
+        self.nms.snapshot.destroy(snapshot_path, '-d')
 
-    def _create_sparsed_file(self, nms, path, size):
-        """Creates file with 0 disk usage.
+    def _set_volume_acl(self, volume):
+        volume_path = self._get_volume_path(volume)
+        group = 'everyone@'
+        acl = {
+            'allow': [
+                'full_set',
+                'dir_inherit',
+                'file_inherit'
+            ]
+        }
+        self.nms.folder.set_group_acl(volume_path, group, acl)
 
-        :param nms: nms object
-        :param path: path to new file
-        :param size: size of file
+    def _get_volume_share(self, volume):
+        """Return NFS share path for the volume."""
+        volume_path = self._get_volume_path(volume)
+        filesystem = self.nms.folder.get_child_props(volume_path, '')
+        if filesystem['mountpoint'] == 'none':
+            self.nms.folder.inherit_prop(volume_path, 'mountpoint', 0)
+            filesystem = self.nms.folder.get_child_props(volume_path, '')
+        if filesystem['mounted'] != 'yes':
+            self.nms.folder.mount(volume_path, 0)
+        share = '%s:%s' % (self.nas_host, filesystem['mountpoint'])
+        return share
+
+    def _local_volume_dir(self, volume):
+        """Get volume dir (mounted locally fs path) for given volume.
+
+        :param volume: volume reference
         """
-        nms.appliance.execute(
-            'truncate --size %(size)dG %(path)s' % {
-                'path': path,
-                'size': size
-            }
-        )
-
-    def _create_regular_file(self, nms, path, size):
-        """Creates regular file of given size.
-
-        Takes a lot of time for large files.
-
-        :param nms: nms object
-        :param path: path to new file
-        :param size: size of file
-        """
-        block_size_mb = 1
-        block_count = size * units.Gi / (block_size_mb * units.Mi)
-
-        LOG.info('Creating regular file: %s.'
-                 'This may take some time.', path)
-
-        nms.appliance.execute(
-            'dd if=/dev/zero of=%(path)s bs=%(bs)dM count=%(count)d' % {
-                'path': path,
-                'bs': block_size_mb,
-                'count': block_count
-            }
-        )
-
-        LOG.info('Regular file: %s created.', path)
-
-    def _set_rw_permissions_for_all(self, nms, path):
-        """Sets 666 permissions for the path.
-
-        :param nms: nms object
-        :param path: path to file
-        """
-        nms.appliance.execute('chmod ugo+rw %s' % path)
+        share = self._get_volume_share(volume)
+        if six.PY3:
+            share = share.encode('utf-8')
+        path = hashlib.md5(share).hexdigest()
+        return os.path.join(self.mount_point_base, path)
 
     def local_path(self, volume):
         """Get volume path (mounted locally fs path) for given volume.
 
         :param volume: volume reference
         """
-        nfs_share = volume['provider_location']
-        return os.path.join(self._get_mount_point_for_share(nfs_share),
-                            volume['name'], 'volume')
+        volume_dir = self._local_volume_dir(volume)
+        return os.path.join(volume_dir, 'volume')
 
-    def _get_mount_point_for_share(self, nfs_share):
-        """Returns path to mount point NFS share.
+    def get_volume_stats(self, refresh=False):
+        """Get volume stats.
 
-        :param nfs_share: example 172.18.194.100:/var/nfs
+        If 'refresh' is True, update the stats first.
         """
-        nfs_share = nfs_share.encode('utf-8')
-        return os.path.join(self.configuration.nexenta_mount_point_base,
-                            hashlib.md5(nfs_share).hexdigest())
+        if refresh or not self._stats:
+            self._update_volume_stats()
 
-    def remote_path(self, volume):
-        """Get volume path (mounted remotely fs path) for given volume.
-
-        :param volume: volume reference
-        """
-        nfs_share = volume['provider_location']
-        share = nfs_share.split(':')[1].rstrip('/')
-        return '%s/%s/volume' % (share, volume['name'])
-
-    def _share_folder(self, nms, volume, folder):
-        """Share NFS folder on NexentaStor Appliance.
-
-        :param nms: nms object
-        :param volume: volume name
-        :param folder: folder name
-        """
-        path = '%s/%s' % (volume, folder.lstrip('/'))
-        share_opts = {
-            'read_write': '*',
-            'read_only': '',
-            'root': 'nobody',
-            'extra_options': 'anon=0',
-            'recursive': 'true',
-            'anonymous_rw': 'true',
-        }
-        LOG.debug('Sharing folder %s on Nexenta Store', folder)
-        nms.netstorsvc.share_folder('svc:/network/nfs/server:default', path,
-                                    share_opts)
-
-    def _load_shares_config(self, share_file):
-        self.shares = {}
-        self.share2nms = {}
-
-        for share in self._read_config_file(share_file):
-            # A configuration line may be either:
-            # host:/share_name  http://user:pass@host:[port]/
-            # or
-            # host:/share_name  http://user:pass@host:[port]/
-            #    -o options=123,rw --other
-            if not share.strip():
-                continue
-            if share.startswith('#'):
-                continue
-
-            share_info = re.split(r'\s+', share, 2)
-
-            share_address = share_info[0].strip()
-            nms_url = share_info[1].strip()
-            share_opts = share_info[2].strip() if len(share_info) > 2 else None
-
-            if not re.match(r'.+:/.+', share_address):
-                LOG.warning("Share %s ignored due to invalid format. "
-                            "Must be of form address:/export.",
-                            share_address)
-                continue
-
-            self.shares[share_address] = share_opts
-            self.share2nms[share_address] = self._get_nms_for_url(nms_url)
-
-        LOG.debug('Shares loaded: %s', self.shares)
-
-    def _get_subshare_mount_point(self, nfs_share, volume):
-        mnt_path = '%s/%s' % (
-            self._get_mount_point_for_share(nfs_share), volume['name'])
-        sub_share = '%s/%s' % (nfs_share, volume['name'])
-        return sub_share, mnt_path
-
-    def _ensure_share_mounted(self, nfs_share, mount_path=None):
-        """Ensure that NFS share is mounted on the host.
-
-        Unlike the parent method this one accepts mount_path as an optional
-        parameter and uses it as a mount point if provided.
-
-        :param nfs_share: NFS share name
-        :param mount_path: mount path on the host
-        """
-        mnt_flags = []
-        if self.shares.get(nfs_share) is not None:
-            mnt_flags = self.shares[nfs_share].split()
-        num_attempts = max(1, self.configuration.nfs_mount_attempts)
-        for attempt in range(num_attempts):
-            try:
-                if mount_path is None:
-                    self._remotefsclient.mount(nfs_share, mnt_flags)
-                else:
-                    if mount_path in self._remotefsclient._read_mounts():
-                        LOG.info('Already mounted: %s', mount_path)
-                        return
-
-                    self._execute('mkdir', '-p', mount_path,
-                                  check_exit_code=False)
-                    self._remotefsclient._mount_nfs(nfs_share, mount_path,
-                                                    mnt_flags)
-                return
-            except Exception as e:
-                if attempt == (num_attempts - 1):
-                    LOG.error('Mount failure for %(share)s after '
-                              '%(count)d attempts.', {
-                                  'share': nfs_share,
-                                  'count': num_attempts})
-                    raise exception.NfsException(six.text_type(e))
-                LOG.warning(
-                    'Mount attempt %(attempt)d failed: %(error)s. '
-                    'Retrying mount ...', {
-                        'attempt': attempt,
-                        'error': e})
-                greenthread.sleep(1)
-
-    def _mount_subfolders(self):
-        ctxt = context.get_admin_context()
-        vol_entries = self.db.volume_get_all_by_host(ctxt, self.host)
-        for vol in vol_entries:
-            nfs_share = vol['provider_location']
-            if ((nfs_share in self.shares) and
-                    (self._get_nfs_server_version(nfs_share) < 4)):
-                sub_share, mnt_path = self._get_subshare_mount_point(
-                    nfs_share, vol)
-                self._ensure_share_mounted(sub_share, mnt_path)
-
-    def _get_nfs_server_version(self, share):
-        if not self.nfs_versions.get(share):
-            nms = self.share2nms[share]
-            nfs_opts = nms.netsvc.get_confopts(
-                'svc:/network/nfs/server:default', 'configure')
-            try:
-                self.nfs_versions[share] = int(
-                    nfs_opts['nfs_server_versmax']['current'])
-            except KeyError:
-                self.nfs_versions[share] = int(
-                    nfs_opts['server_versmax']['current'])
-        return self.nfs_versions[share]
-
-    def _get_capacity_info(self, nfs_share):
-        """Calculate available space on the NFS share.
-
-        :param nfs_share: example 172.18.194.100:/var/nfs
-        """
-        nms = self.share2nms[nfs_share]
-        ns_volume, ns_folder = self._get_share_datasets(nfs_share)
-        folder_props = nms.folder.get_child_props('%s/%s' % (ns_volume,
-                                                             ns_folder),
-                                                  'used|available')
-        free = utils.str2size(folder_props['available'])
-        allocated = utils.str2size(folder_props['used'])
-        self.shares_with_capacities[nfs_share] = {
-            'free': utils.str2gib_size(free),
-            'total': utils.str2gib_size(free + allocated)}
-        return free + allocated, free, allocated
-
-    def _get_nms_for_url(self, url):
-        """Returns initialized nms object for url."""
-        auto, scheme, user, password, host, port, path = (
-            utils.parse_nms_url(url))
-        return jsonrpc.NexentaJSONProxy(scheme, host, port, path, user,
-                                        password, auto=auto,
-                                        verify=self.verify_ssl)
-
-    def _get_snapshot_volume(self, snapshot):
-        ctxt = context.get_admin_context()
-        return db.volume_get(ctxt, snapshot['volume_id'])
-
-    def _get_volroot(self, nms):
-        """Returns volroot property value from NexentaStor appliance."""
-        if not self.nms_cache_volroot:
-            return nms.server.get_prop('volroot')
-        if nms not in self._nms2volroot:
-            self._nms2volroot[nms] = nms.server.get_prop('volroot')
-        return self._nms2volroot[nms]
-
-    def _get_share_datasets(self, nfs_share):
-        nms = self.share2nms[nfs_share]
-        volroot = self._get_volroot(nms)
-        path = nfs_share.split(':')[1][len(volroot):].strip('/')
-        volume_name = path.split('/')[0]
-        folder_name = '/'.join(path.split('/')[1:])
-        return volume_name, folder_name
-
-    def _get_clone_snapshot_name(self, volume):
-        """Return name for snapshot that will be used to clone the volume."""
-        return 'cinder-clone-snapshot-%(id)s' % volume
-
-    def _is_clone_snapshot_name(self, snapshot):
-        """Check if snapshot is created for cloning."""
-        name = snapshot.split('@')[-1]
-        return name.startswith('cinder-clone-snapshot-')
+        return self._stats
 
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor appliance."""
-        LOG.debug('Updating volume stats')
-        total_space = 0
-        free_space = 0
-        share = None
-        for _share in self._mounted_shares:
-            if self.shares_with_capacities[_share]['free'] > free_space:
-                free_space = self.shares_with_capacities[_share]['free']
-                total_space = self.shares_with_capacities[_share]['total']
-                share = _share
-
-        location_info = '%(driver)s:%(share)s' % {
-            'driver': self.__class__.__name__,
-            'share': share
+        pool_name = self.root_path.split('/')[0]
+        stats = {'available': None, 'used': None}
+        payload = '|'.join(stats.keys())
+        props = self.nms.folder.get_child_props(self.root_path, payload)
+        for key in stats:
+            if not props.get(key):
+                LOG.error('Unable to get %(key)s statistics for %(path)s '
+                          'from properties %(props)s',
+                          {'path': self.root_path, 'props': props})
+                continue
+            text = '%sB' % props[key]
+            try:
+                value = strutils.string_to_bytes(text, return_int=True)
+                stats[key] = value
+            except ValueError as error:
+                LOG.error('Failed to convert text value %(text)s to '
+                          'bytes for the %(key)s property: %(error)s',
+                          {'text': text, 'key': key, 'error': error})
+        if None in stats.values():
+            allocated_capacity_gb = 'unknown'
+            free_capacity_gb = 'unknown'
+            total_capacity_gb = 'unknown'
+        else:
+            free_capacity_gb = stats['available'] // units.Gi
+            allocated_capacity_gb = stats['used'] // units.Gi
+            total_capacity_gb = free_capacity_gb + allocated_capacity_gb
+        provisioned_capacity_gb = total_volumes = 0
+        ctxt = context.get_admin_context()
+        volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        for volume in volumes:
+            provisioned_capacity_gb += volume['size']
+            total_volumes += 1
+        volume_backend_name = (
+            self.configuration.safe_get('volume_backend_name'))
+        if not volume_backend_name:
+            LOG.error('Failed to get configured volume backend name')
+            volume_backend_name = '%(product)s_%(protocol)s' % {
+                'product': self.product_name,
+                'protocol': self.storage_protocol
+            }
+        description = (
+            self.configuration.safe_get('nexenta_dataset_description'))
+        if not description:
+            description = '%(product)s %(host)s:%(path)s' % {
+                'product': self.product_name,
+                'host': self.configuration.nas_host,
+                'path': self.configuration.nas_share_path
+            }
+        max_over_subscription_ratio = (
+            self.configuration.safe_get('max_over_subscription_ratio'))
+        reserved_percentage = (
+            self.configuration.safe_get('reserved_percentage'))
+        if reserved_percentage is None:
+            reserved_percentage = 0
+        location_info = '%(driver)s:%(host)s:%(path)s' % {
+            'driver': self.driver_name,
+            'host': self.configuration.nas_host,
+            'path': self.configuration.nas_share_path
         }
-        nms_url = self.share2nms[share].url
+        display_name = 'Capabilities of %(product)s %(protocol)s driver' % {
+            'product': self.product_name,
+            'protocol': self.storage_protocol
+        }
+        visibility = 'public'
         self._stats = {
-            'vendor_name': 'Nexenta',
-            'dedup': self.volume_deduplication,
-            'compression': self.volume_compression,
-            'description': self.volume_description,
-            'nms_url': nms_url,
-            'ns_shares': self.shares_with_capacities,
             'driver_version': self.VERSION,
-            'storage_protocol': 'NFS',
-            'total_capacity_gb': total_space,
-            'free_capacity_gb': free_space,
-            'reserved_percentage': self.configuration.reserved_percentage,
-            'QoS_support': False,
+            'vendor_name': self.vendor_name,
+            'storage_protocol': self.storage_protocol,
+            'volume_backend_name': volume_backend_name,
             'location_info': location_info,
-            'volume_backend_name': self.backend_name,
-            'nfs_mount_point_base': self.nfs_mount_point_base
+            'description': description,
+            'display_name': display_name,
+            'pool_name': pool_name,
+            'multiattach': True,
+            'QoS_support': False,
+            'consistencygroup_support': False,
+            'consistent_group_snapshot_enabled': False,
+            'online_extend_support': True,
+            'sparse_copy_volume': True,
+            'thin_provisioning_support': True,
+            'thick_provisioning_support': True,
+            'total_capacity_gb': total_capacity_gb,
+            'allocated_capacity_gb': allocated_capacity_gb,
+            'free_capacity_gb': free_capacity_gb,
+            'provisioned_capacity_gb': provisioned_capacity_gb,
+            'total_volumes': total_volumes,
+            'max_over_subscription_ratio': max_over_subscription_ratio,
+            'reserved_percentage': reserved_percentage,
+            'visibility': visibility,
+            'dedup': self.configuration.nexenta_dataset_dedup,
+            'compression': self.configuration.nexenta_dataset_compression,
+            'nms_url': self.nms.url
         }
+        LOG.debug('Updated volume backend statistics for host %(host)s '
+                  'and volume backend %(volume_backend_name)s: %(stats)s',
+                  {'host': self.host,
+                   'volume_backend_name': volume_backend_name,
+                   'stats': self._stats})
+
+    def _get_volume_path(self, volume):
+        """Return ZFS datset path for the volume."""
+        return posixpath.join(self.root_path, volume['name'])
+
+    def _get_snapshot_path(self, snapshot):
+        """Return ZFS snapshot path for the snapshot."""
+        volume_name = snapshot['volume_name']
+        snapshot_name = snapshot['name']
+        volume_path = posixpath.join(self.root_path, volume_name)
+        return '%s@%s' % (volume_path, snapshot_name)
+
+    def _get_host_addresses(self):
+        """Return NexentaStor IP addresses list."""
+        addresses = []
+        items = self.nms.appliance.execute('ipadm show-addr -p -o addr')
+        for item in items:
+            cidr = six.text_type(item)
+            addr, mask = cidr.split('/')
+            obj = ipaddress.ip_address(addr)
+            if not obj.is_loopback:
+                addresses.append(obj.exploded)
+        LOG.debug('Configured IP addresses: %(addresses)s',
+                  {'addresses': addresses})
+        return addresses
+
+    @staticmethod
+    def _match_template(template, name):
+        sequence = difflib.SequenceMatcher(None, name, template)
+        added = deleted = result = ''
+        for tag, a1, a2, b1, b2 in sequence.get_opcodes():
+            if tag == 'equal':
+                result += ''.join(sequence.a[a1:a2])
+            elif tag == 'delete':
+                deleted += ''.join(sequence.a[a1:a2])
+            elif tag == 'insert':
+                added += ''.join(sequence.b[b1:b2])
+            elif tag == 'replace':
+                result += ''.join(sequence.b[b1:b2])
+        if result == template and not (added or deleted):
+            return True
+        return False

--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -14,26 +14,24 @@
 #    under the License.
 
 import ipaddress
-import math
+import posixpath
 import random
-import six
 import uuid
 
-from eventlet import greenthread
 from oslo_log import log as logging
+from oslo_utils import strutils
 from oslo_utils import units
-from six.moves import urllib
+import six
 
 from cinder import context
-from cinder import db
-from cinder import exception
 from cinder.i18n import _
+from cinder import objects
 from cinder.volume import driver
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 from cinder.volume.drivers.nexenta import options
-from cinder.volume.drivers.nexenta import utils
+from cinder.volume import utils
+from cinder.volume import volume_types
 
-VERSION = '1.3.6'
 LOG = logging.getLogger(__name__)
 
 
@@ -41,10 +39,13 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
     """Executes volume driver commands on Nexenta Appliance.
 
     Version history:
+
+    .. code-block:: none
+
         1.0.0 - Initial driver version.
         1.1.0 - Added HTTPS support.
-                Added use of sessions for REST calls.
-                Added abandoned volumes and snapshots cleanup.
+              - Added use of sessions for REST calls.
+              - Added abandoned volumes and snapshots cleanup.
         1.2.0 - Failover support.
         1.2.1 - Configurable luns per parget, target prefix.
         1.3.0 - Removed target/TG caching, added support for target portals
@@ -54,26 +55,50 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         1.3.4 - Adapted NexentaException for the latest Cinder.
         1.3.5 - Added deferred deletion for snapshots.
         1.3.6 - Fixed race between volume/clone deletion.
+        1.3.7 - Added consistency group support.
+        1.3.8 - Added volume multi-attach.
+        1.4.0 - Refactored iSCSI driver.
+              - Added pagination support.
+              - Added configuration parameters for REST API connect/read
+                timeouts, connection retries and backoff factor.
+              - Fixed HA failover.
+              - Added retries on EBUSY errors.
+              - Fixed HTTP authentication.
+              - Added coordination for dataset operations.
+        1.4.1 - Support for NexentaStor tenants.
+        1.4.2 - Added manage/unmanage/manageable-list volume/snapshot support.
+        1.4.3 - Added consistency group capability to generic volume group.
+        1.4.4 - Added storage assisted volume migration.
+                Added support for volume retype.
+                Added support for volume type extra specs.
+                Added vendor capabilities support.
+        1.4.5 - Added report discard support.
     """
 
-    VERSION = VERSION
-
-    # ThirdPartySystems wiki page
+    VERSION = '1.4.5'
     CI_WIKI_NAME = "Nexenta_CI"
+
+    vendor_name = 'Nexenta'
+    product_name = 'NexentaStor5'
+    storage_protocol = 'iSCSI'
+    driver_volume_type = 'iscsi'
 
     def __init__(self, *args, **kwargs):
         super(NexentaISCSIDriver, self).__init__(*args, **kwargs)
+        if not self.configuration:
+            message = (_('%(product_name)s %(storage_protocol)s '
+                         'backend configuration not found')
+                       % {'product_name': self.product_name,
+                          'storage_protocol': self.storage_protocol})
+            raise jsonrpc.NefException(code='ENODATA', message=message)
+        self.configuration.append_config_values(
+            options.NEXENTA_CONNECTION_OPTS)
+        self.configuration.append_config_values(
+            options.NEXENTA_ISCSI_OPTS)
+        self.configuration.append_config_values(
+            options.NEXENTA_DATASET_OPTS)
         self.nef = None
-        if self.configuration:
-            self.configuration.append_config_values(
-                options.NEXENTA_CONNECTION_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_ISCSI_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_DATASET_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_RRMGR_OPTS)
-        self.verify_ssl = self.configuration.driver_ssl_cert_verify
+        self.driver_name = self.__class__.__name__
         self.target_prefix = self.configuration.nexenta_target_prefix
         self.target_group_prefix = (
             self.configuration.nexenta_target_group_prefix)
@@ -81,141 +106,87 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         self.luns_per_target = self.configuration.nexenta_luns_per_target
         self.lu_writebackcache_disabled = (
             self.configuration.nexenta_lu_writebackcache_disabled)
-        self.use_https = self.configuration.nexenta_use_https
-        self.nef_host = self.configuration.nexenta_rest_address
         self.iscsi_host = self.configuration.nexenta_host
-        self.nef_port = self.configuration.nexenta_rest_port
-        self.nef_user = self.configuration.nexenta_user
-        self.nef_password = self.configuration.nexenta_password
-        self.storage_pool = self.configuration.nexenta_volume
+        self.pool = self.configuration.nexenta_volume
         self.volume_group = self.configuration.nexenta_volume_group
         self.portal_port = self.configuration.nexenta_iscsi_target_portal_port
         self.portals = self.configuration.nexenta_iscsi_target_portals
-        self.dataset_compression = (
-            self.configuration.nexenta_dataset_compression)
-        self.dataset_deduplication = self.configuration.nexenta_dataset_dedup
-        self.dataset_description = (
-            self.configuration.nexenta_dataset_description)
         self.iscsi_target_portal_port = (
             self.configuration.nexenta_iscsi_target_portal_port)
-
-    @property
-    def backend_name(self):
-        backend_name = None
-        if self.configuration:
-            backend_name = self.configuration.safe_get('volume_backend_name')
-        if not backend_name:
-            backend_name = self.__class__.__name__
-        return backend_name
+        self.root_path = posixpath.join(self.pool, self.volume_group)
+        self.group_snapshot_template = (
+            self.configuration.nexenta_group_snapshot_template)
+        self.origin_snapshot_template = (
+            self.configuration.nexenta_origin_snapshot_template)
 
     def do_setup(self, context):
-        host = self.nef_host or self.iscsi_host
-        self.nef = jsonrpc.NexentaJSONProxy(
-            host, self.nef_port, self.nef_user, self.nef_password,
-            self.use_https, self.storage_pool, self.verify_ssl)
-        url = 'storage/volumeGroups'
-        data = {
-            'path': '/'.join([self.storage_pool, self.volume_group]),
-            'volumeBlockSize': (
-                self.configuration.nexenta_ns5_blocksize * units.Ki)
-        }
-        try:
-            self.nef.post(url, data)
-        except exception.NexentaException as ex:
-            err = utils.ex2err(ex)
-            if err['code'] == 'EEXIST':
-                LOG.debug('Volume group %(group)s already exists',
-                          {'group': self.volume_group})
-            else:
-                raise ex
+        self.nef = jsonrpc.NefProxy(self.driver_volume_type,
+                                    self.root_path,
+                                    self.configuration)
 
     def check_for_setup_error(self):
-        """Verify that the zfs pool, vg and iscsi service exists."""
-        url = 'storage/pools/%s' % self.storage_pool
-        self.nef.get(url)
-        url = 'storage/volumeGroups/%s' % '%2F'.join([
-            self.storage_pool, self.volume_group])
+        """Check root volume group and iSCSI target service."""
         try:
-            self.nef.get(url)
-        except exception.NexentaException:
-            msg = (_('Volume group %(group)s not found')
-                   % {'group': self.volume_group})
-            raise exception.NexentaException(msg)
-        services = self.nef.get('services')
-        for service in services['data']:
-            if service['name'] == 'iscsit':
-                if service['state'] != 'online':
-                    msg = _('iSCSI target service is not running')
-                    raise exception.NexentaException(msg)
-                break
+            self.nef.volumegroups.get(self.root_path)
+        except jsonrpc.NefException as error:
+            if error.code != 'ENOENT':
+                raise
+            block_size = self.configuration.nexenta_ns5_blocksize
+            if block_size < 512:
+                block_size *= units.Ki
+            payload = {
+                'path': self.root_path,
+                'volumeBlockSize': block_size
+            }
+            self.nef.volumegroups.create(payload)
+        service = self.nef.services.get('iscsit')
+        if service['state'] != 'online':
+            message = (_('iSCSI target service is not online: %(state)s')
+                       % {'state': service['state']})
+            raise jsonrpc.NefException(code='ESRCH', message=message)
 
+    @jsonrpc.synchronized
     def create_volume(self, volume):
         """Create a zfs volume on appliance.
 
         :param volume: volume reference
         :returns: model update dict for volume reference
         """
-        LOG.debug('Create volume %(volume)s',
-                  {'volume': volume['name']})
-        url = 'storage/volumes'
-        path = '/'.join([self.storage_pool, self.volume_group, volume['name']])
-        data = {
-            'path': path,
-            'volumeSize': volume['size'] * units.Gi,
-            'volumeBlockSize': (
-                self.configuration.nexenta_ns5_blocksize * units.Ki),
-            'sparseVolume': self.configuration.nexenta_sparse
-        }
-        self.nef.post(url, data)
+        volume_path = self._get_volume_path(volume)
+        volume_size = volume['size'] * units.Gi
+        properties = self.nef.volumes.properties
+        payload = self._get_vendor_properties(volume, properties)
+        payload.update({
+            'path': volume_path,
+            'volumeSize': volume_size
+        })
+        self.nef.volumes.create(payload)
 
+    @jsonrpc.synchronized
     def delete_volume(self, volume):
         """Deletes a logical volume.
 
         :param volume: volume reference
         """
-        LOG.debug('Delete volume %(volume)s',
-                  {'volume': volume['name']})
-        path = self._get_volume_path(volume)
-        params = {'path': path}
-        url = 'storage/volumes?%s' % (
-            urllib.parse.urlencode(params))
-        data = self.nef.get(url).get('data')
-        if not data:
-            return
-        params = {'snapshots': 'true'}
-        url = 'storage/volumes/%s?%s' % (
-            urllib.parse.quote_plus(path),
-            urllib.parse.urlencode(params))
+        volume_path = self._get_volume_path(volume)
+        delete_payload = {'snapshots': True}
         try:
-            self.nef.delete(url)
-        except exception.NexentaException as ex:
-            err = utils.ex2err(ex)
-            if err['code'] == 'EEXIST':
-                params = {'parent': path}
-                url = 'storage/snapshots?%s' % (
-                    urllib.parse.urlencode(params))
-                snap_map = {}
-                for snap in self.nef.get(url)['data']:
-                    url = 'storage/snapshots/%s' % (
-                        urllib.parse.quote_plus(snap['path']))
-                    data = self.nef.get(url)
-                    if data and data.get('clones'):
-                        snap_map[data['creationTxg']] = snap['path']
-                if snap_map:
-                    snap = snap_map[max(snap_map)]
-                    url = 'storage/snapshots/%s' % urllib.parse.quote_plus(
-                        snap)
-                    clone = self.nef.get(url)['clones'][0]
-                    url = 'storage/volumes/%s/promote' % (
-                        urllib.parse.quote_plus(clone))
-                    self.nef.post(url)
-                params = {'snapshots': 'true'}
-                url = 'storage/volumes/%s?%s' % (
-                    urllib.parse.quote_plus(path),
-                    urllib.parse.urlencode(params))
-                self.nef.delete(url)
-            else:
-                raise ex
+            self.nef.volumes.delete(volume_path, delete_payload)
+        except jsonrpc.NefException as error:
+            if error.code != 'EEXIST':
+                raise
+            snapshots_tree = {}
+            snapshots_payload = {'parent': volume_path, 'fields': 'path'}
+            snapshots = self.nef.snapshots.list(snapshots_payload)
+            for snapshot in snapshots:
+                clones_payload = {'fields': 'clones,creationTxg'}
+                data = self.nef.snapshots.get(snapshot['path'], clones_payload)
+                if data['clones']:
+                    snapshots_tree[data['creationTxg']] = data['clones'][0]
+            if snapshots_tree:
+                clone_path = snapshots_tree[max(snapshots_tree)]
+                self.nef.volumes.promote(clone_path)
+            self.nef.volumes.delete(volume_path, delete_payload)
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -223,66 +194,42 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: volume reference
         :param new_size: volume new size in GB
         """
-        LOG.debug('Extend volume %(volume)s, new size: %(size)sGB',
-                  {'volume': volume['name'],
-                   'size': new_size})
-        path = '%2F'.join([
-            self.storage_pool, self.volume_group, volume['name']])
-        url = 'storage/volumes/%s' % path
+        volume_path = self._get_volume_path(volume)
+        payload = {'volumeSize': new_size * units.Gi}
+        self.nef.volumes.set(volume_path, payload)
 
-        self.nef.put(url, {'volumeSize': new_size * units.Gi})
-
+    @jsonrpc.synchronized
     def create_snapshot(self, snapshot):
         """Creates a snapshot.
 
         :param snapshot: snapshot reference
         """
-        snapshot_vol = self._get_snapshot_volume(snapshot)
-        LOG.info('Create snapshot %(snapshot)s for volume %(volume)s',
-                 {'snapshot': snapshot['name'],
-                  'volume': snapshot_vol['name']})
-        volume_path = self._get_volume_path(snapshot_vol)
-        url = 'storage/snapshots'
-        data = {'path': '%s@%s' % (volume_path, snapshot['name'])}
-        self.nef.post(url, data)
+        snapshot_path = self._get_snapshot_path(snapshot)
+        payload = {'path': snapshot_path}
+        self.nef.snapshots.create(payload)
 
+    @jsonrpc.synchronized
     def delete_snapshot(self, snapshot):
         """Deletes a snapshot.
 
         :param snapshot: snapshot reference
         """
-        LOG.debug('Delete snapshot: %(snapshot)s',
-                  {'snapshot': snapshot['name']})
-        volume = self._get_snapshot_volume(snapshot)
-        path = '%s@%s' % (self._get_volume_path(volume),
-                          snapshot['name'])
-        params = {'path': path}
-        url = 'storage/snapshots?%s' % urllib.parse.urlencode(params)
-        snap_data = self.nef.get(url).get('data')
-        if not snap_data:
-            return
-        params = {'defer': 'true'}
-        url = 'storage/snapshots/%s?%s' % (
-            urllib.parse.quote_plus(path),
-            urllib.parse.urlencode(params))
-        self.nef.delete(url)
+        snapshot_path = self._get_snapshot_path(snapshot)
+        payload = {'defer': True}
+        self.nef.snapshots.delete(snapshot_path, payload)
 
+    @jsonrpc.synchronized
     def create_volume_from_snapshot(self, volume, snapshot):
         """Create new volume from other's snapshot on appliance.
 
         :param volume: reference of volume to be created
         :param snapshot: reference of source snapshot
         """
-        LOG.debug('Create volume %(volume)s from snapshot: %(snapshot)s',
-                 {'volume': volume['name'],
-                  'snapshot': snapshot['name']})
-        snapshot_vol = self._get_snapshot_volume(snapshot)
-        path = '%2F'.join([
-            self.storage_pool, self.volume_group, snapshot_vol['name']])
-        url = 'storage/snapshots/%s@%s/clone' % (path, snapshot['name'])
-        self.nef.post(url, {'targetPath': self._get_volume_path(volume)})
-        if (('size' in volume) and (
-                volume['size'] > snapshot['volume_size'])):
+        snapshot_path = self._get_snapshot_path(snapshot)
+        clone_path = self._get_volume_path(volume)
+        payload = {'targetPath': clone_path}
+        self.nef.snapshots.clone(snapshot_path, payload)
+        if volume['size'] > snapshot['volume_size']:
             self.extend_volume(volume, volume['size'])
 
     def create_cloned_volume(self, volume, src_vref):
@@ -291,45 +238,42 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: new volume reference
         :param src_vref: source volume reference
         """
-        snapshot = {'volume_name': src_vref['name'],
-                    'volume_id': src_vref['id'],
-                    'volume_size': src_vref['size'],
-                    'name': self._get_clone_snapshot_name(volume)}
-        LOG.debug('Create temporary snapshot %(snapshot)s '
-                  'for the original volume %(volume)s',
-                  {'snapshot': snapshot['name'],
-                   'volume': snapshot['volume_name']})
+        snapshot = {
+            'name': self.origin_snapshot_template % volume['id'],
+            'volume_id': src_vref['id'],
+            'volume_name': src_vref['name'],
+            'volume_size': src_vref['size']
+        }
         self.create_snapshot(snapshot)
-        LOG.debug('Create clone %(clone)s from '
-                  'temporary snapshot %(snapshot)s',
-                  {'clone': volume['name'],
-                   'snapshot': snapshot['name']})
         try:
             self.create_volume_from_snapshot(volume, snapshot)
-        except exception.NexentaException as ex:
-            LOG.debug('Volume creation failed, deleting temporary '
-                      'snapshot %(volume)s@%(snapshot)s',
-                      {'volume': snapshot['volume_name'],
-                       'snapshot': snapshot['name']})
+        except jsonrpc.NefException as error:
+            LOG.debug('Failed to create clone %(clone)s '
+                      'from volume %(volume)s: %(error)s',
+                      {'clone': volume['name'],
+                       'volume': src_vref['name'],
+                       'error': error})
+            raise
+        finally:
             try:
                 self.delete_snapshot(snapshot)
-            except (exception.NexentaException, exception.SnapshotIsBusy):
+            except jsonrpc.NefException as error:
                 LOG.debug('Failed to delete temporary snapshot '
-                          '%(volume)s@%(snapshot)s',
-                          {'volume': snapshot['volume_name'],
-                           'snapshot': snapshot['name']})
-            raise ex
+                          '%(volume)s@%(snapshot)s: %(error)s',
+                          {'volume': src_vref['name'],
+                           'snapshot': snapshot['name'],
+                           'error': error})
 
-    def create_export(self, _ctx, volume, connector):
-        """Export a volume."""
+    def create_export(self, context, volume, connector):
+        """Driver entry point to get the export info for a new volume."""
         pass
 
-    def ensure_export(self, _ctx, volume):
-        """Synchronously recreate an export for a volume."""
+    def ensure_export(self, context, volume):
+        """Driver entry point to get the export info for an existing volume."""
         pass
 
-    def remove_export(self, _ctx, volume):
-        """Remove an export for a volume."""
+    def remove_export(self, context, volume):
+        """Driver entry point to remove an export for a volume."""
         pass
 
     def terminate_connection(self, volume, connector, **kwargs):
@@ -339,29 +283,47 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param connector: a connector object
         :returns: dictionary of connection information
         """
-        info = {'driver_volume_type': 'iscsi', 'data': {}}
+        info = {'driver_volume_type': self.driver_volume_type, 'data': {}}
         host_iqn = None
         host_groups = []
         volume_path = self._get_volume_path(volume)
         if isinstance(connector, dict) and 'initiator' in connector:
-            host_iqn = connector.get('initiator')
+            connectors = []
+            if 'volume_attachment' in volume:
+                if isinstance(volume['volume_attachment'], list):
+                    for attachment in volume['volume_attachment']:
+                        if not isinstance(attachment, dict):
+                            continue
+                        if 'connector' not in attachment:
+                            continue
+                        connectors.append(attachment['connector'])
+            if connectors.count(connector) > 1:
+                LOG.debug('Detected %(count)s connections from host '
+                          '%(host_name)s (IP:%(host_ip)s) to volume '
+                          '%(volume)s, skip terminating connection',
+                          {'count': connectors.count(connector),
+                           'host_name': connector.get('host', 'unknown'),
+                           'host_ip': connector.get('ip', 'unknown'),
+                           'volume': volume['name']})
+                return True
+            host_iqn = connector['initiator']
             host_groups.append(options.DEFAULT_HOST_GROUP)
             host_group = self._get_host_group(host_iqn)
             if host_group is not None:
                 host_groups.append(host_group)
             LOG.debug('Terminate connection for volume %(volume)s '
                       'and initiator %(initiator)s',
-                      {'volume': volume_path, 'initiator': host_iqn})
+                      {'volume': volume['name'],
+                       'initiator': host_iqn})
         else:
             LOG.debug('Terminate all connections for volume %(volume)s',
-                      {'volume': volume_path})
+                      {'volume': volume['name']})
 
-        params = {'volume': volume_path}
-        url = 'san/lunMappings?%s' % urllib.parse.urlencode(params)
-        mappings = self.nef.get(url).get('data')
-        if len(mappings) == 0:
+        payload = {'volume': volume_path}
+        mappings = self.nef.mappings.list(payload)
+        if not mappings:
             LOG.debug('There are no LUN mappings found for volume %(volume)s',
-                      {'volume': volume_path})
+                      {'volume': volume['name']})
             return info
         for mapping in mappings:
             mapping_id = mapping.get('id')
@@ -370,13 +332,13 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             if host_iqn is None or mapping_hg in host_groups:
                 LOG.debug('Delete LUN mapping %(id)s for volume %(volume)s, '
                           'target group %(tg)s and host group %(hg)s',
-                          {'id': mapping_id, 'volume': volume_path,
+                          {'id': mapping_id, 'volume': volume['name'],
                            'tg': mapping_tg, 'hg': mapping_hg})
                 self._delete_lun_mapping(mapping_id)
             else:
                 LOG.debug('Skip LUN mapping %(id)s for volume %(volume)s, '
                           'target group %(tg)s and host group %(hg)s',
-                          {'id': mapping_id, 'volume': volume_path,
+                          {'id': mapping_id, 'volume': volume['name'],
                            'tg': mapping_tg, 'hg': mapping_hg})
         return info
 
@@ -385,55 +347,102 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
 
         If 'refresh' is True, run update the stats first.
         """
-        if refresh:
+        if refresh or not self._stats:
             self._update_volume_stats()
 
         return self._stats
 
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor appliance."""
-        LOG.debug('Updating volume stats')
-
-        url = 'storage/volumeGroups/%s?fields=bytesAvailable,bytesUsed' % (
-            '%2F'.join([self.storage_pool, self.volume_group]))
-        stats = self.nef.get(url)
-        free = utils.str2gib_size(stats['bytesAvailable'])
-        allocated = utils.str2gib_size(stats['bytesUsed'])
-
+        payload = {'fields': 'bytesAvailable,bytesUsed'}
+        dataset = self.nef.volumegroups.get(self.root_path, payload)
+        free_capacity_gb = dataset['bytesAvailable'] // units.Gi
+        allocated_capacity_gb = dataset['bytesUsed'] // units.Gi
+        total_capacity_gb = free_capacity_gb + allocated_capacity_gb
+        provisioned_capacity_gb = total_volumes = 0
+        ctxt = context.get_admin_context()
+        volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        for volume in volumes:
+            provisioned_capacity_gb += volume['size']
+            total_volumes += 1
+        volume_backend_name = (
+            self.configuration.safe_get('volume_backend_name'))
+        if not volume_backend_name:
+            LOG.debug('Failed to get configured volume backend name')
+            volume_backend_name = '%(product)s_%(protocol)s' % {
+                'product': self.product_name,
+                'protocol': self.storage_protocol
+            }
+        description = (
+            self.configuration.safe_get('nexenta_dataset_description'))
+        if not description:
+            description = '%(product)s %(host)s:%(pool)s/%(group)s' % {
+                'product': self.product_name,
+                'host': self.configuration.nexenta_host,
+                'pool': self.configuration.nexenta_volume,
+                'group': self.configuration.nexenta_volume_group
+            }
+        max_over_subscription_ratio = (
+            self.configuration.safe_get('max_over_subscription_ratio'))
+        reserved_percentage = (
+            self.configuration.safe_get('reserved_percentage'))
+        if reserved_percentage is None:
+            reserved_percentage = 0
         location_info = '%(driver)s:%(host)s:%(pool)s/%(group)s' % {
-            'driver': self.__class__.__name__,
-            'host': self.iscsi_host,
-            'pool': self.storage_pool,
-            'group': self.volume_group,
+            'driver': self.driver_name,
+            'host': self.configuration.nexenta_host,
+            'pool': self.configuration.nexenta_volume,
+            'group': self.configuration.nexenta_volume_group
         }
+        display_name = 'Capabilities of %(product)s %(protocol)s driver' % {
+            'product': self.product_name,
+            'protocol': self.storage_protocol
+        }
+        visibility = 'public'
         self._stats = {
-            'vendor_name': 'Nexenta',
-            'dedup': self.dataset_deduplication,
-            'compression': self.dataset_compression,
-            'description': self.dataset_description,
             'driver_version': self.VERSION,
-            'storage_protocol': 'iSCSI',
-            'sparsed_volumes': self.configuration.nexenta_sparse,
-            'total_capacity_gb': free + allocated,
-            'free_capacity_gb': free,
-            'reserved_percentage': self.configuration.reserved_percentage,
-            'QoS_support': False,
-            'volume_backend_name': self.backend_name,
+            'vendor_name': self.vendor_name,
+            'storage_protocol': self.storage_protocol,
+            'volume_backend_name': volume_backend_name,
             'location_info': location_info,
-            'iscsi_target_portal_port': self.iscsi_target_portal_port,
-            'nef_url': self.nef.url
+            'description': description,
+            'display_name': display_name,
+            'pool_name': self.configuration.nexenta_volume,
+            'multiattach': True,
+            'QoS_support': False,
+            'consistencygroup_support': True,
+            'consistent_group_snapshot_enabled': True,
+            'online_extend_support': True,
+            'sparse_copy_volume': True,
+            'thin_provisioning_support': True,
+            'thick_provisioning_support': True,
+            'total_capacity_gb': total_capacity_gb,
+            'allocated_capacity_gb': allocated_capacity_gb,
+            'free_capacity_gb': free_capacity_gb,
+            'provisioned_capacity_gb': provisioned_capacity_gb,
+            'total_volumes': total_volumes,
+            'max_over_subscription_ratio': max_over_subscription_ratio,
+            'reserved_percentage': reserved_percentage,
+            'visibility': visibility,
+            'nef_port': self.nef.port,
+            'nef_url': self.nef.host
         }
+        LOG.debug('Updated volume backend statistics for host %(host)s '
+                  'and volume backend %(volume_backend_name)s: %(stats)s',
+                  {'host': self.host,
+                   'volume_backend_name': volume_backend_name,
+                   'stats': self._stats})
 
-    # auxiliary methods  ######################################################
     def _get_volume_path(self, volume):
-        """Return zfs volume name that corresponds given volume name."""
-        return '%s/%s/%s' % (self.storage_pool, self.volume_group,
-                             volume['name'])
+        """Return ZFS datset path for the volume."""
+        return posixpath.join(self.root_path, volume['name'])
 
-    @staticmethod
-    def _get_clone_snapshot_name(volume):
-        """Return name for snapshot that will be used to clone the volume."""
-        return 'cinder-clone-snapshot-%(id)s' % volume
+    def _get_snapshot_path(self, snapshot):
+        """Return ZFS snapshot path for the snapshot."""
+        volume_name = snapshot['volume_name']
+        snapshot_name = snapshot['name']
+        volume_path = posixpath.join(self.root_path, volume_name)
+        return '%s@%s' % (volume_path, snapshot_name)
 
     def _get_target_group_name(self, target_name):
         """Return Nexenta iSCSI target group name for volume."""
@@ -452,9 +461,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
     def _get_host_addresses(self):
         """Return Nexenta IP addresses list."""
         host_addresses = []
-        url = 'network/addresses'
-        data = self.nef.get(url).get('data')
-        for item in data:
+        items = self.nef.netaddrs.list()
+        for item in items:
             ip_cidr = six.text_type(item['address'])
             ip_addr, ip_mask = ip_cidr.split('/')
             ip_obj = ipaddress.ip_address(ip_addr)
@@ -514,15 +522,14 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                       {'group': group_name})
             return {}
         group_props = {}
-        params = {'name': group_name}
-        url = 'san/targetgroups?%s' % urllib.parse.urlencode(params)
-        data = self.nef.get(url).get('data')
+        payload = {'name': group_name}
+        data = self.nef.targetgroups.list(payload)
         if not data:
             LOG.debug('Skip target group %(group)s: group not found',
                       {'group': group_name})
             return {}
         target_names = data[0]['members']
-        if len(target_names) == 0:
+        if not target_names:
             target_name = self._get_target_name(group_name)
             self._create_target(target_name, host_portals)
             self._update_target_group(group_name, [target_name])
@@ -530,9 +537,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             return group_props
         for target_name in target_names:
             group_props[target_name] = []
-            params = {'name': target_name}
-            url = 'san/iscsi/targets?%s' % urllib.parse.urlencode(params)
-            data = self.nef.get(url).get('data')
+            payload = {'name': target_name}
+            data = self.nef.targets.list(payload)
             if not data:
                 LOG.debug('Skip target group %(group)s: '
                           'group member %(target)s not found',
@@ -579,22 +585,21 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         props_portals = []
         props_iqns = []
         props_luns = []
-        params = {'volume': volume_path}
-        url = 'san/lunMappings?%s' % urllib.parse.urlencode(params)
-        mappings = self.nef.get(url).get('data')
+        payload = {'volume': volume_path}
+        mappings = self.nef.mappings.list(payload)
         for mapping in mappings:
             mapping_id = mapping['id']
             mapping_lu = mapping['lun']
             mapping_hg = mapping['hostGroup']
             mapping_tg = mapping['targetGroup']
-            if mapping_hg not in host_groups:
-                LOG.debug('Skip LUN mapping %(id)s for host group %(hg)s',
-                          {'id': mapping_id, 'hg': mapping_hg})
-                continue
             if mapping_tg == options.DEFAULT_TARGET_GROUP:
                 LOG.debug('Delete LUN mapping %(id)s for target group %(tg)s',
                           {'id': mapping_id, 'tg': mapping_tg})
-                self.self._delete_lun_mapping(mapping_id)
+                self._delete_lun_mapping(mapping_id)
+                continue
+            if mapping_hg not in host_groups:
+                LOG.debug('Skip LUN mapping %(id)s for host group %(hg)s',
+                          {'id': mapping_id, 'hg': mapping_hg})
                 continue
             group_props = self._target_group_props(mapping_tg, host_portals)
             if not group_props:
@@ -608,6 +613,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 props_luns += [mapping_lu] * len(target_portals)
 
         props = {}
+        props['discard'] = True
         props['target_discovered'] = False
         props['encrypted'] = False
         props['qos_specs'] = None
@@ -621,22 +627,22 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 props['target_iqns'] = props_iqns
                 props['target_luns'] = props_luns
             else:
-                index = random.randrange(0, len(props_luns))
+                index = random.randrange(len(props_luns))
                 props['target_portal'] = props_portals[index]
                 props['target_iqn'] = props_iqns[index]
                 props['target_lun'] = props_luns[index]
             LOG.debug('Use existing LUN mapping(s) %(props)s',
                       {'props': props})
-            return {'driver_volume_type': 'iscsi', 'data': props}
+            return {'driver_volume_type': self.driver_volume_type,
+                    'data': props}
 
         if host_group is None:
             host_group = '%s-%s' % (self.host_group_prefix, uuid.uuid4().hex)
-            self._create_host_group(host_group, host_iqn)
+            self._create_host_group(host_group, [host_iqn])
 
         mappings_spread = {}
         targets_spread = {}
-        url = 'san/targetgroups'
-        data = self.nef.get(url).get('data')
+        data = self.nef.targetgroups.list()
         for item in data:
             target_group = item['name']
             group_props = self._target_group_props(target_group, host_portals)
@@ -645,9 +651,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 LOG.debug('Skip unsuitable target group %(tg)s',
                           {'tg': target_group})
                 continue
-            params = {'targetGroup': target_group}
-            url = 'san/lunMappings?%s' % urllib.parse.urlencode(params)
-            data = self.nef.get(url).get('data')
+            payload = {'targetGroup': target_group}
+            data = self.nef.mappings.list(payload)
             mappings = len(data)
             if not mappings < self.luns_per_target:
                 LOG.debug('Skip target group %(tg)s: '
@@ -661,7 +666,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                       {'tg': target_group, 'members': members,
                        'mappings': mappings})
 
-        if len(mappings_spread) == 0:
+        if not mappings_spread:
             target = '%s-%s' % (self.target_prefix, uuid.uuid4().hex)
             target_group = self._get_target_group_name(target)
             self._create_target(target, host_portals)
@@ -678,31 +683,25 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                       {'tg': target_group, 'members': members,
                        'mappings': mappings})
             for target in targets:
-                    portals = targets[target]
-                    props_portals += portals
-                    props_iqns += [target] * len(portals)
+                portals = targets[target]
+                props_portals += portals
+                props_iqns += [target] * len(portals)
 
-        url = 'san/lunMappings'
-        data = {
-            'volume': volume_path,
-            'targetGroup': target_group,
-            'hostGroup': host_group
-        }
-        LOG.debug('Create LUN mapping %(data)s',
-                  {'data': data})
-        self.nef.post(url, data)
-
-        params = {
-            'fields': 'lun',
-            'volume': volume_path,
-            'targetGroup': target_group,
-            'hostGroup': host_group
-        }
-        LOG.debug('Get LUN number of LUN mapping for %(params)s',
-                  {'params': params})
-        url = 'san/lunMappings?%s' % urllib.parse.urlencode(params)
-        data = self._poll_result(url)
-        lun = data[0]['lun']
+        payload = {'volume': volume_path,
+                   'targetGroup': target_group,
+                   'hostGroup': host_group}
+        self.nef.mappings.create(payload)
+        mapping = {}
+        for attempt in range(self.nef.retries):
+            mapping = self.nef.mappings.list(payload)
+            if mapping:
+                break
+            self.nef.delay(attempt)
+        if not mapping:
+            message = (_('Failed to get LUN number for %(volume)s')
+                       % {'volume': volume_path})
+            raise jsonrpc.NefException(code='ENOTBLK', message=message)
+        lun = mapping[0]['lun']
         props_luns = [lun] * len(props_iqns)
 
         if multipath:
@@ -710,27 +709,27 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             props['target_iqns'] = props_iqns
             props['target_luns'] = props_luns
         else:
-            index = random.randrange(0, len(props_luns))
+            index = random.randrange(len(props_luns))
             props['target_portal'] = props_portals[index]
             props['target_iqn'] = props_iqns[index]
             props['target_lun'] = props_luns[index]
 
-        if not self.lu_writebackcache_disabled:
-            LOG.debug('Get LUN guid for volume %(volume)s',
-                      {'volume': volume_path})
-            params = {'fields': 'guid', 'volume': volume_path}
-            url = 'san/logicalUnits?%s' % urllib.parse.urlencode(params)
-            data = self.nef.get(url).get('data')
-            guid = data[0]['guid']
-            LOG.debug('Enable Write Back Cache for LUN %(guid)s',
-                      {'guid': guid})
-            url = 'san/logicalUnits/%s' % urllib.parse.quote_plus(guid)
-            data = {'writebackCacheDisabled': False}
-            self.nef.put(url, data)
+        LOG.debug('Set LUN properties for volume %(volume)s',
+                  {'volume': volume_path})
+        payload = {
+            'volume': volume_path,
+            'fields': 'guid'
+        }
+        logicalunits = self.nef.logicalunits.list(payload)
+        guid = logicalunits[0]['guid']
+        properties = self.nef.logicalunits.properties
+        payload = self._get_vendor_properties(volume, properties)
+        self.nef.logicalunits.set(guid, payload)
 
-        LOG.debug('Created new LUN mapping(s): %(props)s',
+        LOG.debug('Created new LUN mapping: %(props)s',
                   {'props': props})
-        return {'driver_volume_type': 'iscsi', 'data': props}
+        return {'driver_volume_type': self.driver_volume_type,
+                'data': props}
 
     def _create_target_group(self, name, members):
         """Create a new target group with members.
@@ -738,15 +737,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param name: group name
         :param members: group members list
         """
-        url = 'san/targetgroups'
-        data = {
-            'name': name,
-            'members': members
-        }
-        LOG.debug('Create new target group %(name)s '
-                  'with members %(members)s',
-                  {'name': name, 'members': members})
-        self.nef.post(url, data)
+        payload = {'name': name, 'members': members}
+        self.nef.targetgroups.create(payload)
 
     def _update_target_group(self, name, members):
         """Update a existing target group with new members.
@@ -754,24 +746,15 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param name: group name
         :param members: group members list
         """
-        url = 'san/targetgroups/%s' % urllib.parse.quote_plus(name)
-        data = {
-            'members': members
-        }
-        LOG.debug('Update existing target group %(name)s '
-                  'with new members %(members)s',
-                  {'name': name, 'members': members})
-        self.nef.put(url, data)
+        payload = {'members': members}
+        self.nef.targetgroups.set(name, payload)
 
-    def _delete_lun_mapping(self, mapping):
+    def _delete_lun_mapping(self, name):
         """Delete an existing LUN mapping.
 
-        :param mapping: LUN mapping ID
+        :param name: LUN mapping ID
         """
-        url = 'san/lunMappings/%s' % mapping
-        LOG.debug('Delete LUN mapping %(mapping)s',
-                  {'mapping': mapping})
-        self.nef.delete(url)
+        self.nef.mappings.delete(name)
 
     def _create_target(self, name, portals):
         """Create a new target with portals.
@@ -779,14 +762,9 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param name: target name
         :param portals: target portals list
         """
-        url = 'san/iscsi/targets'
-        data = {
-            'name': name,
-            'portals': self._s2d(portals)
-        }
-        LOG.debug('Create new target %(name)s with portals %(portals)s',
-                  {'name': name, 'portals': portals})
-        self.nef.post(url, data)
+        payload = {'name': name,
+                   'portals': self._s2d(portals)}
+        self.nef.targets.create(payload)
 
     def _get_host_group(self, member):
         """Find existing host group by group member.
@@ -794,8 +772,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param member: host group member
         :returns: host group name
         """
-        url = 'san/hostgroups'
-        host_groups = self.nef.get(url).get('data')
+        host_groups = self.nef.hostgroups.list()
         for host_group in host_groups:
             members = host_group['members']
             if member in members:
@@ -805,38 +782,17 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 return name
         return None
 
-    def _create_host_group(self, name, member):
+    def _create_host_group(self, name, members):
         """Create a new host group.
 
         :param name: host group name
-        :param member: host group member
+        :param members: host group members list
         """
-        url = 'san/hostgroups'
-        data = {
-            'name': name,
-            'members': [member]
-        }
-        LOG.debug('Create new host group %(name)s with member %(member)s',
-                  {'name': name, 'member': member})
-        self.nef.post(url, data)
+        payload = {'name': name, 'members': members}
+        self.nef.hostgroups.create(payload)
 
-    def _poll_result(self, url):
-        """Poll non-empty response data for NEF get method.
-
-        :param url: NEF URL
-        :returns: response data list
-        """
-        for retry in range(0, options.POLL_RETRIES):
-            data = self.nef.get(url).get('data')
-            if data:
-                return data
-            delay = int(math.exp(retry))
-            LOG.debug('Retry after %(delay)s seconds delay',
-                      {'delay': delay})
-            greenthread.sleep(delay)
-        return []
-
-    def _s2d(self, css):
+    @staticmethod
+    def _s2d(css):
         """Parse list of colon-separated address and port to dictionary.
 
         :param css: list of colon-separated address and port
@@ -848,7 +804,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             result.append({'address': key, 'port': int(val)})
         return result
 
-    def _d2s(self, kvp):
+    @staticmethod
+    def _d2s(kvp):
         """Parse dictionary to list of colon-separated address and port.
 
         :param kvp: dictionary
@@ -859,6 +816,1072 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             result.append('%s:%s' % (key_val['address'], key_val['port']))
         return result
 
-    def _get_snapshot_volume(self, snapshot):
+    def create_consistencygroup(self, context, group):
+        """Creates a consistency group.
+
+        :param context: the context of the caller.
+        :param group: the dictionary of the consistency group to be created.
+        :returns: group_model_update
+        """
+        group_model_update = {}
+        return group_model_update
+
+    def create_group(self, context, group):
+        """Creates a group.
+
+        :param context: the context of the caller.
+        :param group: the group object.
+        :returns: model_update
+        """
+        return self.create_consistencygroup(context, group)
+
+    def delete_consistencygroup(self, context, group, volumes):
+        """Deletes a consistency group.
+
+        :param context: the context of the caller.
+        :param group: the dictionary of the consistency group to be deleted.
+        :param volumes: a list of volume dictionaries in the group.
+        :returns: group_model_update, volumes_model_update
+        """
+        group_model_update = {}
+        volumes_model_update = []
+        for volume in volumes:
+            self.delete_volume(volume)
+        return group_model_update, volumes_model_update
+
+    def delete_group(self, context, group, volumes):
+        """Deletes a group.
+
+        :param context: the context of the caller.
+        :param group: the group object.
+        :param volumes: a list of volume objects in the group.
+        :returns: model_update, volumes_model_update
+        """
+        return self.delete_consistencygroup(context, group, volumes)
+
+    def update_consistencygroup(self, context, group, add_volumes=None,
+                                remove_volumes=None):
+        """Updates a consistency group.
+
+        :param context: the context of the caller.
+        :param group: the dictionary of the consistency group to be updated.
+        :param add_volumes: a list of volume dictionaries to be added.
+        :param remove_volumes: a list of volume dictionaries to be removed.
+        :returns: group_model_update, add_volumes_update, remove_volumes_update
+        """
+        group_model_update = {}
+        add_volumes_update = []
+        remove_volumes_update = []
+        return group_model_update, add_volumes_update, remove_volumes_update
+
+    def update_group(self, context, group,
+                     add_volumes=None, remove_volumes=None):
+        """Updates a group.
+
+        :param context: the context of the caller.
+        :param group: the group object.
+        :param add_volumes: a list of volume objects to be added.
+        :param remove_volumes: a list of volume objects to be removed.
+        :returns: model_update, add_volumes_update, remove_volumes_update
+        """
+        return self.update_consistencygroup(context, group, add_volumes,
+                                            remove_volumes)
+
+    def create_cgsnapshot(self, context, cgsnapshot, snapshots):
+        """Creates a consistency group snapshot.
+
+        :param context: the context of the caller.
+        :param cgsnapshot: the dictionary of the cgsnapshot to be created.
+        :param snapshots: a list of snapshot dictionaries in the cgsnapshot.
+        :returns: group_model_update, snapshots_model_update
+        """
+        group_model_update = {}
+        snapshots_model_update = []
+        cgsnapshot_name = self.group_snapshot_template % cgsnapshot['id']
+        cgsnapshot_path = '%s@%s' % (self.root_path, cgsnapshot_name)
+        create_payload = {'path': cgsnapshot_path, 'recursive': True}
+        self.nef.snapshots.create(create_payload)
+        for snapshot in snapshots:
+            volume_name = snapshot['volume_name']
+            volume_path = posixpath.join(self.root_path, volume_name)
+            snapshot_name = snapshot['name']
+            snapshot_path = '%s@%s' % (volume_path, cgsnapshot_name)
+            rename_payload = {'newName': snapshot_name}
+            self.nef.snapshots.rename(snapshot_path, rename_payload)
+        delete_payload = {'defer': True, 'recursive': True}
+        self.nef.snapshots.delete(cgsnapshot_path, delete_payload)
+        return group_model_update, snapshots_model_update
+
+    def create_group_snapshot(self, context, group_snapshot, snapshots):
+        """Creates a group_snapshot.
+
+        :param context: the context of the caller.
+        :param group_snapshot: the GroupSnapshot object to be created.
+        :param snapshots: a list of Snapshot objects in the group_snapshot.
+        :returns: model_update, snapshots_model_update
+        """
+        return self.create_cgsnapshot(context, group_snapshot, snapshots)
+
+    def delete_cgsnapshot(self, context, cgsnapshot, snapshots):
+        """Deletes a consistency group snapshot.
+
+        :param context: the context of the caller.
+        :param cgsnapshot: the dictionary of the cgsnapshot to be created.
+        :param snapshots: a list of snapshot dictionaries in the cgsnapshot.
+        :returns: group_model_update, snapshots_model_update
+        """
+        group_model_update = {}
+        snapshots_model_update = []
+        for snapshot in snapshots:
+            self.delete_snapshot(snapshot)
+        return group_model_update, snapshots_model_update
+
+    def delete_group_snapshot(self, context, group_snapshot, snapshots):
+        """Deletes a group_snapshot.
+
+        :param context: the context of the caller.
+        :param group_snapshot: the GroupSnapshot object to be deleted.
+        :param snapshots: a list of snapshot objects in the group_snapshot.
+        :returns: model_update, snapshots_model_update
+        """
+        return self.delete_cgsnapshot(context, group_snapshot, snapshots)
+
+    def create_consistencygroup_from_src(self, context, group, volumes,
+                                         cgsnapshot=None, snapshots=None,
+                                         source_cg=None, source_vols=None):
+        """Creates a consistency group from source.
+
+        :param context: the context of the caller.
+        :param group: the dictionary of the consistency group to be created.
+        :param volumes: a list of volume dictionaries in the group.
+        :param cgsnapshot: the dictionary of the cgsnapshot as source.
+        :param snapshots: a list of snapshot dictionaries in the cgsnapshot.
+        :param source_cg: the dictionary of a consistency group as source.
+        :param source_vols: a list of volume dictionaries in the source_cg.
+        :returns: group_model_update, volumes_model_update
+        """
+        group_model_update = {}
+        volumes_model_update = []
+        if cgsnapshot and snapshots:
+            for volume, snapshot in zip(volumes, snapshots):
+                self.create_volume_from_snapshot(volume, snapshot)
+        elif source_cg and source_vols:
+            snapshot_name = self.origin_snapshot_template % group['id']
+            snapshot_path = '%s@%s' % (self.root_path, snapshot_name)
+            create_payload = {'path': snapshot_path, 'recursive': True}
+            self.nef.snapshots.create(create_payload)
+            for volume, source_vol in zip(volumes, source_vols):
+                snapshot = {
+                    'name': snapshot_name,
+                    'volume_id': source_vol['id'],
+                    'volume_name': source_vol['name'],
+                    'volume_size': source_vol['size']
+                }
+                self.create_volume_from_snapshot(volume, snapshot)
+            delete_payload = {'defer': True, 'recursive': True}
+            self.nef.snapshots.delete(snapshot_path, delete_payload)
+        return group_model_update, volumes_model_update
+
+    def create_group_from_src(self, context, group, volumes,
+                              group_snapshot=None, snapshots=None,
+                              source_group=None, source_vols=None):
+        """Creates a group from source.
+
+        :param context: the context of the caller.
+        :param group: the Group object to be created.
+        :param volumes: a list of Volume objects in the group.
+        :param group_snapshot: the GroupSnapshot object as source.
+        :param snapshots: a list of snapshot objects in group_snapshot.
+        :param source_group: the Group object as source.
+        :param source_vols: a list of volume objects in the source_group.
+        :returns: model_update, volumes_model_update
+        """
+        return self.create_consistencygroup_from_src(context, group, volumes,
+                                                     group_snapshot, snapshots,
+                                                     source_group, source_vols)
+
+    def _get_existing_volume(self, existing_ref):
+        types = {
+            'source-name': 'name',
+            'source-guid': 'guid'
+        }
+        if not any(key in types for key in existing_ref):
+            keys = ', '.join(types.keys())
+            message = (_('Manage existing volume failed '
+                         'due to invalid backend reference. '
+                         'Volume reference must contain '
+                         'at least one valid key: %(keys)s')
+                       % {'keys': keys})
+            raise jsonrpc.NefException(code='EINVAL', message=message)
+        payload = {
+            'parent': self.root_path,
+            'fields': 'name,path,volumeSize'
+        }
+        for key, value in types.items():
+            if key in existing_ref:
+                payload[value] = existing_ref[key]
+        existing_volumes = self.nef.volumes.list(payload)
+        if len(existing_volumes) == 1:
+            volume_path = existing_volumes[0]['path']
+            volume_name = existing_volumes[0]['name']
+            volume_size = existing_volumes[0]['volumeSize'] // units.Gi
+            existing_volume = {
+                'name': volume_name,
+                'path': volume_path,
+                'size': volume_size
+            }
+            vid = utils.extract_id_from_volume_name(volume_name)
+            if utils.check_already_managed_volume(vid):
+                message = (_('Volume %(name)s already managed')
+                           % {'name': volume_name})
+                raise jsonrpc.NefException(code='EBUSY', message=message)
+            return existing_volume
+        elif not existing_volumes:
+            code = 'ENOENT'
+            reason = _('no matching volumes were found')
+        else:
+            code = 'EINVAL'
+            reason = _('too many volumes were found')
+        message = (_('Unable to manage existing volume by '
+                     'reference %(reference)s: %(reason)s')
+                   % {'reference': existing_ref, 'reason': reason})
+        raise jsonrpc.NefException(code=code, message=message)
+
+    def _check_already_managed_snapshot(self, snapshot_id):
+        """Check cinder database for already managed snapshot.
+
+        :param snapshot_id: snapshot id parameter
+        :returns: return True, if database entry with specified
+                  snapshot id exists, otherwise return False
+        """
+        if not isinstance(snapshot_id, six.string_types):
+            return False
+        try:
+            uuid.UUID(snapshot_id, version=4)
+        except ValueError:
+            return False
         ctxt = context.get_admin_context()
-        return db.volume_get(ctxt, snapshot['volume_id'])
+        return objects.Snapshot.exists(ctxt, snapshot_id)
+
+    def _get_existing_snapshot(self, snapshot, existing_ref):
+        types = {
+            'source-name': 'name',
+            'source-guid': 'guid'
+        }
+        if not any(key in types for key in existing_ref):
+            keys = ', '.join(types.keys())
+            message = (_('Manage existing snapshot failed '
+                         'due to invalid backend reference. '
+                         'Snapshot reference must contain '
+                         'at least one valid key: %(keys)s')
+                       % {'keys': keys})
+            raise jsonrpc.NefException(code='EINVAL', message=message)
+        volume_name = snapshot['volume_name']
+        volume_size = snapshot['volume_size']
+        volume = {'name': volume_name}
+        volume_path = self._get_volume_path(volume)
+        payload = {
+            'parent': volume_path,
+            'fields': 'name,path',
+            'recursive': False
+        }
+        for key, value in types.items():
+            if key in existing_ref:
+                payload[value] = existing_ref[key]
+        existing_snapshots = self.nef.snapshots.list(payload)
+        if len(existing_snapshots) == 1:
+            name = existing_snapshots[0]['name']
+            path = existing_snapshots[0]['path']
+            existing_snapshot = {
+                'name': name,
+                'path': path,
+                'volume_name': volume_name,
+                'volume_size': volume_size
+            }
+            sid = utils.extract_id_from_snapshot_name(name)
+            if self._check_already_managed_snapshot(sid):
+                message = (_('Snapshot %(name)s already managed')
+                           % {'name': name})
+                raise jsonrpc.NefException(code='EBUSY', message=message)
+            return existing_snapshot
+        elif not existing_snapshots:
+            code = 'ENOENT'
+            reason = _('no matching snapshots were found')
+        else:
+            code = 'EINVAL'
+            reason = _('too many snapshots were found')
+        message = (_('Unable to manage existing snapshot by '
+                     'reference %(reference)s: %(reason)s')
+                   % {'reference': existing_ref, 'reason': reason})
+        raise jsonrpc.NefException(code=code, message=message)
+
+    @jsonrpc.synchronized
+    def manage_existing(self, volume, existing_ref):
+        """Brings an existing backend storage object under Cinder management.
+
+        existing_ref is passed straight through from the API request's
+        manage_existing_ref value, and it is up to the driver how this should
+        be interpreted.  It should be sufficient to identify a storage object
+        that the driver should somehow associate with the newly-created cinder
+        volume structure.
+
+        There are two ways to do this:
+
+        1. Rename the backend storage object so that it matches the,
+           volume['name'] which is how drivers traditionally map between a
+           cinder volume and the associated backend storage object.
+
+        2. Place some metadata on the volume, or somewhere in the backend, that
+           allows other driver requests (e.g. delete, clone, attach, detach...)
+           to locate the backend storage object when required.
+
+        If the existing_ref doesn't make sense, or doesn't refer to an existing
+        backend storage object, raise a ManageExistingInvalidReference
+        exception.
+
+        The volume may have a volume_type, and the driver can inspect that and
+        compare against the properties of the referenced backend storage
+        object.  If they are incompatible, raise a
+        ManageExistingVolumeTypeMismatch, specifying a reason for the failure.
+
+        :param volume:       Cinder volume to manage
+        :param existing_ref: Driver-specific information used to identify a
+                             volume
+        """
+        existing_volume = self._get_existing_volume(existing_ref)
+        existing_volume_path = existing_volume['path']
+        payload = {'volume': existing_volume_path}
+        mappings = self.nef.mappings.list(payload)
+        if mappings:
+            message = (_('Failed to manage existing volume %(path)s '
+                         'due to existing LUN mappings: %(mappings)s')
+                       % {'path': existing_volume_path,
+                          'mappings': mappings})
+            raise jsonrpc.NefException(code='EEXIST', message=message)
+        if existing_volume['name'] != volume['name']:
+            volume_path = self._get_volume_path(volume)
+            payload = {'newPath': volume_path}
+            self.nef.volumes.rename(existing_volume_path, payload)
+
+    def manage_existing_get_size(self, volume, existing_ref):
+        """Return size of volume to be managed by manage_existing.
+
+        When calculating the size, round up to the next GB.
+
+        :param volume:       Cinder volume to manage
+        :param existing_ref: Driver-specific information used to identify a
+                             volume
+        :returns size:       Volume size in GiB (integer)
+        """
+        existing_volume = self._get_existing_volume(existing_ref)
+        return existing_volume['size']
+
+    def get_manageable_volumes(self, cinder_volumes, marker, limit, offset,
+                               sort_keys, sort_dirs):
+        """List volumes on the backend available for management by Cinder.
+
+        Returns a list of dictionaries, each specifying a volume in the host,
+        with the following keys:
+        - reference (dictionary): The reference for a volume, which can be
+          passed to "manage_existing".
+        - size (int): The size of the volume according to the storage
+          backend, rounded up to the nearest GB.
+        - safe_to_manage (boolean): Whether or not this volume is safe to
+          manage according to the storage backend. For example, is the volume
+          in use or invalid for any reason.
+        - reason_not_safe (string): If safe_to_manage is False, the reason why.
+        - cinder_id (string): If already managed, provide the Cinder ID.
+        - extra_info (string): Any extra information to return to the user
+
+        :param cinder_volumes: A list of volumes in this host that Cinder
+                               currently manages, used to determine if
+                               a volume is manageable or not.
+        :param marker:    The last item of the previous page; we return the
+                          next results after this value (after sorting)
+        :param limit:     Maximum number of items to return
+        :param offset:    Number of items to skip after marker
+        :param sort_keys: List of keys to sort results by (valid keys are
+                          'identifier' and 'size')
+        :param sort_dirs: List of directions to sort by, corresponding to
+                          sort_keys (valid directions are 'asc' and 'desc')
+        """
+        manageable_volumes = []
+        cinder_volume_names = {}
+        for cinder_volume in cinder_volumes:
+            key = cinder_volume['name']
+            value = cinder_volume['id']
+            cinder_volume_names[key] = value
+        payload = {
+            'parent': self.root_path,
+            'fields': 'name,guid,path,volumeSize',
+            'recursive': False
+        }
+        volumes = self.nef.volumes.list(payload)
+        for volume in volumes:
+            safe_to_manage = True
+            reason_not_safe = None
+            cinder_id = None
+            extra_info = None
+            path = volume['path']
+            guid = volume['guid']
+            size = volume['volumeSize'] // units.Gi
+            name = volume['name']
+            if name in cinder_volume_names:
+                cinder_id = cinder_volume_names[name]
+                safe_to_manage = False
+                reason_not_safe = _('Volume already managed')
+            else:
+                payload = {
+                    'volume': path,
+                    'fields': 'hostGroup'
+                }
+                mappings = self.nef.mappings.list(payload)
+                members = []
+                for mapping in mappings:
+                    hostgroup = mapping['hostGroup']
+                    if hostgroup == options.DEFAULT_HOST_GROUP:
+                        members.append(hostgroup)
+                    else:
+                        group = self.nef.hostgroups.get(hostgroup)
+                        members += group['members']
+                if members:
+                    safe_to_manage = False
+                    hosts = ', '.join(members)
+                    reason_not_safe = (_('Volume is connected '
+                                         'to host(s) %(hosts)s')
+                                       % {'hosts': hosts})
+            reference = {
+                'source-name': name,
+                'source-guid': guid
+            }
+            manageable_volumes.append({
+                'reference': reference,
+                'size': size,
+                'safe_to_manage': safe_to_manage,
+                'reason_not_safe': reason_not_safe,
+                'cinder_id': cinder_id,
+                'extra_info': extra_info
+            })
+        return utils.paginate_entries_list(manageable_volumes,
+                                           marker, limit, offset,
+                                           sort_keys, sort_dirs)
+
+    def unmanage(self, volume):
+        """Removes the specified volume from Cinder management.
+
+        Does not delete the underlying backend storage object.
+
+        For most drivers, this will not need to do anything.  However, some
+        drivers might use this call as an opportunity to clean up any
+        Cinder-specific configuration that they have associated with the
+        backend storage object.
+
+        :param volume: Cinder volume to unmanage
+        """
+        pass
+
+    @jsonrpc.synchronized
+    def manage_existing_snapshot(self, snapshot, existing_ref):
+        """Brings an existing backend storage object under Cinder management.
+
+        existing_ref is passed straight through from the API request's
+        manage_existing_ref value, and it is up to the driver how this should
+        be interpreted.  It should be sufficient to identify a storage object
+        that the driver should somehow associate with the newly-created cinder
+        snapshot structure.
+
+        There are two ways to do this:
+
+        1. Rename the backend storage object so that it matches the
+           snapshot['name'] which is how drivers traditionally map between a
+           cinder snapshot and the associated backend storage object.
+
+        2. Place some metadata on the snapshot, or somewhere in the backend,
+           that allows other driver requests (e.g. delete) to locate the
+           backend storage object when required.
+
+        If the existing_ref doesn't make sense, or doesn't refer to an existing
+        backend storage object, raise a ManageExistingInvalidReference
+        exception.
+
+        :param snapshot:     Cinder volume snapshot to manage
+        :param existing_ref: Driver-specific information used to identify a
+                             volume snapshot
+        """
+        existing_snapshot = self._get_existing_snapshot(snapshot, existing_ref)
+        existing_snapshot_path = existing_snapshot['path']
+        if existing_snapshot['name'] != snapshot['name']:
+            payload = {'newName': snapshot['name']}
+            self.nef.snapshots.rename(existing_snapshot_path, payload)
+
+    def manage_existing_snapshot_get_size(self, snapshot, existing_ref):
+        """Return size of snapshot to be managed by manage_existing.
+
+        When calculating the size, round up to the next GB.
+
+        :param snapshot:     Cinder volume snapshot to manage
+        :param existing_ref: Driver-specific information used to identify a
+                             volume snapshot
+        :returns size:       Volume snapshot size in GiB (integer)
+        """
+        existing_snapshot = self._get_existing_snapshot(snapshot, existing_ref)
+        return existing_snapshot['volume_size']
+
+    def get_manageable_snapshots(self, cinder_snapshots, marker, limit, offset,
+                                 sort_keys, sort_dirs):
+        """List snapshots on the backend available for management by Cinder.
+
+        Returns a list of dictionaries, each specifying a snapshot in the host,
+        with the following keys:
+        - reference (dictionary): The reference for a snapshot, which can be
+          passed to "manage_existing_snapshot".
+        - size (int): The size of the snapshot according to the storage
+          backend, rounded up to the nearest GB.
+        - safe_to_manage (boolean): Whether or not this snapshot is safe to
+          manage according to the storage backend. For example, is the snapshot
+          in use or invalid for any reason.
+        - reason_not_safe (string): If safe_to_manage is False, the reason why.
+        - cinder_id (string): If already managed, provide the Cinder ID.
+        - extra_info (string): Any extra information to return to the user
+        - source_reference (string): Similar to "reference", but for the
+          snapshot's source volume.
+
+        :param cinder_snapshots: A list of snapshots in this host that Cinder
+                                 currently manages, used to determine if
+                                 a snapshot is manageable or not.
+        :param marker:    The last item of the previous page; we return the
+                          next results after this value (after sorting)
+        :param limit:     Maximum number of items to return
+        :param offset:    Number of items to skip after marker
+        :param sort_keys: List of keys to sort results by (valid keys are
+                          'identifier' and 'size')
+        :param sort_dirs: List of directions to sort by, corresponding to
+                          sort_keys (valid directions are 'asc' and 'desc')
+
+        """
+        manageable_snapshots = []
+        cinder_volume_names = {}
+        cinder_snapshot_names = {}
+        ctxt = context.get_admin_context()
+        cinder_volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        for cinder_volume in cinder_volumes:
+            key = self._get_volume_path(cinder_volume)
+            value = {
+                'name': cinder_volume['name'],
+                'size': cinder_volume['size']
+            }
+            cinder_volume_names[key] = value
+        for cinder_snapshot in cinder_snapshots:
+            key = cinder_snapshot['name']
+            value = {
+                'id': cinder_snapshot['id'],
+                'size': cinder_snapshot['volume_size'],
+                'parent': cinder_snapshot['volume_name']
+            }
+            cinder_snapshot_names[key] = value
+        payload = {
+            'parent': self.root_path,
+            'fields': 'name,guid,path,parent,hprService,snaplistId',
+            'recursive': True
+        }
+        snapshots = self.nef.snapshots.list(payload)
+        for snapshot in snapshots:
+            safe_to_manage = True
+            reason_not_safe = None
+            cinder_id = None
+            extra_info = None
+            name = snapshot['name']
+            guid = snapshot['guid']
+            path = snapshot['path']
+            parent = snapshot['parent']
+            if parent not in cinder_volume_names:
+                LOG.debug('Skip snapshot %(path)s: parent '
+                          'volume %(parent)s is unmanaged',
+                          {'path': path, 'parent': parent})
+                continue
+            if name.startswith(self.origin_snapshot_template):
+                LOG.debug('Skip temporary origin snapshot %(path)s',
+                          {'path': path})
+                continue
+            if name.startswith(self.group_snapshot_template):
+                LOG.debug('Skip temporary group snapshot %(path)s',
+                          {'path': path})
+                continue
+            if snapshot['hprService'] or snapshot['snaplistId']:
+                LOG.debug('Skip HPR/snapping snapshot %(path)s',
+                          {'path': path})
+                continue
+            if name in cinder_snapshot_names:
+                size = cinder_snapshot_names[name]['size']
+                cinder_id = cinder_snapshot_names[name]['id']
+                safe_to_manage = False
+                reason_not_safe = _('Snapshot already managed')
+            else:
+                size = cinder_volume_names[parent]['size']
+                payload = {'fields': 'clones'}
+                props = self.nef.snapshots.get(path)
+                clones = props['clones']
+                unmanaged_clones = []
+                for clone in clones:
+                    if clone not in cinder_volume_names:
+                        unmanaged_clones.append(clone)
+                if unmanaged_clones:
+                    safe_to_manage = False
+                    dependent_clones = ', '.join(unmanaged_clones)
+                    reason_not_safe = (_('Snapshot has unmanaged '
+                                         'dependent clone(s) %(clones)s')
+                                       % {'clones': dependent_clones})
+            reference = {
+                'source-name': name,
+                'source-guid': guid
+            }
+            source_reference = {
+                'name': cinder_volume_names[parent]['name']
+            }
+            manageable_snapshots.append({
+                'reference': reference,
+                'size': size,
+                'safe_to_manage': safe_to_manage,
+                'reason_not_safe': reason_not_safe,
+                'cinder_id': cinder_id,
+                'extra_info': extra_info,
+                'source_reference': source_reference
+            })
+        return utils.paginate_entries_list(manageable_snapshots,
+                                           marker, limit, offset,
+                                           sort_keys, sort_dirs)
+
+    def unmanage_snapshot(self, snapshot):
+        """Removes the specified snapshot from Cinder management.
+
+        Does not delete the underlying backend storage object.
+
+        For most drivers, this will not need to do anything. However, some
+        drivers might use this call as an opportunity to clean up any
+        Cinder-specific configuration that they have associated with the
+        backend storage object.
+
+        :param snapshot: Cinder volume snapshot to unmanage
+        """
+        pass
+
+    def local_path(self, volume):
+        """Return local path to existing local volume."""
+        raise NotImplementedError()
+
+    def migrate_volume(self, context, volume, host):
+        """Migrate the volume to the specified host.
+
+        Returns a boolean indicating whether the migration occurred,
+        as well as model_update.
+
+        :param context: Security context
+        :param volume: A dictionary describing the volume to migrate
+        :param host: A dictionary describing the host to migrate to, where
+                     host['host'] is its name, and host['capabilities'] is a
+                     dictionary of its reported capabilities.
+        """
+        LOG.debug('Start storage assisted volume migration '
+                  'for volume %(volume)s to host %(host)s',
+                  {'volume': volume['name'],
+                   'host': host['host']})
+        false_ret = (False, None)
+        if 'capabilities' not in host:
+            LOG.debug('No host capabilities found for '
+                      'the destination host %(host)s',
+                      {'host': host['host']})
+            return false_ret
+        capabilities = host['capabilities']
+        required_capabilities = [
+            'vendor_name',
+            'location_info',
+            'storage_protocol',
+            'free_capacity_gb',
+            'nef_url',
+            'nef_port'
+        ]
+        for capability in required_capabilities:
+            if capability not in capabilities:
+                LOG.debug('Required host capability %(capability)s not '
+                          'found for the destination host %(host)s',
+                          {'capability': capability, 'host': host['host']})
+                return false_ret
+        vendor = capabilities['vendor_name']
+        if vendor != self.vendor_name:
+            LOG.debug('Unsupported vendor %(vendor)s found '
+                      'for the destination host %(host)s',
+                      {'vendor': vendor, 'host': host['host']})
+            return false_ret
+        location = capabilities['location_info']
+        try:
+            driver, san_host, san_path = location.split(':')
+        except ValueError as error:
+            LOG.debug('Failed to split location info %(location)s '
+                      'for the destination host %(host)s: %(error)s',
+                      {'location': location, 'host': host['host'],
+                       'error': error})
+            return false_ret
+        if not (driver and san_path):
+            LOG.debug('Incomplete location info %(location)s '
+                      'found for the destination host %(host)s',
+                      {'location': location, 'host': host['host']})
+            return false_ret
+        if driver != self.driver_name:
+            LOG.debug('Unsupported storage driver %(driver)s '
+                      'found for the destination host %(host)s',
+                      {'driver': driver, 'host': host['host']})
+            return false_ret
+        try:
+            payload = {'fields': 'name'}
+            self.nef.hpr.list(payload)
+        except jsonrpc.NefException as error:
+            LOG.debug('Storage assisted volume migration is unavailable '
+                      'for the destination host %(host)s: %(error)s',
+                      {'host': host['host'], 'error': error})
+            return false_ret
+        src_path = self._get_volume_path(volume)
+        dst_path = posixpath.join(san_path, volume['name'])
+        dst_port = capabilities['nef_port']
+        src_hosts = self._get_host_addresses()
+        dst_hosts = capabilities['nef_url'].split(',')
+        service_name = 'cinder-migrate-%s' % volume['name']
+        service_created = service_running = service_success = False
+        while dst_hosts and not service_created:
+            dst_host = dst_hosts.pop()
+            if dst_host is not None:
+                dst_host = dst_host.strip()
+            payload = {
+                'name': service_name,
+                'sourceDataset': src_path,
+                'destinationDataset': dst_path,
+                'type': 'scheduled'
+            }
+            if dst_host not in src_hosts:
+                payload['isSource'] = True
+                payload['remoteNode'] = {
+                    'host': dst_host,
+                    'port': dst_port
+                }
+            elif src_path == dst_path:
+                LOG.debug('Skip local to local replication: '
+                          'source volume %(src_path)s and '
+                          'destination volume %(dst_path)s '
+                          'are the same volume',
+                          {'src_path': src_path,
+                           'dst_path': dst_path})
+                return True, None
+            try:
+                self.nef.hpr.create(payload)
+                service_created = True
+            except jsonrpc.NefException as error:
+                LOG.debug('Failed to create replication service '
+                          'with payload %(payload)s: %(error)s',
+                          {'payload': payload, 'error': error})
+                if error.code not in ('ENOENT', 'EINVAL'):
+                    return false_ret
+        if service_created:
+            try:
+                self.nef.hpr.start(service_name)
+                service_running = True
+            except jsonrpc.NefException as error:
+                LOG.debug('Failed to start replication service '
+                          '%(service_name)s: %(error)s',
+                          {'service_name': service_name,
+                           'error': error})
+        retry_count = 0
+        while service_running and not service_success:
+            try:
+                service = self.nef.hpr.get(service_name)
+            except jsonrpc.NefException as error:
+                LOG.debug('Failed to stat replication service '
+                          '%(service_name)s: %(error)s',
+                          {'service_name': service_name,
+                           'error': error})
+                break
+            state = service['state']
+            if state == 'faulted':
+                service_error = service['lastError']
+                LOG.debug('Replication service %(service_name)s '
+                          'failed with error: %(service_error)s',
+                          {'service_name': service_name,
+                           'service_error': service_error})
+                break
+            elif state == 'disabled':
+                LOG.debug('Replication service %(service_name)s '
+                          'successfully replicated %(src_path)s '
+                          'to %(dst_host)s:%(dst_path)s',
+                          {'service_name': service_name,
+                           'src_path': src_path,
+                           'dst_host': dst_host,
+                           'dst_path': dst_path})
+                service_running = False
+                service_success = True
+                break
+            else:
+                progress = service['progress']
+                LOG.debug('Replication service %(service_name)s '
+                          'is running, progress %(progress)s%%',
+                          {'service_name': service_name,
+                           'progress': progress})
+                self.nef.delay(retry_count)
+                retry_count += 1
+        if service_created:
+            payload = {
+                'destroySourceSnapshots': True,
+                'destroyDestinationSnapshots': True,
+                'force': True
+            }
+            try:
+                self.nef.hpr.delete(service_name, payload)
+            except jsonrpc.NefException as error:
+                LOG.debug('Failed to delete replication service '
+                          '%(service_name)s: %(error)s',
+                          {'service_name': service_name,
+                           'error': error})
+        if not service_success:
+            return false_ret
+        try:
+            self.delete_volume(volume)
+        except jsonrpc.NefException as error:
+            LOG.debug('Failed to delete source '
+                      'volume %(volume)s: %(error)s',
+                      {'volume': volume['name'],
+                       'error': error})
+        return True, None
+
+    def update_migrated_volume(self, context, volume, new_volume,
+                               original_volume_status):
+        """Return model update for migrated volume.
+
+        This method should rename the back-end volume name on the
+        destination host back to its original name on the source host.
+
+        :param context: The context of the caller
+        :param volume: The original volume that was migrated to this backend
+        :param new_volume: The migration volume object that was created on
+                           this backend as part of the migration process
+        :param original_volume_status: The status of the original volume
+        :returns: model_update to update DB with any needed changes
+        """
+        name_id = None
+        path = self._get_volume_path(volume)
+        new_path = self._get_volume_path(new_volume)
+        payload = {'newPath': path}
+        try:
+            self.terminate_connection(new_volume, None)
+        except jsonrpc.NefException as error:
+            LOG.debug('Failed to terminate all connections '
+                      'to migrated volume %(volume)s before '
+                      'renaming: %(error)s',
+                      {'volume': new_volume['name'],
+                       'error': error})
+        try:
+            self.nef.volumes.rename(new_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.debug('Failed to rename volume %(new_volume)s '
+                      'to %(volume)s after migration: %(error)s',
+                      {'new_volume': new_volume['name'],
+                       'volume': volume['name'],
+                       'error': error})
+            name_id = new_volume._name_id or new_volume.id
+        model_update = {'_name_id': name_id}
+        return model_update
+
+    def retype(self, context, volume, new_type, diff, host):
+        """Retype from one volume type to another."""
+        LOG.debug('Retype volume %(volume)s to host %(host)s '
+                  'and volume type %(type)s with diff %(diff)s',
+                  {'volume': volume['name'], 'host': host['host'],
+                   'type': new_type['name'], 'diff': diff})
+        retyped = False
+        migrated, model_update = self.migrate_volume(context, volume, host)
+        volume_path = self._get_volume_path(volume)
+        payload = {'source': True}
+        volume_specs = self.nef.volumes.get(volume_path, payload)
+        payload = {}
+        extra_specs = volume_types.get_volume_type_extra_specs(new_type['id'])
+        vendor_specs = self.nef.volumes.properties
+        for vendor_spec in vendor_specs:
+            property_name = vendor_spec['name']
+            api = vendor_spec['api']
+            if 'retype' in vendor_spec:
+                LOG.debug('Skip retype vendor volume property '
+                          '%(property_name)s. %(reason)s',
+                          {'property_name': property_name,
+                           'reason': vendor_spec['retype']})
+                continue
+            if property_name in extra_specs:
+                extra_spec = extra_specs[property_name]
+                value = self._get_vendor_value(extra_spec, vendor_spec)
+                payload[api] = value
+            elif (api in volume_specs and 'source' in volume_specs and
+                    api in volume_specs['source'] and
+                    volume_specs['source'][api] in ['local', 'received']):
+                if 'cfg' in vendor_spec:
+                    cfg = vendor_spec['cfg']
+                    value = self.configuration.safe_get(cfg)
+                    if volume_specs[api] != value:
+                        payload[api] = value
+                else:
+                    if 'inherit' in vendor_spec:
+                        LOG.debug('Skip inherit vendor volume property '
+                                  '%(property_name)s. %(reason)s',
+                                  {'property_name': property_name,
+                                   'reason': vendor_spec['inherit']})
+                        continue
+                    payload[api] = None
+        try:
+            self.nef.volumes.set(volume_path, payload)
+            retyped = True
+        except jsonrpc.NefException as error:
+            LOG.debug('Failed to retype volume %(volume)s: %(error)s',
+                      {'volume': volume['name'], 'error': error})
+        return retyped or migrated, model_update
+
+    def _init_vendor_properties(self):
+        """Create a dictionary of vendor unique properties.
+
+        This method creates a dictionary of vendor unique properties
+        and returns both created dictionary and vendor name.
+        Returned vendor name is used to check for name of vendor
+        unique properties.
+
+        - Vendor name shouldn't include colon(:) because of the separator
+          and it is automatically replaced by underscore(_).
+          ex. abc:d -> abc_d
+        - Vendor prefix is equal to vendor name.
+          ex. abcd
+        - Vendor unique properties must start with vendor prefix + ':'.
+          ex. abcd:maxIOPS
+
+        Each backend driver needs to override this method to expose
+        its own properties using _set_property() like this:
+
+        self._set_property(
+            properties,
+            "vendorPrefix:specific_property",
+            "Title of property",
+            _("Description of property"),
+            "type")
+
+        : return dictionary of vendor unique properties
+        : return vendor name
+        """
+        properties = {}
+        vendor_properties = []
+        namespace = self.nef.volumes.namespace
+        keys = ('enum', 'default', 'minimum', 'maximum')
+        vendor_properties += self.nef.volumes.properties
+        vendor_properties += self.nef.logicalunits.properties
+        for vendor_spec in vendor_properties:
+            property_spec = {}
+            for key in keys:
+                if key in vendor_spec:
+                    property_spec[key] = vendor_spec[key]
+            property_name = vendor_spec['name']
+            property_title = vendor_spec['title']
+            property_description = vendor_spec['description']
+            property_type = vendor_spec['type']
+            LOG.debug('Set %(product_name)s %(storage_protocol)s backend '
+                      '%(property_type)s property %(property_name)s: '
+                      '%(property_spec)s',
+                      {'product_name': self.product_name,
+                       'storage_protocol': self.storage_protocol,
+                       'property_type': property_type,
+                       'property_name': property_name,
+                       'property_spec': property_spec})
+            self._set_property(
+                properties,
+                property_name,
+                property_title,
+                property_description,
+                property_type,
+                **property_spec
+            )
+        return properties, namespace
+
+    def _get_vendor_properties(self, volume, vendor_specs):
+        properties = extra_specs = {}
+        type_id = volume.get('volume_type_id', None)
+        if type_id:
+            extra_specs = volume_types.get_volume_type_extra_specs(type_id)
+        for vendor_spec in vendor_specs:
+            property_name = vendor_spec['name']
+            if property_name in extra_specs:
+                extra_spec = extra_specs[property_name]
+                value = self._get_vendor_value(extra_spec, vendor_spec)
+            elif 'cfg' in vendor_spec:
+                cfg = vendor_spec['cfg']
+                value = self.configuration.safe_get(cfg)
+            else:
+                continue
+            api = vendor_spec['api']
+            if api == 'volumeBlockSize' and value < 512:
+                value *= units.Ki
+            properties[api] = value
+            LOG.debug('Get vendor property name %(property_name)s '
+                      'with API name %(api)s and %(type)s value '
+                      '%(value)s for volume %(volume)s',
+                      {'property_name': property_name,
+                       'api': api,
+                       'type': type(value).__name__,
+                       'value': value,
+                       'volume': volume['name']})
+        return properties
+
+    def _get_vendor_value(self, value, vendor_spec):
+        name = vendor_spec['name']
+        code = 'EINVAL'
+        if vendor_spec['type'] == 'integer':
+            try:
+                value = int(value)
+            except ValueError:
+                message = (_('Invalid non-integer value %(value)s for '
+                             'vendor property name %(name)s')
+                           % {'value': value, 'name': name})
+                raise jsonrpc.NefException(code=code, message=message)
+            if 'minimum' in vendor_spec:
+                minimum = vendor_spec['minimum']
+                if value < minimum:
+                    message = (_('Integer value %(value)s is less than '
+                                 'allowed minimum %(minimum)s for vendor '
+                                 'property name %(name)s')
+                               % {'value': value, 'minimum': minimum,
+                                  'name': name})
+                    raise jsonrpc.NefException(code=code, message=message)
+            if 'maximum' in vendor_spec:
+                maximum = vendor_spec['maximum']
+                if value > maximum:
+                    message = (_('Integer value %(value)s is greater than '
+                                 'allowed maximum %(maximum)s for vendor '
+                                 'property name %(name)s')
+                               % {'value': value, 'maximum': maximum,
+                                  'name': name})
+                    raise jsonrpc.NefException(code=code, message=message)
+        elif vendor_spec['type'] == 'string':
+            try:
+                value = str(value)
+            except UnicodeEncodeError:
+                message = (_('Invalid non-ASCII value %(value)s for vendor '
+                             'property name %(name)s')
+                           % {'value': value, 'name': name})
+                raise jsonrpc.NefException(code=code, message=message)
+        elif vendor_spec['type'] == 'boolean':
+            words = value.split()
+            if len(words) == 2 and words[0] == '<is>':
+                value = words[1]
+            try:
+                value = strutils.bool_from_string(value, strict=True)
+            except ValueError:
+                message = (_('Invalid non-boolean value %(value)s for vendor '
+                             'property name %(name)s')
+                           % {'value': value, 'name': name})
+                raise jsonrpc.NefException(code=code, message=message)
+        if 'enum' in vendor_spec:
+            enum = vendor_spec['enum']
+            if value not in enum:
+                message = (_('Value %(value)s is out of allowed enumeration '
+                             '%(enum)s for vendor property name %(name)s')
+                           % {'value': value, 'enum': enum, 'name': name})
+                raise jsonrpc.NefException(code=code, message=message)
+        return value

--- a/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -13,328 +13,923 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import hashlib
 import json
+import posixpath
+
+from eventlet import greenthread
+from oslo_log import log as logging
 import requests
 import six
-import time
-
-from oslo_log import log as logging
 
 from cinder import exception
 from cinder.i18n import _
-from cinder.utils import retry
-from cinder.volume.drivers.nexenta import utils
-from oslo_serialization import jsonutils
-from requests.cookies import extract_cookies_to_jar
-from requests.packages.urllib3 import exceptions
+from cinder import utils
 
 LOG = logging.getLogger(__name__)
-TIMEOUT = 60
-APPLIANCE ='NexentaStor Appliance'
 
-requests.packages.urllib3.disable_warnings(exceptions.InsecureRequestWarning)
-requests.packages.urllib3.disable_warnings(exceptions.InsecurePlatformWarning)
 
-def check_error(response):
-    code = response.status_code
-    if code not in (200, 201, 202):
-        reason = response.reason
-        body = response.content
-        try:
-            content = jsonutils.loads(body) if body else None
-        except ValueError:
-            msg = (_('Could not parse response from %(appliance)s: '
-                     '%(code)s %(reason)s %(body)s')
-                   % {'appliance': APPLIANCE,
-                      'code': code,
-                      'reason': reason,
-                      'body': body})
-            raise exception.NexentaException(msg)
-        if content and 'code' in content:
-            raise exception.NexentaException(content)
-        msg = (_('Got bad response from %(appliance)s: '
-                 '%(code)s %(reason)s %(content)s')
-               % {'appliance': APPLIANCE,
-                  'code': code,
-                  'reason': reason,
-                  'content': content})
-        raise exception.NexentaException(msg)
+class NefException(exception.VolumeDriverException):
+    def __init__(self, data=None, **kwargs):
+        defaults = {
+            'name': 'NexentaError',
+            'code': 'EBADMSG',
+            'source': 'CinderDriver',
+            'message': 'Unknown error'
+        }
+        if isinstance(data, dict):
+            for key in defaults:
+                if key in kwargs:
+                    continue
+                if key in data:
+                    kwargs[key] = data[key]
+                else:
+                    kwargs[key] = defaults[key]
+        elif isinstance(data, six.string_types):
+            if 'message' not in kwargs:
+                kwargs['message'] = data
+        for key in defaults:
+            if key not in kwargs:
+                kwargs[key] = defaults[key]
+        message = (_('%(message)s (source: %(source)s, '
+                     'name: %(name)s, code: %(code)s)')
+                   % kwargs)
+        self.code = kwargs['code']
+        del kwargs['message']
+        super(NefException, self).__init__(message, **kwargs)
 
-class RESTCaller(object):
 
-    retry_exc_tuple = (
-        requests.exceptions.ConnectionError,
-        requests.exceptions.ConnectTimeout
-    )
-
+class NefRequest(object):
     def __init__(self, proxy, method):
-        self.__proxy = proxy
-        self.__method = method
+        self.proxy = proxy
+        self.method = method
+        self.path = None
+        self.lock = False
+        self.time = 0
+        self.data = []
+        self.payload = {}
+        self.stat = {}
+        self.hooks = {
+            'response': self.hook
+        }
+        self.kwargs = {
+            'hooks': self.hooks,
+            'timeout': self.proxy.timeout
+        }
 
-    def get_full_url(self, path):
-        return '/'.join((self.__proxy.url, path))
-
-    @retry(retry_exc_tuple, interval=1, retries=6)
-    def __call__(self, *args):
-        url = self.get_full_url(args[0])
-        kwargs = {'timeout': TIMEOUT, 'verify': self.__proxy.verify}
-        data = None
-        if len(args) > 1:
-            kwargs['json'] = args[1]
-            data = args[1]
-
-        LOG.debug('Issuing call to %(appliance)s: '
-                  '%(url)s %(method)s data: %(data)s',
-                  {'appliance': APPLIANCE,
-                   'url': url,
-                   'method': self.__method,
-                   'data': data})
-
+    def __call__(self, path, payload=None):
+        LOG.debug('NEF request start: %(method)s %(path)s %(payload)s',
+                  {'method': self.method, 'path': path, 'payload': payload})
+        if self.method not in ['get', 'delete', 'put', 'post']:
+            message = (_('NEF API does not support %(method)s method')
+                       % {'method': self.method})
+            raise NefException(code='EINVAL', message=message)
+        if not path:
+            message = _('NEF API call requires collection path')
+            raise NefException(code='EINVAL', message=message)
+        self.path = path
+        if payload:
+            if not isinstance(payload, dict):
+                message = _('NEF API call payload must be a dictionary')
+                raise NefException(code='EINVAL', message=message)
+            if self.method in ['get', 'delete']:
+                self.payload = {'params': payload}
+            elif self.method in ['put', 'post']:
+                self.payload = {'data': json.dumps(payload)}
         try:
-            response = getattr(
-                self.__proxy.session, self.__method)(url, **kwargs)
-        except requests.exceptions.ConnectionError:
-            LOG.warning('Connection error on call to %(appliance)s: '
-                        '%(url)s %(method)s data: %(data)s',
-                        {'appliance': APPLIANCE,
-                         'url': self.__proxy.url,
-                         'method': self.__method,
-                         'data': data})
-            self.handle_failover()
-            url = self.get_full_url(args[0])
-            response = getattr(
-                self.__proxy.session, self.__method)(url, **kwargs)
-        try:
-            check_error(response)
-        except exception.NexentaException as ex:
-            err = utils.ex2err(ex)
-            if err['code'] == 'ENOENT':
-                LOG.warning('Exception on call to %(appliance)s: '
-                            '%(url)s %(method)s data: %(data)s '
-                            'returned message: %(message)s',
-                            {'appliance': APPLIANCE,
-                             'url': url,
-                             'method': self.__method,
-                             'data': data,
-                             'message': six.text_type(err)})
-                if (err['source'] == 'hpr' and
-                        'Destination pool' in err['message']):
-                    return content
-                self.handle_failover()
-                url = self.get_full_url(args[0])
-                response = getattr(
-                    self.__proxy.session, self.__method)(url, **kwargs)
-            else:
+            response = self.request(self.method, self.path, **self.payload)
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout) as error:
+            LOG.debug('Failed to %(method)s %(path)s %(payload)s: %(error)s',
+                      {'method': self.method, 'path': self.path,
+                       'payload': self.payload, 'error': error})
+            if not self.failover():
                 raise
-        check_error(response)
-        content = json.loads(response.content) if response.content else None
-        LOG.debug('Got response from %(appliance)s: '
-                  '%(code)s %(reason)s %(content)s',
-                  {'appliance': APPLIANCE,
-                   'code': response.status_code,
-                   'reason': response.reason,
-                   'content': content})
-
-        if response.status_code == 202 and content:
-            url = self.get_full_url(content['links'][0]['href'])
-            keep_going = True
-            while keep_going:
-                time.sleep(1)
-                response = self.__proxy.session.get(
-                    url, verify=self.__proxy.verify)
-                try:
-                    check_error(response)
-                except exception.NexentaException as ex:
-                    err = utils.ex2err(ex)
-                    if err['code'] == 'ENOENT':
-                        LOG.debug('Exception on call to %(appliance)s: '
-                                  '%(url)s %(method)s data: %(data)s '
-                                  'returned message: %(message)s',
-                                  {'appliance': APPLIANCE,
-                                   'url': url,
-                                   'method': self.__method,
-                                   'data': data,
-                                   'message': six.text_type(err)})
-                        if (err['source'] == 'hpr' and
-                                'Destination pool' in err['message']):
-                            return content
-                        self.handle_failover()
-                        url = self.get_full_url(args[0])
-                        response = getattr(
-                            self.__proxy.session, self.__method)(url, **kwargs)
-                    else:
-                        raise
-                LOG.debug('Got response from %(appliance)s: '
-                          '%(code)s %(reason)s',
-                          {'appliance': APPLIANCE,
-                           'code': response.status_code,
-                           'reason': response.reason})
-                content = response.json() if response.content else None
-                keep_going = response.status_code == 202
+            LOG.debug('Retry initial request after failover: '
+                      '%(method)s %(path)s %(payload)s',
+                      {'method': self.method,
+                       'path': self.path,
+                       'payload': self.payload})
+            response = self.request(self.method, self.path, **self.payload)
+        LOG.debug('NEF request done: %(method)s %(path)s %(payload)s, '
+                  'total response time: %(time)s seconds, '
+                  'total requests count: %(count)s, '
+                  'requests statistics: %(stat)s',
+                  {'method': self.method,
+                   'path': self.path,
+                   'payload': self.payload,
+                   'time': self.time,
+                   'count': sum(self.stat.values()),
+                   'stat': self.stat})
+        if response.ok and not response.content:
+            return None
+        content = json.loads(response.content)
+        if not response.ok:
+            raise NefException(content)
+        if isinstance(content, dict) and 'data' in content:
+            return self.data
         return content
 
-    def handle_failover(self):
-        if self.__proxy.backup:
-            LOG.info('Primary %(appliance)s %(host)s is unavailable, '
-                     'failing over to secondary %(backup)s',
-                     {'appliance': APPLIANCE,
-                      'host': self.__proxy.host,
-                      'backup': self.__proxy.backup})
-            host = '%s,%s' % (self.__proxy.backup, self.__proxy.host)
-            self.__proxy.__init__(
-                host, self.__proxy.port, self.__proxy.user,
-                self.__proxy.password, self.__proxy.use_https,
-                self.__proxy.pool, self.__proxy.verify)
-            url = self.get_full_url('rsf/clusters')
-            response = self.__proxy.session.get(
-                url, verify=self.__proxy.verify)
-            content = response.json() if response.content else None
-            if not content:
-                raise exception.NexentaException(response)
-            cluster_name = content['data'][0]['clusterName']
-            for node in content['data'][0]['nodes']:
-                if node['ipAddress'] == self.__proxy.host:
-                    node_name = node['machineName']
-            counter = 0
-            interval = 5
-            url = self.get_full_url(
-                'rsf/clusters/%s/services' % cluster_name)
-            while counter < 24:
-                counter += 1
-                response = self.__proxy.session.get(
-                    url, verify=self.__proxy.verify)
-                content = response.json() if response.content else None
-                if content:
-                    for service in content['data']:
-                        if service['serviceName'] == self.__proxy.pool:
-                            if len(service['vips']) == 0:
-                                continue
-                            for mapping in service['vips'][0]['nodeMapping']:
-                                if (mapping['node'] == node_name and
-                                        mapping['status'] == 'up'):
-                                    return
-                LOG.debug('Pool %(pool)s service is not ready, '
-                          'sleeping for %(interval)ss',
-                          {'pool': self.__proxy.pool,
-                           'interval': interval})
-                time.sleep(interval)
-            msg = (_('Waited for %(period)ss, but pool %(pool)s '
-                     'service is still not running')
-                   % {'period': counter * interval,
-                      'pool': self.__proxy.pool})
-            raise exception.NexentaException(msg)
-        else:
-            raise
+    def request(self, method, path, **kwargs):
+        url = self.proxy.url(path)
+        LOG.debug('Perform session request: %(method)s %(url)s %(body)s',
+                  {'method': method, 'url': url, 'body': kwargs})
+        kwargs.update(self.kwargs)
+        return self.proxy.session.request(method, url, **kwargs)
+
+    def hook(self, response, **kwargs):
+        initial_text = (_('initial request %(method)s %(path)s %(body)s')
+                        % {'method': self.method,
+                           'path': self.path,
+                           'body': self.payload})
+        request_text = (_('session request %(method)s %(url)s %(body)s')
+                        % {'method': response.request.method,
+                           'url': response.request.url,
+                           'body': response.request.body})
+        response_text = (_('session response %(code)s %(content)s')
+                         % {'code': response.status_code,
+                            'content': response.content})
+        text = (_('%(request_text)s and %(response_text)s')
+                % {'request_text': request_text,
+                   'response_text': response_text})
+        LOG.debug('Hook start on %(text)s', {'text': text})
+
+        if response.status_code not in self.stat:
+            self.stat[response.status_code] = 0
+        self.stat[response.status_code] += 1
+        self.time += response.elapsed.total_seconds()
+
+        if response.ok and not response.content:
+            LOG.debug('Hook done on %(text)s: '
+                      'empty response content',
+                      {'text': text})
+            return response
+
+        if not response.content:
+            message = (_('There is no response content '
+                         'is available for %(text)s')
+                       % {'text': text})
+            raise NefException(code='ENODATA', message=message)
+
+        try:
+            content = json.loads(response.content)
+        except (TypeError, ValueError) as error:
+            message = (_('Failed to decode JSON for %(text)s: %(error)s')
+                       % {'text': text, 'error': error})
+            raise NefException(code='ENOMSG', message=message)
+
+        method = 'get'
+        if response.status_code == requests.codes.unauthorized:
+            if self.stat[response.status_code] > self.proxy.retries:
+                raise NefException(content)
+            self.auth()
+            LOG.debug('Retry %(text)s after authentication',
+                      {'text': request_text})
+            request = response.request.copy()
+            request.headers.update(self.proxy.session.headers)
+            return self.proxy.session.send(request, **kwargs)
+        elif response.status_code == requests.codes.not_found:
+            if self.lock:
+                LOG.debug('Hook done on %(text)s: '
+                          'nested failover is detected',
+                          {'text': text})
+                return response
+            if self.stat[response.status_code] > self.proxy.retries:
+                raise NefException(content)
+            if not self.failover():
+                LOG.debug('Hook done on %(text)s: '
+                          'no valid hosts found',
+                          {'text': text})
+                return response
+            LOG.debug('Retry %(text)s after failover',
+                      {'text': initial_text})
+            self.data = []
+            return self.request(self.method, self.path, **self.payload)
+        elif response.status_code == requests.codes.server_error:
+            if not (isinstance(content, dict) and
+                    'code' in content and
+                    content['code'] == 'EBUSY'):
+                raise NefException(content)
+            if self.stat[response.status_code] > self.proxy.retries:
+                raise NefException(content)
+            self.proxy.delay(self.stat[response.status_code])
+            LOG.debug('Retry %(text)s after delay',
+                      {'text': initial_text})
+            self.data = []
+            return self.request(self.method, self.path, **self.payload)
+        elif response.status_code == requests.codes.accepted:
+            path = self.getpath(content, 'monitor')
+            if not path:
+                message = (_('There is no monitor path '
+                             'available for %(text)s')
+                           % {'text': text})
+                raise NefException(code='ENOMSG', message=message)
+            self.proxy.delay(self.stat[response.status_code])
+            return self.request(method, path)
+        elif response.status_code == requests.codes.ok:
+            if not (isinstance(content, dict) and 'data' in content):
+                LOG.debug('Hook done on %(text)s: there '
+                          'is no JSON data available',
+                          {'text': text})
+                return response
+            LOG.debug('Append %(count)s data items to response',
+                      {'count': len(content['data'])})
+            self.data += content['data']
+            path = self.getpath(content, 'next')
+            if not path:
+                LOG.debug('Hook done on %(text)s: there '
+                          'is no next path available',
+                          {'text': text})
+                return response
+            LOG.debug('Perform next session request %(method)s %(path)s',
+                      {'method': method, 'path': path})
+            return self.request(method, path)
+        LOG.debug('Hook done on %(text)s and '
+                  'returned original response',
+                  {'text': text})
+        return response
+
+    def auth(self):
+        method = 'post'
+        path = 'auth/login'
+        payload = {
+            'username': self.proxy.username,
+            'password': self.proxy.password
+        }
+        data = json.dumps(payload)
+        kwargs = {'data': data}
+        self.proxy.delete_bearer()
+        response = self.request(method, path, **kwargs)
+        content = json.loads(response.content)
+        if not (isinstance(content, dict) and 'token' in content):
+            message = (_('There is no authentication token available '
+                         'for authentication request %(method)s %(url)s '
+                         '%(body)s and response %(code)s %(content)s')
+                       % {'method': response.request.method,
+                          'url': response.request.url,
+                          'body': response.request.body,
+                          'code': response.status_code,
+                          'content': response.content})
+            raise NefException(code='ENODATA', message=message)
+        token = content['token']
+        self.proxy.update_token(token)
+
+    def failover(self):
+        result = False
+        self.lock = True
+        method = 'get'
+        root = self.proxy.root
+        for host in self.proxy.hosts:
+            self.proxy.update_host(host)
+            LOG.debug('Try to failover path '
+                      '%(root)s to host %(host)s',
+                      {'root': root, 'host': host})
+            try:
+                response = self.request(method, root)
+            except (requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout) as error:
+                LOG.debug('Skip unavailable host %(host)s '
+                          'due to error: %(error)s',
+                          {'host': host, 'error': error})
+                continue
+            LOG.debug('Failover result: %(code)s %(content)s',
+                      {'code': response.status_code,
+                       'content': response.content})
+            if response.status_code == requests.codes.ok:
+                LOG.debug('Successful failover path '
+                          '%(root)s to host %(host)s',
+                          {'root': root, 'host': host})
+                result = True
+                break
+            else:
+                LOG.debug('Skip unsuitable host %(host)s: '
+                          'there is no %(root)s path found',
+                          {'host': host, 'root': root})
+        self.lock = False
+        return result
+
+    @staticmethod
+    def getpath(content, name):
+        if isinstance(content, dict) and 'links' in content:
+            for link in content['links']:
+                if not isinstance(link, dict):
+                    continue
+                if 'rel' in link and 'href' in link:
+                    if link['rel'] == name:
+                        return link['href']
+        return None
 
 
-class HTTPSAuth(requests.auth.AuthBase):
+class NefCollections(object):
 
-    def __init__(self, url, username, password, verify):
-        self.url = url
-        self.username = username
-        self.password = password
-        self.token = None
-        self.verify = verify
+    def __init__(self, proxy):
+        self.proxy = proxy
+        self.namespace = 'nexenta'
+        self.prefix = 'instance'
+        self.root = '/collections'
+        self.subj = 'collection'
+        self.properties = []
 
-    def __eq__(self, other):
-        return all([
-            self.url == getattr(other, 'url', None),
-            self.username == getattr(other, 'username', None),
-            self.password == getattr(other, 'password', None),
-            self.token == getattr(other, 'token', None)
-        ])
+    def path(self, name):
+        quoted_name = six.moves.urllib.parse.quote_plus(name)
+        return posixpath.join(self.root, quoted_name)
 
-    def __ne__(self, other):
-        return not self == other
+    def key(self, name):
+        return '%s:%s_%s' % (self.namespace, self.prefix, name)
 
-    def handle_401(self, r, **kwargs):
-        if r.status_code == 401:
-            LOG.debug('Got [401] response from %(appliance)s: '
-                      'trying to reauthenticate ...',
-                      {'appliance': APPLIANCE})
-            self.token = self.https_auth()
-            # Consume content and release the original connection
-            # to allow our new request to reuse the same one.
-            r.content
-            r.close()
-            prep = r.request.copy()
-            extract_cookies_to_jar(prep._cookies, r.request, r.raw)
-            prep.prepare_cookies(prep._cookies)
+    def get(self, name, payload=None):
+        LOG.debug('Get properties of %(subj)s %(name)s: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = self.path(name)
+        return self.proxy.get(path, payload)
 
-            prep.headers['Authorization'] = 'Bearer %s' % self.token
-            _r = r.connection.send(prep, **kwargs)
-            _r.history.append(r)
-            _r.request = prep
+    def set(self, name, payload=None):
+        LOG.debug('Modify properties of %(subj)s %(name)s: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = self.path(name)
+        return self.proxy.put(path, payload)
 
-            return _r
-        return r
+    def list(self, payload=None):
+        LOG.debug('List of %(subj)ss: %(payload)s',
+                  {'subj': self.subj, 'payload': payload})
+        return self.proxy.get(self.root, payload)
 
-    def __call__(self, r):
-        if not self.token:
-            self.token = self.https_auth()
-        r.headers['Authorization'] = 'Bearer %s' % self.token
-        r.register_hook('response', self.handle_401)
-        return r
+    def create(self, payload=None):
+        LOG.debug('Create %(subj)s: %(payload)s',
+                  {'subj': self.subj, 'payload': payload})
+        try:
+            return self.proxy.post(self.root, payload)
+        except NefException as error:
+            if error.code != 'EEXIST':
+                raise
 
-    def https_auth(self):
-        LOG.debug('Sending auth request to %(appliance)s: %(url)s',
-                  {'appliance': APPLIANCE,
-                   'url': self.url})
-        url = '/'.join((self.url, 'auth/login'))
-        headers = {'Content-Type': 'application/json'}
-        data = {'username': self.username, 'password': self.password}
-        response = requests.post(url, json=data, verify=self.verify,
-                                 headers=headers, timeout=TIMEOUT)
-        content = json.loads(response.content) if response.content else None
-        LOG.debug('Auth response from %(appliance)s: '
-                  '%(code)s %(reason)s %(content)s',
-                  {'appliance': APPLIANCE,
-                   'code': response.status_code,
-                   'reason': response.reason,
-                   'content': content})
-        check_error(response)
-        response.close()
-        if response.content:
-            token = content['token']
-            del content['token']
-            return token
-        msg = (_('Got bad response from %(appliance)s: '
-                 '%(code)s %(reason)s')
-               % {'appliance': APPLIANCE,
-                  'code': response.status_code,
-                  'reason': response.reason})
-        raise exception.NexentaException(msg)
+    def delete(self, name, payload=None):
+        LOG.debug('Delete %(subj)s %(name)s: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = self.path(name)
+        try:
+            return self.proxy.delete(path, payload)
+        except NefException as error:
+            if error.code != 'ENOENT':
+                raise
 
-class NexentaJSONProxy(object):
 
-    def __init__(self, host, port, user, password, use_https, pool, verify):
+class NefSettings(NefCollections):
+
+    def __init__(self, proxy):
+        super(NefSettings, self).__init__(proxy)
+        self.root = '/settings/properties'
+        self.subj = 'setting'
+
+    def create(self, payload=None):
+        return NotImplemented
+
+    def delete(self, name, payload=None):
+        return NotImplemented
+
+
+class NefDatasets(NefCollections):
+
+    def __init__(self, proxy):
+        super(NefDatasets, self).__init__(proxy)
+        self.root = '/storage/datasets'
+        self.subj = 'dataset'
+
+    def rename(self, name, payload=None):
+        LOG.debug('Rename %(subj)s %(name)s: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = posixpath.join(self.path(name), 'rename')
+        return self.proxy.post(path, payload)
+
+
+class NefSnapshots(NefDatasets, NefCollections):
+
+    def __init__(self, proxy):
+        super(NefSnapshots, self).__init__(proxy)
+        self.root = '/storage/snapshots'
+        self.subj = 'snapshot'
+
+    def clone(self, name, payload=None):
+        LOG.debug('Clone %(subj)s %(name)s: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = posixpath.join(self.path(name), 'clone')
+        return self.proxy.post(path, payload)
+
+
+class NefVolumeGroups(NefDatasets, NefCollections):
+
+    def __init__(self, proxy):
+        super(NefVolumeGroups, self).__init__(proxy)
+        self.root = '/storage/volumeGroups'
+        self.subj = 'volume group'
+
+    def rollback(self, name, payload=None):
+        LOG.debug('Rollback %(subj)s %(name)s: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = posixpath.join(self.path(name), 'rollback')
+        return self.proxy.post(path, payload)
+
+
+class NefVolumes(NefVolumeGroups, NefDatasets, NefCollections):
+
+    def __init__(self, proxy):
+        super(NefVolumes, self).__init__(proxy)
+        self.prefix = 'volume'
+        self.root = '/storage/volumes'
+        self.subj = 'volume'
+        self.properties = [
+            {
+                'name': self.key('blocksize'),
+                'api': 'volumeBlockSize',
+                'cfg': 'nexenta_ns5_blocksize',
+                'title': 'Block size',
+                'retype': _('Volume block size cannot be changed after '
+                            'the volume has been created.'),
+                'description': _('Controls the block size of a volume.'),
+                'type': 'integer',
+                'enum': [512, 1024, 2048, 4096, 8192,
+                         16384, 32768, 65536, 131072],
+                'default': 32768
+            },
+            {
+                'name': self.key('checksum'),
+                'api': 'checksumMode',
+                'title': 'Data integrity mode',
+                'description': _('Controls the checksum algorithm used to '
+                                 'verify volume data integrity.'),
+                'type': 'string',
+                'enum': ['on', 'off', 'fletcher2', 'fletcher4', 'sha256'],
+                'default': 'on'
+            },
+            {
+                'name': self.key('compression'),
+                'api': 'compressionMode',
+                'cfg': 'nexenta_dataset_compression',
+                'title': 'Data compression mode',
+                'description': _('Controls the compression algorithm used '
+                                 'to compress volume data.'),
+                'type': 'string',
+                'enum': ['off', 'on', 'lz4', 'lzjb', 'zle', 'gzip', 'gzip-1',
+                         'gzip-2', 'gzip-3', 'gzip-4', 'gzip-5', 'gzip-6',
+                         'gzip-7', 'gzip-8', 'gzip-9'],
+                'default': 'lz4'
+            },
+            {
+                'name': self.key('copies'),
+                'api': 'dataCopies',
+                'title': 'Number of data copies',
+                'description': _('Controls the number of copies of volume '
+                                 'data.'),
+                'type': 'integer',
+                'enum': [1, 2, 3],
+                'default': 1
+            },
+            {
+                'name': self.key('dedup'),
+                'api': 'dedupMode',
+                'cfg': 'nexenta_dataset_dedup',
+                'title': 'Data deduplication mode',
+                'description': _('Controls the deduplication algorithm used '
+                                 'to verify volume data integrity.'),
+                'type': 'string',
+                'enum': ['off', 'on', 'verify', 'sha256', 'sha256,verify'],
+                'default': 'off'
+            },
+            {
+                'name': self.key('logbias'),
+                'api': 'logBiasMode',
+                'title': 'Log bias mode',
+                'description': _('Provides a hint about handling of '
+                                 'synchronous requests for a volume.'),
+                'type': 'string',
+                'enum': ['latency', 'throughput'],
+                'default': 'latency'
+            },
+            {
+                'name': self.key('primarycache'),
+                'api': 'primaryCacheMode',
+                'title': 'Primary cache mode',
+                'description': _('Controls what is cached in the primary '
+                                 'cache (ARC).'),
+                'type': 'string',
+                'enum': ['all', 'none', 'metadata'],
+                'default': 'all'
+            },
+            {
+                'name': self.key('readonly'),
+                'api': 'readOnly',
+                'title': 'Read-only mode',
+                'description': _('Controls whether a volume can be modified.'),
+                'type': 'boolean',
+                'default': False
+            },
+            {
+                'name': self.key('redundant_metadata'),
+                'api': 'redundantMetadata',
+                'title': 'Metadata redundancy mode',
+                'description': _('Controls what types of metadata are stored '
+                                 'redundantly.'),
+                'type': 'string',
+                'enum': ['all', 'most'],
+                'default': 'all'
+            },
+            {
+                'name': self.key('secondarycache'),
+                'api': 'secondaryCache',
+                'title': 'Secondary cache',
+                'description': _('Controls what is cached in the secondary '
+                                 'cache (L2ARC).'),
+                'type': 'string',
+                'enum': ['all', 'none', 'metadata'],
+                'default': 'all'
+            },
+            {
+                'name': self.key('thin_provisioning'),
+                'api': 'sparseVolume',
+                'cfg': 'nexenta_sparse',
+                'title': 'Thin provisioning',
+                'retype': _('Volume provisioning type cannot be changed '
+                            'after the volume has been created.'),
+                'description': _('Controls if a volume is created sparse '
+                                 '(with no space reservation).'),
+                'type': 'boolean',
+                'default': False
+            },
+            {
+                'name': self.key('sync'),
+                'api': 'syncMode',
+                'title': 'Sync mode',
+                'description': _('Controls the behavior of synchronous '
+                                 'requests to a volume.'),
+                'type': 'string',
+                'enum': ['standard', 'always', 'disabled'],
+                'default': 'standard'
+            },
+            {
+                'name': self.key('write_back_cache'),
+                'api': 'writeBackCache',
+                'title': 'Write-back cache mode',
+                'inherit': _('Write-back cache mode cannot be inherit.'),
+                'description': _('Controls if the ZFS write-back cache '
+                                 'is enabled for a volume.'),
+                'type': 'boolean',
+                'default': False
+            },
+            {
+                'name': self.key('zpl_meta_to_metadev'),
+                'api': 'zplMetaToMetadev',
+                'title': 'ZPL metadata placement behavior',
+                'description': _('Control ZFS POSIX metadata placement '
+                                 'to a special virtual device.'),
+                'type': 'string',
+                'enum': ['off', 'on', 'dual'],
+                'default': 'off'
+            }
+        ]
+
+    def promote(self, name, payload=None):
+        LOG.debug('Promote %(subj)s %(name)s: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = posixpath.join(self.path(name), 'promote')
+        return self.proxy.post(path, payload)
+
+
+class NefFilesystems(NefVolumes, NefVolumeGroups, NefDatasets, NefCollections):
+
+    def __init__(self, proxy):
+        super(NefFilesystems, self).__init__(proxy)
+        self.root = '/storage/filesystems'
+        self.subj = 'filesystem'
+        for prop in self.properties:
+            if prop['name'] == self.key('blocksize'):
+                del prop['cfg']
+                prop['api'] = 'recordSize'
+                prop['description'] = _('Specifies a suggested block size '
+                                        'for a volume.')
+                prop['enum'] = [512, 1024, 2048, 4096, 8192, 16384, 32768,
+                                65536, 131072, 262144, 524288, 1048576]
+                prop['default'] = 131072
+            elif prop['name'] == self.key('thin_provisioning'):
+                prop['cfg'] = 'nexenta_sparsed_volumes'
+                prop['default'] = True
+        self.properties.append({
+            'name': self.key('rate_limit'),
+            'api': 'rateLimit',
+            'title': 'Transfer rate limit',
+            'description': _('Controls a transfer rate limit '
+                             '(bytes per second) for a volume.'),
+            'type': 'integer',
+            'default': 0
+        })
+        self.properties.append({
+            'name': self.key('snapdir'),
+            'api': 'snapshotDirectory',
+            'title': '.zfs directory visibility',
+            'description': _('Controls whether the .zfs directory '
+                             'is hidden or visible in the root of '
+                             'the volume file system.'),
+            'type': 'boolean',
+            'default': False
+        })
+
+    def mount(self, name, payload=None):
+        LOG.debug('Mount %(subj)s %(name)s: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = posixpath.join(self.path(name), 'mount')
+        return self.proxy.post(path, payload)
+
+    def unmount(self, name, payload=None):
+        LOG.debug('Unmount %(subj)s %(name)s: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = posixpath.join(self.path(name), 'unmount')
+        return self.proxy.post(path, payload)
+
+    def acl(self, name, payload=None):
+        LOG.debug('Set %(subj)s %(name)s ACL: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = posixpath.join(self.path(name), 'acl')
+        return self.proxy.post(path, payload)
+
+
+class NefHpr(NefCollections):
+
+    def __init__(self, proxy):
+        super(NefHpr, self).__init__(proxy)
+        self.root = '/hpr/services'
+        self.subj = 'HPR service'
+
+    def activate(self, payload=None):
+        LOG.debug('Activate %(payload)s',
+                  {'payload': payload})
+        root = posixpath.dirname(self.root)
+        path = posixpath.join(root, 'activate')
+        return self.proxy.post(path, payload)
+
+    def start(self, name, payload=None):
+        LOG.debug('Start %(subj)s %(name)s: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = posixpath.join(self.path(name), 'start')
+        return self.proxy.post(path, payload)
+
+
+class NefRsf(NefCollections):
+
+    def __init__(self, proxy):
+        super(NefRsf, self).__init__(proxy)
+        self.root = 'rsf/clusters'
+        self.subj = 'RSF Clusters'
+
+
+class NefServices(NefCollections):
+
+    def __init__(self, proxy):
+        super(NefServices, self).__init__(proxy)
+        self.root = '/services'
+        self.subj = 'service'
+
+
+class NefNfs(NefCollections):
+
+    def __init__(self, proxy):
+        super(NefNfs, self).__init__(proxy)
+        self.root = '/nas/nfs'
+        self.subj = 'NFS'
+
+
+class NefTargets(NefCollections):
+
+    def __init__(self, proxy):
+        super(NefTargets, self).__init__(proxy)
+        self.root = '/san/iscsi/targets'
+        self.subj = 'iSCSI target'
+
+
+class NefHostGroups(NefCollections):
+
+    def __init__(self, proxy):
+        super(NefHostGroups, self).__init__(proxy)
+        self.root = '/san/hostgroups'
+        self.subj = 'host group'
+
+
+class NefTargetsGroups(NefCollections):
+
+    def __init__(self, proxy):
+        super(NefTargetsGroups, self).__init__(proxy)
+        self.root = '/san/targetgroups'
+        self.subj = 'target group'
+
+
+class NefLunMappings(NefCollections):
+
+    def __init__(self, proxy):
+        super(NefLunMappings, self).__init__(proxy)
+        self.root = '/san/lunMappings'
+        self.subj = 'LUN mapping'
+
+
+class NefLogicalUnits(NefCollections):
+
+    def __init__(self, proxy):
+        super(NefLogicalUnits, self).__init__(proxy)
+        self.prefix = 'logical_unit'
+        self.root = '/san/logicalUnits'
+        self.subj = 'logical unit'
+        self.properties = [
+            {
+                'name': self.key('writeback_cache_disabled'),
+                'api': 'writebackCacheDisabled',
+                'cfg': 'nexenta_lu_writebackcache_disabled',
+                'title': 'Logical unit write-back cache disable mode',
+                'description': _('Controls logical unit write-back '
+                                 'cache disable behavior.'),
+                'type': 'boolean',
+                'default': False
+            },
+            {
+                'name': self.key('write_protect'),
+                'api': 'writeProtect',
+                'title': 'Logical unit write protect mode',
+                'description': _('Controls logical unit write '
+                                 'protection behavior.'),
+                'type': 'boolean',
+                'default': False
+            }
+        ]
+
+
+class NefNetAddresses(NefCollections):
+
+    def __init__(self, proxy):
+        super(NefNetAddresses, self).__init__(proxy)
+        self.root = '/network/addresses'
+        self.subj = 'network address'
+
+
+class NefProxy(object):
+    def __init__(self, proto, path, conf):
         self.session = requests.Session()
-        self.session.headers.update({'Content-Type': 'application/json'})
-        self.pool = pool
-        self.user = user
-        self.verify = verify
-        self.password = password
-        self.use_https = use_https
-        parts = host.split(',')
-        self.host = parts[0].strip()
-        self.backup = parts[1].strip() if len(parts) > 1 else None
-        if use_https:
+        self.settings = NefSettings(self)
+        self.filesystems = NefFilesystems(self)
+        self.volumegroups = NefVolumeGroups(self)
+        self.volumes = NefVolumes(self)
+        self.snapshots = NefSnapshots(self)
+        self.services = NefServices(self)
+        self.hpr = NefHpr(self)
+        self.rsf = NefRsf(self)
+        self.nfs = NefNfs(self)
+        self.targets = NefTargets(self)
+        self.hostgroups = NefHostGroups(self)
+        self.targetgroups = NefTargetsGroups(self)
+        self.mappings = NefLunMappings(self)
+        self.logicalunits = NefLogicalUnits(self)
+        self.netaddrs = NefNetAddresses(self)
+        self.lock = None
+        self.tokens = {}
+        self.headers = {
+            'Content-Type': 'application/json',
+            'X-XSS-Protection': '1'
+        }
+        if conf.nexenta_use_https:
             self.scheme = 'https'
-            self.port = port if port else 8443
-            self.session.auth = HTTPSAuth(self.url, user, password, verify)
         else:
             self.scheme = 'http'
-            self.port = port if port else 8080
-            self.session.auth = (user, password)
-
-    @property
-    def url(self):
-        return '{}://{}:{}'.format(self.scheme, self.host, self.port)
+        self.username = conf.nexenta_user
+        self.password = conf.nexenta_password
+        self.hosts = []
+        if conf.nexenta_rest_address:
+            for host in conf.nexenta_rest_address.split(','):
+                self.hosts.append(host.strip())
+        if proto == 'nfs':
+            self.root = self.filesystems.path(path)
+            if not self.hosts:
+                self.hosts.append(conf.nas_host)
+        elif proto == 'iscsi':
+            self.root = self.volumegroups.path(path)
+            if not self.hosts:
+                self.hosts.append(conf.nexenta_host)
+        else:
+            message = (_('Storage protocol %(proto)s not supported')
+                       % {'proto': proto})
+            raise NefException(code='EPROTO', message=message)
+        self.host = self.hosts[0]
+        if conf.nexenta_rest_port:
+            self.port = conf.nexenta_rest_port
+        else:
+            if conf.nexenta_use_https:
+                self.port = 8443
+            else:
+                self.port = 8080
+        self.proto = proto
+        self.path = path
+        self.backoff_factor = conf.nexenta_rest_backoff_factor
+        self.retries = len(self.hosts) * conf.nexenta_rest_retry_count
+        self.timeout = (conf.nexenta_rest_connect_timeout,
+                        conf.nexenta_rest_read_timeout)
+        max_retries = requests.packages.urllib3.util.retry.Retry(
+            total=conf.nexenta_rest_retry_count,
+            backoff_factor=conf.nexenta_rest_backoff_factor)
+        adapter = requests.adapters.HTTPAdapter(max_retries=max_retries)
+        self.session.verify = conf.driver_ssl_cert_verify
+        self.session.headers.update(self.headers)
+        self.session.mount('%s://' % self.scheme, adapter)
+        if not conf.driver_ssl_cert_verify:
+            requests.packages.urllib3.disable_warnings()
+        self.update_lock()
 
     def __getattr__(self, name):
-        if name in ('get', 'post', 'put', 'delete'):
-            return RESTCaller(self, name)
-        return super(NexentaJSONProxy, self).__getattribute__(name)
+        return NefRequest(self, name)
 
-    def __repr__(self):
-        return 'HTTP JSON proxy: %s' % self.url
+    def delete_bearer(self):
+        if 'Authorization' in self.session.headers:
+            del self.session.headers['Authorization']
+
+    def update_bearer(self, token):
+        bearer = 'Bearer %s' % token
+        self.session.headers['Authorization'] = bearer
+
+    def update_token(self, token):
+        self.tokens[self.host] = token
+        self.update_bearer(token)
+
+    def update_host(self, host):
+        self.host = host
+        if host in self.tokens:
+            token = self.tokens[host]
+            self.update_bearer(token)
+
+    def update_lock(self):
+        settings = {}
+        guid = None
+        try:
+            settings = self.settings.get('system.guid')
+        except NefException as error:
+            LOG.error('Unable to get host settings: %(error)s',
+                      {'error': error})
+        if settings and 'value' in settings:
+            guid = settings['value']
+            LOG.debug('Host guid: %(guid)s', {'guid': guid})
+        else:
+            LOG.error('Unable to get host guid: %(settings)s',
+                      {'settings': settings})
+        guids = []
+        clusters = []
+        payload = {'fields': 'nodes'}
+        try:
+            clusters = self.rsf.list(payload)
+        except NefException as error:
+            LOG.error('Unable to get HA cluster guid: %(error)s',
+                      {'error': error})
+        for cluster in clusters:
+            if 'nodes' not in cluster:
+                continue
+            nodes = cluster['nodes']
+            for node in nodes:
+                if 'machineId' in node:
+                    guids.append(node['machineId'])
+        if guid in guids:
+            guid = ':'.join(sorted(guids))
+            LOG.debug('HA cluster guid: %(guid)s',
+                      {'guid': guid})
+        if not guid:
+            guid = ':'.join(sorted(self.hosts))
+        lock = '%s:%s' % (guid, self.path)
+        if six.PY3:
+            lock = lock.encode('utf-8')
+        self.lock = hashlib.md5(lock).hexdigest()
+        LOG.debug('NEF coordination lock: %(lock)s',
+                  {'lock': self.lock})
+
+    def url(self, path):
+        if not path:
+            message = _('NEF API url requires path')
+            raise NefException(code='EINVAL', message=message)
+        netloc = '%s:%d' % (self.host, self.port)
+        components = (self.scheme, netloc, path, None, None)
+        url = six.moves.urllib.parse.urlunsplit(components)
+        return url
+
+    def delay(self, attempt):
+        interval = int(self.backoff_factor * (2 ** (attempt - 1)))
+        LOG.debug('Waiting for %(interval)s seconds',
+                  {'interval': interval})
+        greenthread.sleep(interval)
+
+
+def synchronized(method):
+    def wrapper(instance, *args, **kwargs):
+        lock = instance.nef.lock
+        LOG.debug('Synchronized call for %(instance)s '
+                  '%(method)s(%(args)s, %(kwargs)s) '
+                  'and coordination lock: %(lock)s',
+                  {'instance': instance,
+                   'method': method,
+                   'args': args,
+                   'kwargs': kwargs,
+                   'lock': lock})
+
+        @utils.synchronized(lock, external=True)
+        def wrapped():
+            return method(instance, *args, **kwargs)
+        return wrapped()
+    return wrapper

--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -13,42 +13,46 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import errno
 import hashlib
+import ipaddress
 import os
+import posixpath
+import uuid
+
+from oslo_log import log as logging
+from oslo_utils import strutils
+from oslo_utils import units
 import six
 
-from eventlet import greenthread
-from oslo_log import log as logging
-from oslo_utils import units
-from six.moves import urllib
-
 from cinder import context
-from cinder import db
-from cinder import exception
 from cinder.i18n import _
+from cinder import objects
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 from cinder.volume.drivers.nexenta import options
-from cinder.volume.drivers.nexenta import utils
 from cinder.volume.drivers import nfs
+from cinder.volume import utils
+from cinder.volume import volume_types
 
-VERSION = '1.6.9'
 LOG = logging.getLogger(__name__)
-BLOCK_SIZE_MB = 1
 
 
 class NexentaNfsDriver(nfs.NfsDriver):
     """Executes volume driver commands on Nexenta Appliance.
 
     Version history:
+
+    .. code-block:: none
+
         1.0.0 - Initial driver version.
         1.1.0 - Support for extend volume.
         1.2.0 - Added HTTPS support.
-                Added use of sessions for REST calls.
-                Added abandoned volumes and snapshots cleanup.
+              - Added use of sessions for REST calls.
+              - Added abandoned volumes and snapshots cleanup.
         1.3.0 - Failover support.
         1.4.0 - Migrate volume support and new NEF API calls.
         1.6.0 - Get mountPoint from API to support old style mount points.
-                Mount and umount shares on each operation to avoid mass
+              - Mount and umount shares on each operation to avoid mass
                 mounts on controller. Clean up mount folders on delete.
         1.6.1 - Fixed volume from image creation.
         1.6.2 - Removed redundant share mount from initialize_connection.
@@ -59,85 +63,143 @@ class NexentaNfsDriver(nfs.NfsDriver):
         1.6.7 - Fixed volume migration for HA environment.
         1.6.8 - Added deferred deletion for snapshots.
         1.6.9 - Fixed race between volume/clone deletion.
+        1.7.0 - Added consistency group support.
+        1.7.1 - Removed redundant hpr/activate call from initialize_connection.
+        1.7.2 - Merged upstream changes for umount.
+        1.8.0 - Refactored NFS driver.
+              - Added pagination support.
+              - Added configuration parameters for REST API connect/read
+                timeouts, connection retries and backoff factor.
+              - Fixed HA failover.
+              - Added retries on EBUSY errors.
+              - Fixed HTTP authentication.
+              - Disabled non-blocking mandatory locks.
+              - Added coordination for dataset operations.
+        1.8.1 - Support for NexentaStor tenants.
+        1.8.2 - Added manage/unmanage/manageable-list volume/snapshot support.
+        1.8.3 - Added consistency group capability to generic volume group.
+        1.8.4 - Refactored storage assisted volume migration.
+                Added support for volume retype.
+                Added support for volume type extra specs.
+                Added vendor capabilities support.
+        1.8.5 - Fixed NFS protocol version for generic volume migration.
+        1.8.6 - Fixed post-migration volume mount.
     """
 
-    driver_prefix = 'nexenta'
-    volume_backend_name = 'NexentaNfsDriver'
-    VERSION = VERSION
-
-    # ThirdPartySystems wiki page
+    VERSION = '1.8.6'
     CI_WIKI_NAME = "Nexenta_CI"
+
+    vendor_name = 'Nexenta'
+    product_name = 'NexentaStor5'
+    storage_protocol = 'NFS'
+    driver_volume_type = 'nfs'
 
     def __init__(self, *args, **kwargs):
         super(NexentaNfsDriver, self).__init__(*args, **kwargs)
-        if self.configuration:
-            self.configuration.append_config_values(
-                options.NEXENTA_CONNECTION_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_NFS_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_DATASET_OPTS)
-
-        self.verify_ssl = self.configuration.driver_ssl_cert_verify
-        self.nfs_mount_point_base = self.configuration.nexenta_mount_point_base
-        self.dataset_compression = (
-            self.configuration.nexenta_dataset_compression)
-        self.dataset_description = (
-            self.configuration.nexenta_dataset_description)
-        self.sparsed_volumes = self.configuration.nexenta_sparsed_volumes
+        if not self.configuration:
+            message = (_('%(product_name)s %(storage_protocol)s '
+                         'backend configuration not found')
+                       % {'product_name': self.product_name,
+                          'storage_protocol': self.storage_protocol})
+            raise jsonrpc.NefException(code='ENODATA', message=message)
+        self.configuration.append_config_values(
+            options.NEXENTA_CONNECTION_OPTS)
+        self.configuration.append_config_values(
+            options.NEXENTA_NFS_OPTS)
+        self.configuration.append_config_values(
+            options.NEXENTA_DATASET_OPTS)
         self.nef = None
-        self.use_https = self.configuration.nexenta_use_https
-        self.nef_host = self.configuration.nexenta_rest_address
+        self.driver_name = self.__class__.__name__
         self.nas_host = self.configuration.nas_host
-        self.share = self.configuration.nas_share_path
-        self.nef_port = self.configuration.nexenta_rest_port
-        self.nef_user = self.configuration.nexenta_user
-        self.nef_password = self.configuration.nexenta_password
-
-    @property
-    def backend_name(self):
-        backend_name = None
-        if self.configuration:
-            backend_name = self.configuration.safe_get('volume_backend_name')
-        if not backend_name:
-            backend_name = self.__class__.__name__
-        return backend_name
+        self.root_path = self.configuration.nas_share_path
+        self.mount_point_base = self.configuration.nexenta_mount_point_base
+        self.group_snapshot_template = (
+            self.configuration.nexenta_group_snapshot_template)
+        self.origin_snapshot_template = (
+            self.configuration.nexenta_origin_snapshot_template)
 
     def do_setup(self, context):
-        host = self.nef_host or self.nas_host
-        pool_name, fs = self._get_share_datasets(self.share)
-        self.nef = jsonrpc.NexentaJSONProxy(
-            host, self.nef_port, self.nef_user,
-            self.nef_password, self.use_https, pool_name, self.verify_ssl)
+        self.nef = jsonrpc.NefProxy(self.driver_volume_type,
+                                    self.root_path,
+                                    self.configuration)
 
     def check_for_setup_error(self):
-        """Verify that nas_share_path is shared over NFS."""
-        pool_name, fs = self._get_share_datasets(self.share)
-        url = 'storage/pools/%s' % (pool_name)
-        self.nef.get(url)
+        """Check root filesystem, NFS service and NFS share."""
+        filesystem = self.nef.filesystems.get(self.root_path)
+        if filesystem['mountPoint'] == 'none':
+            message = (_('NFS root filesystem %(path)s is not writable')
+                       % {'path': filesystem['mountPoint']})
+            raise jsonrpc.NefException(code='ENOENT', message=message)
+        if not filesystem['isMounted']:
+            message = (_('NFS root filesystem %(path)s is not mounted')
+                       % {'path': filesystem['mountPoint']})
+            raise jsonrpc.NefException(code='ENOTDIR', message=message)
+        payload = {}
+        if filesystem['nonBlockingMandatoryMode']:
+            payload['nonBlockingMandatoryMode'] = False
+        if filesystem['smartCompression']:
+            payload['smartCompression'] = False
+        if payload:
+            self.nef.filesystems.set(self.root_path, payload)
+        service = self.nef.services.get('nfs')
+        if service['state'] != 'online':
+            message = (_('NFS server service is not online: %(state)s')
+                       % {'state': service['state']})
+            raise jsonrpc.NefException(code='ESRCH', message=message)
+        share = self.nef.nfs.get(self.root_path)
+        if share['shareState'] != 'online':
+            message = (_('NFS share %(share)s is not online: %(state)s')
+                       % {'share': self.root_path,
+                          'state': share['shareState']})
+            raise jsonrpc.NefException(code='ESRCH', message=message)
 
-        url = 'nas/nfs?filesystem=%s' % urllib.parse.quote_plus(self.share)
-        data = self.nef.get(url).get('data')
-        if not (data and data[0].get('shareState') == 'online'):
-            msg = (_('NFS share %(share)s is not accessible')
-                   % {'share': self.share})
-            raise exception.NexentaException(msg)
-
+    @jsonrpc.synchronized
     def create_volume(self, volume):
         """Creates a volume.
 
         :param volume: volume reference
-        :returns: provider_location update dict for database
         """
-        LOG.debug('Create volume %(volume)s',
-                  {'volume': volume['name']})
-        self._do_create_volume(volume)
-        return {'provider_location': volume['provider_location']}
+        volume_path = self._get_volume_path(volume)
+        properties = self.nef.filesystems.properties
+        payload = self._get_vendor_properties(volume, properties)
+        sparsed_volume = payload.pop('sparseVolume', True)
+        payload.update({'path': volume_path})
+        self.nef.filesystems.create(payload)
+        try:
+            self._set_volume_acl(volume)
+            self._mount_volume(volume)
+            volume_file = self.local_path(volume)
+            if sparsed_volume:
+                self._create_sparsed_file(volume_file, volume['size'])
+            else:
+                payload = {'source': True}
+                filesystem = self.nef.filesystems.get(volume_path, payload)
+                compression = filesystem['compressionMode']
+                source = filesystem['source']['compressionMode']
+                if compression != 'off':
+                    payload = {'compressionMode': 'off'}
+                    self.nef.filesystems.set(volume_path, payload)
+                self._create_regular_file(volume_file, volume['size'])
+                if compression != 'off':
+                    if source in ['local', 'received']:
+                        payload = {'compressionMode': compression}
+                    else:
+                        payload = {'compressionMode': None}
+                    self.nef.filesystems.set(volume_path, payload)
+        except jsonrpc.NefException as create_error:
+            try:
+                payload = {'force': True}
+                self.nef.filesystems.delete(volume_path, payload)
+            except jsonrpc.NefException as delete_error:
+                LOG.debug('Failed to delete volume %(path)s: %(error)s',
+                          {'path': volume_path, 'error': delete_error})
+            raise create_error
+        finally:
+            self._unmount_volume(volume)
 
     def copy_image_to_volume(self, context, volume, image_service, image_id):
         LOG.debug('Copy image %(image)s to volume %(volume)s',
-                  {'image': image_id,
-                   'volume': volume['name']})
+                  {'image': image_id, 'volume': volume['name']})
         self._mount_volume(volume)
         super(NexentaNfsDriver, self).copy_image_to_volume(
             context, volume, image_service, image_id)
@@ -145,150 +207,61 @@ class NexentaNfsDriver(nfs.NfsDriver):
 
     def copy_volume_to_image(self, context, volume, image_service, image_meta):
         LOG.debug('Copy volume %(volume)s to image %(image)s',
-                  {'volume': volume['name'],
-                   'image': image_meta['id']})
+                  {'volume': volume['name'], 'image': image_meta['id']})
         self._mount_volume(volume)
         super(NexentaNfsDriver, self).copy_volume_to_image(
             context, volume, image_service, image_meta)
         self._unmount_volume(volume)
 
-    def _do_create_volume(self, volume):
-        pool, fs = self._get_share_datasets(self.share)
-        filesystem = '%s/%s/%s' % (pool, fs, volume['name'])
-        LOG.debug('Create filesystem %(filesystem)s',
-                  {'filesystem': filesystem})
-        url = 'storage/filesystems'
-        data = {
-            'path': '/'.join([pool, fs, volume['name']]),
-            'compressionMode': self.dataset_compression,
-        }
-        try:
-            self.nef.post(url, data)
-        except exception.NexentaException as ex:
-            err = utils.ex2err(ex)
-            if err['code'] == 'EEXIST':
-                LOG.debug('Filesystem %(filesystem)s already exists, '
-                          'reuse existing filesystem',
-                          {'filesystem': filesystem})
-            else:
-                raise ex
-        volume['provider_location'] = '%s:/%s/%s' % (
-            self.nas_host, self.share, volume['name'])
-        try:
-            self._share_folder(fs, volume['name'])
-            self._mount_volume(volume)
-            volume_size = volume['size']
-            if getattr(self.configuration,
-                       self.driver_prefix + '_sparsed_volumes'):
-                self._create_sparsed_file(self.local_path(volume), volume_size)
-            else:
-                url = 'storage/filesystems/%s' % (
-                    '%2F'.join([pool, fs, volume['name']]))
-                compression = self.nef.get(url).get('compressionMode')
-                if compression != 'off':
-                    # Disable compression, because otherwise will not use space
-                    # on disk.
-                    self.nef.put(url, {'compressionMode': 'off'})
-                try:
-                    self._create_regular_file(
-                        self.local_path(volume), volume_size)
-                finally:
-                    if compression != 'off':
-                        # Backup default compression value if it was changed.
-                        self.nef.put(url, {'compressionMode': compression})
-
-        except exception.NexentaException as ex:
-            try:
-                url = 'storage/filesystems/%s' % (
-                    '%2F'.join([pool, fs, volume['name']]))
-                self.nef.delete(url)
-            except exception.NexentaException:
-                LOG.debug('Cannot destroy created filesystem '
-                          '%(pool)s/%(filesystem)s/%(volume)s: %(error)s',
-                          {'pool': pool,
-                           'filesystem': fs,
-                           'volume': volume['name'],
-                           'error': six.text_type(ex)})
-            raise ex
-        finally:
-            self._unmount_volume(volume)
-
-    def _ensure_share_unmounted(self, nfs_share, mount_path=None):
+    def _ensure_share_unmounted(self, share):
         """Ensure that NFS share is unmounted on the host.
 
-        :param nfs_share: NFS share name
-        :param mount_path: mount path on the host
+        :param share: share path
         """
-
-        num_attempts = max(1, self.configuration.nfs_mount_attempts)
-
-        if mount_path is None:
-            mount_path = self._get_mount_point_for_share(nfs_share)
-
-        if mount_path not in self._remotefsclient._read_mounts():
+        attempts = max(1, self.configuration.nfs_mount_attempts)
+        path = self._get_mount_point_for_share(share)
+        if path not in self._remotefsclient._read_mounts():
             LOG.debug('NFS share %(share)s is not mounted at %(path)s',
-                      {'share': nfs_share,
-                       'path': mount_path})
+                      {'share': share, 'path': path})
             return
-
-        for attempt in range(num_attempts):
+        for attempt in range(attempts):
             try:
-                self._execute('umount', mount_path, run_as_root=True)
+                self._execute('umount', path, run_as_root=True)
                 LOG.debug('NFS share %(share)s has been unmounted at %(path)s',
-                          {'share': nfs_share,
-                           'path': mount_path})
+                          {'share': share, 'path': path})
                 break
-            except Exception as ex:
-                msg = six.text_type(ex)
-                if attempt == (num_attempts - 1):
-                    LOG.error('Unmount failure for %(share)s after '
-                              '%(count)d attempts',
-                              {'share': nfs_share,
-                               'count': num_attempts})
-                    raise exception.NfsException(msg)
-                LOG.warning('Unmount attempt %(attempt)d failed: %(msg)s, '
-                            'retrying unmount %(share)s from %(path)s',
-                            {'attempt': attempt,
-                             'msg': msg,
-                             'share': nfs_share,
-                             'path': mount_path})
-                greenthread.sleep(1)
-
-        self._delete(mount_path)
+            except Exception as error:
+                if attempt == (attempts - 1):
+                    LOG.error('Failed to unmount NFS share %(share)s '
+                              'after %(attempts)s attempts',
+                              {'share': share, 'attempts': attempts})
+                    raise
+                LOG.debug('Unmount attempt %(attempt)s failed: %(error)s, '
+                          'retrying unmount %(share)s from %(path)s',
+                          {'attempt': attempt, 'error': error,
+                           'share': share, 'path': path})
+                self.nef.delay(attempt)
+        self._delete(path)
 
     def _mount_volume(self, volume):
         """Ensure that volume is activated and mounted on the host."""
-        dataset_name = self._get_dataset_name(volume)
-        dataset_url = 'storage/filesystems/%s' % (
-            urllib.parse.quote_plus(dataset_name))
-        dataset = self.nef.get(dataset_url)
-        dataset_mount_point = dataset.get('mountPoint')
-        dataset_ready = dataset.get('isMounted')
-        if dataset_mount_point == 'none':
-            hpr_url = 'hpr/activate'
-            data = {'datasetName': dataset_name}
-            self.nef.post(hpr_url, data)
-            dataset = self.nef.get(dataset_url)
-            dataset_mount_point = dataset.get('mountPoint')
-        elif not dataset_ready:
-            dataset_url = 'storage/filesystems/%s/mount' % (
-                urllib.parse.quote_plus(dataset_name))
-            self.nef.post(dataset_url)
-        nfs_share = '%s:%s' % (self.nas_host, dataset_mount_point)
-        self._ensure_share_mounted(nfs_share)
+        share = self._get_volume_share(volume)
+        self._ensure_share_mounted(share)
+
+    def _remount_volume(self, volume):
+        """Workaround for NEX-16457."""
+        volume_path = self._get_volume_path(volume)
+        self.nef.filesystems.unmount(volume_path)
+        self.nef.filesystems.mount(volume_path)
 
     def _unmount_volume(self, volume):
         """Ensure that volume is unmounted on the host."""
-        dataset_name = self._get_dataset_name(volume)
-        params = {'path': dataset_name}
-        url = 'storage/filesystems?%s' % urllib.parse.urlencode(params)
-        data = self.nef.get(url).get('data')
-        if not data:
-            return
-        dataset = data[0]
-        dataset_mount_point = dataset.get('mountPoint')
-        nfs_share = '%s:%s' % (self.nas_host, dataset_mount_point)
-        self._ensure_share_unmounted(nfs_share)
+        try:
+            share = self._get_volume_share(volume)
+        except jsonrpc.NefException as error:
+            if error.code == 'ENOENT':
+                return
+        self._ensure_share_unmounted(share)
 
     def _create_sparsed_file(self, path, size):
         """Creates file with 0 disk usage."""
@@ -297,226 +270,296 @@ class NexentaNfsDriver(nfs.NfsDriver):
         else:
             super(NexentaNfsDriver, self)._create_sparsed_file(path, size)
 
-    def migrate_volume(self, ctxt, volume, host):
-        """Migrate if volume and host are managed by Nexenta appliance.
+    def migrate_volume(self, context, volume, host):
+        """Migrate the volume to the specified host.
 
-        :param ctxt: context
-        :param volume: a dictionary describing the volume to migrate
-        :param host: a dictionary describing the host to migrate to
+        Returns a boolean indicating whether the migration occurred,
+        as well as model_update.
+
+        :param context: Security context
+        :param volume: A dictionary describing the volume to migrate
+        :param host: A dictionary describing the host to migrate to, where
+                     host['host'] is its name, and host['capabilities'] is a
+                     dictionary of its reported capabilities.
         """
-        LOG.debug('Migrate volume %(volume)s to host %(host)s',
+        LOG.debug('Start storage assisted volume migration '
+                  'for volume %(volume)s to host %(host)s',
                   {'volume': volume['name'],
-                   'host': host})
-
+                   'host': host['host']})
         false_ret = (False, None)
-
-        if volume['status'] not in ('available', 'retyping'):
-            LOG.error('Volume %(volume)s status must be available or '
-                      'retyping, current volume status is %(status)s',
-                      {'volume': volume['name'],
-                       'status': volume['status']})
-            return false_ret
-
         if 'capabilities' not in host:
-            LOG.error('Unsupported host %(host)s: '
-                      'no capabilities found',
-                      {'host': host})
+            LOG.debug('No host capabilities found for '
+                      'the destination host %(host)s',
+                      {'host': host['host']})
             return false_ret
-
         capabilities = host['capabilities']
-
-        if not ('location_info' in capabilities and
-                'vendor_name' in capabilities and
-                'free_capacity_gb' in capabilities):
-            LOG.error('Unsupported host %(host)s: required NFS '
-                      'and vendor capabilities are not found',
-                      {'host': host})
-            return false_ret
-
-        dst_driver_name = capabilities['location_info'].split(':')[0]
-        dst_fs = capabilities['location_info'].split(':/')[1]
-
-        if not (capabilities['vendor_name'] == 'Nexenta' and
-                dst_driver_name == self.__class__.__name__):
-            LOG.error('Unsupported host %(host)s: incompatible '
-                      'vendor %(vendor)s or driver %(driver)s',
-                      {'host': host,
-                       'vendor': capabilities['vendor_name'],
-                       'driver': dst_driver_name})
-            return false_ret
-
-        if capabilities['free_capacity_gb'] < volume['size']:
-            LOG.error('There is not enough space available on the '
-                      'host %(host)s to migrate volume %(volume), '
-                      'free space: %(free)d, required: %(size)d',
-                      {'host': host,
-                       'volume': volume['name'],
-                       'free': capabilities['free_capacity_gb'],
-                       'size': volume['size']})
-            return false_ret
-
-        nef_ips = capabilities['nef_url'].split(',')
-        nef_ips.append(None)
-        pool, fs = self._get_share_datasets(self.share)
-        url = 'hpr/services'
-        svc = 'cinder-migrate-%s' % volume['name']
-        data = {
-            'name': svc,
-            'sourceDataset': '/'.join([pool, fs, volume['name']]),
-            'destinationDataset': '/'.join([dst_fs, volume['name']]),
-            'type': 'scheduled',
-            'sendShareNfs': True
-        }
-        for nef_ip in nef_ips:
-            hpr = data
-            if nef_ip is not None:
-                hpr['isSource'] = True
-                hpr['remoteNode'] = {
-                    'host': nef_ip,
-                    'port': capabilities['nef_port']
-                }
-            try:
-                self.nef.post(url, hpr)
-                break
-            except exception.NexentaException as ex:
-                err = utils.ex2err(ex)
-                if nef_ip is None or err['code'] not in ('EINVAL', 'ENOENT'):
-                    LOG.error('Failed to create replication '
-                              'service %(data)s: %(error)s',
-                              {'data': data,
-                               'error': six.text_type(err)})
-                    return false_ret
-
-        url = 'hpr/services/%s/start' % svc
-        try:
-            self.nef.post(url)
-        except exception.NexentaException as ex:
-            err = utils.ex2err(ex)
-            LOG.error('Failed to start replication '
-                      'service %(svc)s: %(error)s',
-                      {'svc': svc,
-                       'error': six.text_type(err)})
-            return false_ret
-
-        provider_location = '/'.join([
-            capabilities['location_info'].lstrip('%s:' % dst_driver_name),
-            volume['name']])
-
-        data = {
-            'destroySourceSnapshots': 'true',
-            'destroyDestinationSnapshots': 'true'
-        }
-        params = urllib.parse.urlencode(data)
-        in_progress = True
-        url = 'hpr/services/%s' % svc
-        timeout = 1
-        while in_progress:
-            state = self.nef.get(url)['state']
-            if state == 'disabled':
-                in_progress = False
-            elif state == 'enabled':
-                greenthread.sleep(timeout)
-                timeout = timeout * 2
-            else:
-                url = 'hpr/services/%s?%s' % (svc, params)
-                self.nef.delete(url)
+        required_capabilities = [
+            'vendor_name',
+            'location_info',
+            'storage_protocol',
+            'free_capacity_gb',
+            'nef_url',
+            'nef_port'
+        ]
+        for capability in required_capabilities:
+            if capability not in capabilities:
+                LOG.debug('Required host capability %(capability)s not '
+                          'found for the destination host %(host)s',
+                          {'capability': capability, 'host': host['host']})
                 return false_ret
-
-        url = 'hpr/services/%s?%s' % (svc, params)
-        self.nef.delete(url)
-
+        vendor = capabilities['vendor_name']
+        if vendor != self.vendor_name:
+            LOG.debug('Unsupported vendor %(vendor)s found '
+                      'for the destination host %(host)s',
+                      {'vendor': vendor, 'host': host['host']})
+            return false_ret
+        location = capabilities['location_info']
+        try:
+            driver, nas_host, nas_path = location.split(':')
+        except ValueError as error:
+            LOG.debug('Failed to split location info %(location)s '
+                      'for the destination host %(host)s: %(error)s',
+                      {'location': location, 'host': host['host'],
+                       'error': error})
+            return false_ret
+        if not (driver and nas_host and nas_path):
+            LOG.debug('Incomplete location info %(location)s '
+                      'found for the destination host %(host)s',
+                      {'location': location, 'host': host['host']})
+            return false_ret
+        if driver != self.driver_name:
+            LOG.debug('Unsupported storage driver %(driver)s '
+                      'found for the destination host %(host)s',
+                      {'driver': driver, 'host': host['host']})
+            return false_ret
+        storage_protocol = capabilities['storage_protocol']
+        if storage_protocol != self.storage_protocol:
+            LOG.debug('Unsupported storage protocol %(protocol)s '
+                      'found for the destination host %(host)s',
+                      {'protocol': storage_protocol,
+                       'host': host['host']})
+            return false_ret
+        free_capacity_gb = capabilities['free_capacity_gb']
+        if free_capacity_gb < volume['size']:
+            LOG.debug('There is not enough space available on the '
+                      'destination host %(host)s to migrate volume '
+                      '%(volume)s, available space: %(free)sG, '
+                      'required space: %(required)sG',
+                      {'host': host['host'], 'volume': volume['name'],
+                       'free': free_capacity_gb,
+                       'required': volume['size']})
+            return false_ret
+        try:
+            payload = {'fields': 'name'}
+            self.nef.hpr.list(payload)
+        except jsonrpc.NefException as error:
+            LOG.debug('Storage assisted volume migration is unavailable '
+                      'for the destination host %(host)s: %(error)s',
+                      {'host': host['host'], 'error': error})
+            return false_ret
+        src_path = self._get_volume_path(volume)
+        dst_path = posixpath.join(nas_path, volume['name'])
+        dst_port = capabilities['nef_port']
+        src_hosts = self._get_host_addresses()
+        dst_hosts = capabilities['nef_url'].split(',')
+        service_name = 'cinder-migrate-%s' % volume['name']
+        service_created = service_running = service_success = False
+        while dst_hosts and not service_created:
+            dst_host = dst_hosts.pop()
+            if dst_host is not None:
+                dst_host = dst_host.strip()
+            payload = {
+                'name': service_name,
+                'sourceDataset': src_path,
+                'destinationDataset': dst_path,
+                'type': 'scheduled'
+            }
+            if dst_host not in src_hosts:
+                payload['isSource'] = True
+                payload['remoteNode'] = {
+                    'host': dst_host,
+                    'port': dst_port
+                }
+            elif src_path == dst_path:
+                LOG.debug('Skip local to local replication: '
+                          'source volume %(src_path)s and '
+                          'destination volume %(dst_path)s '
+                          'are the same volume',
+                          {'src_path': src_path,
+                           'dst_path': dst_path})
+                return True, None
+            try:
+                self.nef.hpr.create(payload)
+                service_created = True
+            except jsonrpc.NefException as error:
+                LOG.debug('Failed to create replication service '
+                          'with payload %(payload)s: %(error)s',
+                          {'payload': payload, 'error': error})
+                if error.code not in ('ENOENT', 'EINVAL'):
+                    return false_ret
+        if service_created:
+            try:
+                self.nef.hpr.start(service_name)
+                service_running = True
+            except jsonrpc.NefException as error:
+                LOG.debug('Failed to start replication service '
+                          '%(service_name)s: %(error)s',
+                          {'service_name': service_name,
+                           'error': error})
+        retry_count = 0
+        while service_running and not service_success:
+            try:
+                service = self.nef.hpr.get(service_name)
+            except jsonrpc.NefException as error:
+                LOG.debug('Failed to stat replication service '
+                          '%(service_name)s: %(error)s',
+                          {'service_name': service_name,
+                           'error': error})
+                break
+            state = service['state']
+            if state == 'faulted':
+                service_error = service['lastError']
+                LOG.debug('Replication service %(service_name)s '
+                          'failed with error: %(service_error)s',
+                          {'service_name': service_name,
+                           'service_error': service_error})
+                break
+            elif state == 'disabled':
+                LOG.debug('Replication service %(service_name)s '
+                          'successfully replicated %(src_path)s '
+                          'to %(dst_host)s:%(dst_path)s',
+                          {'service_name': service_name,
+                           'src_path': src_path,
+                           'dst_host': dst_host,
+                           'dst_path': dst_path})
+                service_running = False
+                service_success = True
+                break
+            else:
+                progress = service['progress']
+                LOG.debug('Replication service %(service_name)s '
+                          'is running, progress %(progress)s%%',
+                          {'service_name': service_name,
+                           'progress': progress})
+                self.nef.delay(retry_count)
+                retry_count += 1
+        if service_created:
+            payload = {
+                'destroySourceSnapshots': True,
+                'destroyDestinationSnapshots': True,
+                'force': True
+            }
+            try:
+                self.nef.hpr.delete(service_name, payload)
+            except jsonrpc.NefException as error:
+                LOG.debug('Failed to delete replication service '
+                          '%(service_name)s: %(error)s',
+                          {'service_name': service_name,
+                           'error': error})
+        if not service_success:
+            return false_ret
         try:
             self.delete_volume(volume)
-        except exception.NexentaException as ex:
-            LOG.warning('Cannot delete source volume %(volume)s: %(error)s',
-                        {'volume': volume['name'],
-                         'error': six.text_type(ex)})
+        except jsonrpc.NefException as error:
+            LOG.debug('Failed to delete source '
+                      'volume %(volume)s: %(error)s',
+                      {'volume': volume['name'],
+                       'error': error})
+        return True, None
 
-        return True, {'provider_location': provider_location}
+    def create_export(self, context, volume, connector):
+        """Driver entry point to get the export info for a new volume."""
+        pass
+
+    def ensure_export(self, context, volume):
+        """Driver entry point to get the export info for an existing volume."""
+        pass
+
+    def remove_export(self, context, volume):
+        """Driver entry point to remove an export for a volume."""
+        pass
 
     def terminate_connection(self, volume, connector, **kwargs):
+        """Terminate a connection to a volume.
+
+        :param volume: a volume object
+        :param connector: a connector object
+        :returns: dictionary of connection information
+        """
         LOG.debug('Terminate volume connection for %(volume)s',
                   {'volume': volume['name']})
         self._unmount_volume(volume)
 
     def initialize_connection(self, volume, connector):
+        """Terminate a connection to a volume.
+
+        :param volume: a volume object
+        :param connector: a connector object
+        :returns: dictionary of connection information
+        """
         LOG.debug('Initialize volume connection for %(volume)s',
                   {'volume': volume['name']})
-        url = 'hpr/activate'
-        data = {'datasetName': '/'.join([self.share, volume['name']])}
-        self.nef.post(url, data)
-        self._mount_volume(volume)
-        data = {'export': volume['provider_location'], 'name': 'volume'}
-        return {
-            'driver_volume_type': self.driver_volume_type,
-            'data': data,
-            'mount_point_base': self.nfs_mount_point_base
+        share = self._get_volume_share(volume)
+        data = {
+            'export': share,
+            'name': 'volume'
         }
+        nfs_options = self.configuration.safe_get('nfs_mount_options')
+        nas_options = self.configuration.safe_get('nas_mount_options')
+        if nfs_options and nas_options:
+            LOG.debug('Overriding NFS mount options for volume %(volume)s: '
+                      'nfs_mount_options = "%(nfs_options)s" with '
+                      'nas_mount_options = "%(nas_options)s"',
+                      {'volume': volume['name'],
+                       'nfs_options': nfs_options,
+                       'nas_options': nas_options})
+        if nas_options:
+            data['options'] = '-o %s' % nas_options
+        elif nfs_options:
+            data['options'] = '-o %s' % nfs_options
+        info = {
+            'driver_volume_type': self.driver_volume_type,
+            'mount_point_base': self.mount_point_base,
+            'data': data
+        }
+        return info
 
+    @jsonrpc.synchronized
     def delete_volume(self, volume):
-        """Deletes a logical volume.
+        """Deletes a volume.
 
         :param volume: volume reference
         """
-        LOG.debug('Delete volume %(volume)s',
-                  {'volume': volume['name']})
-        path = self._get_dataset_name(volume)
-        params = {'path': path}
-        url = 'storage/filesystems?%s' % (
-            urllib.parse.urlencode(params))
-        fs_data = self.nef.get(url).get('data')
-        if not fs_data:
-            return
+        volume_path = self._get_volume_path(volume)
         self._unmount_volume(volume)
-        params = {
-            'force': 'true',
-            'snapshots': 'true'
-        }
-        url = 'storage/filesystems/%s?%s' % (
-            urllib.parse.quote_plus(path),
-            urllib.parse.urlencode(params))
+        delete_payload = {'force': True, 'snapshots': True}
         try:
-            self.nef.delete(url)
-        except exception.NexentaException as ex:
-            err = utils.ex2err(ex)
-            if err['code'] == 'EEXIST':
-                params = {'parent': path}
-                url = 'storage/snapshots?%s' % (
-                    urllib.parse.urlencode(params))
-                snap_map = {}
-                for snap in self.nef.get(url)['data']:
-                    url = 'storage/snapshots/%s' % (
-                        urllib.parse.quote_plus(snap['path']))
-                    data = self.nef.get(url)
-                    if data and data.get('clones'):
-                        snap_map[data['creationTxg']] = snap['path']
-                if snap_map:
-                    snap = snap_map[max(snap_map)]
-                    url = 'storage/snapshots/%s' % urllib.parse.quote_plus(
-                        snap)
-                    clone = self.nef.get(url)['clones'][0]
-                    url = 'storage/filesystems/%s/promote' % (
-                        urllib.parse.quote_plus(clone))
-                    self.nef.post(url)
-                params = {
-                    'force': 'true',
-                    'snapshots': 'true'
-                }
-                url = 'storage/filesystems/%s?%s' % (
-                    urllib.parse.quote_plus(path),
-                    urllib.parse.urlencode(params))
-                self.nef.delete(url)
-            else:
-                raise ex
+            self.nef.filesystems.delete(volume_path, delete_payload)
+        except jsonrpc.NefException as error:
+            if error.code != 'EEXIST':
+                raise
+            snapshots_tree = {}
+            snapshots_payload = {'parent': volume_path, 'fields': 'path'}
+            snapshots = self.nef.snapshots.list(snapshots_payload)
+            for snapshot in snapshots:
+                clones_payload = {'fields': 'clones,creationTxg'}
+                data = self.nef.snapshots.get(snapshot['path'], clones_payload)
+                if data['clones']:
+                    snapshots_tree[data['creationTxg']] = data['clones'][0]
+            if snapshots_tree:
+                clone_path = snapshots_tree[max(snapshots_tree)]
+                self.nef.filesystems.promote(clone_path)
+            self.nef.filesystems.delete(volume_path, delete_payload)
 
     def _delete(self, path):
+        """Override parent method for safe remove mountpoint."""
         try:
             os.rmdir(path)
             LOG.debug('The mountpoint %(path)s has been successfully removed',
                       {'path': path})
-        except OSError as ex:
-            LOG.debug('Unable to remove mountpoint %(path)s: %(error)s',
-                      {'path': path, 'error': ex.strerror})
+        except OSError as error:
+            LOG.debug('Failed to remove mountpoint %(path)s: %(error)s',
+                      {'path': path, 'error': error.strerror})
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -524,65 +567,51 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: volume reference
         :param new_size: volume new size in GB
         """
-        LOG.info('Extending volume: %(volume)s, new size: %(size)sGB',
-                 {'volume': volume['name'],
-                  'size': new_size})
+        LOG.info('Extend volume %(volume)s, new size: %(size)sGB',
+                 {'volume': volume['name'], 'size': new_size})
         self._mount_volume(volume)
-        if self.sparsed_volumes:
-            self._execute('truncate', '-s', '%sG' % new_size,
-                          self.local_path(volume),
+        volume_file = self.local_path(volume)
+        properties = self.nef.filesystems.properties
+        payload = self._get_vendor_properties(volume, properties)
+        sparsed_volume = payload.pop('sparseVolume', True)
+        if sparsed_volume:
+            self._execute('truncate', '-s',
+                          '%dG' % new_size,
+                          volume_file,
                           run_as_root=True)
         else:
-            seek = (volume['size'] * units.Gi //
-                    (BLOCK_SIZE_MB * units.Mi))
-            count = ((new_size - volume['size']) * units.Gi //
-                     (BLOCK_SIZE_MB * units.Mi))
-            self._execute(
-                'dd', 'if=/dev/zero',
-                'seek=%d' % seek,
-                'of=%s' % self.local_path(volume),
-                'bs=%dM' % BLOCK_SIZE_MB,
-                'count=%d' % count,
-                run_as_root=True)
+            seek = volume['size'] * units.Ki
+            count = (new_size - volume['size']) * units.Ki
+            self._execute('dd',
+                          'if=/dev/zero',
+                          'of=%s' % volume_file,
+                          'bs=%d' % units.Mi,
+                          'seek=%d' % seek,
+                          'count=%d' % count,
+                          run_as_root=True)
         self._unmount_volume(volume)
 
+    @jsonrpc.synchronized
     def create_snapshot(self, snapshot):
         """Creates a snapshot.
 
         :param snapshot: snapshot reference
         """
-        volume = self._get_snapshot_volume(snapshot)
-        LOG.debug('Create snapshot %(snapshot)s for volume %(volume)s',
-                  {'snapshot': snapshot['name'],
-                   'volume': volume['name']})
-        pool, fs = self._get_share_datasets(self.share)
-        url = 'storage/snapshots'
+        snapshot_path = self._get_snapshot_path(snapshot)
+        payload = {'path': snapshot_path}
+        self.nef.snapshots.create(payload)
 
-        data = {'path': '%s@%s' % ('/'.join([pool, fs, volume['name']]),
-                                   snapshot['name'])}
-        self.nef.post(url, data)
-
+    @jsonrpc.synchronized
     def delete_snapshot(self, snapshot):
         """Deletes a snapshot.
 
         :param snapshot: snapshot reference
         """
-        LOG.debug('Delete snapshot %(snapshot)s',
-                  {'snapshot': snapshot['name']})
-        volume = self._get_snapshot_volume(snapshot)
-        path = '%s@%s' % (self._get_dataset_name(volume),
-                          snapshot['name'])
-        params = {'path': path}
-        url = 'storage/snapshots?%s' % urllib.parse.urlencode(params)
-        snap_data = self.nef.get(url).get('data')
-        if not snap_data:
-            return
-        params = {'defer': 'true'}
-        url = 'storage/snapshots/%s?%s' % (
-            urllib.parse.quote_plus(path),
-            urllib.parse.urlencode(params))
-        self.nef.delete(url)
+        snapshot_path = self._get_snapshot_path(snapshot)
+        payload = {'defer': True}
+        self.nef.snapshots.delete(snapshot_path, payload)
 
+    @jsonrpc.synchronized
     def create_volume_from_snapshot(self, volume, snapshot):
         """Create new volume from other's snapshot on appliance.
 
@@ -590,44 +619,18 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param snapshot: reference of source snapshot
         """
         LOG.debug('Create volume %(volume)s from snapshot %(snapshot)s',
-                  {'volume': volume['name'],
-                   'snapshot': snapshot['name']})
-        snapshot_vol = self._get_snapshot_volume(snapshot)
-        volume['provider_location'] = '%s:/%s/%s' % (
-            self.nas_host, self.share, volume['name'])
-        pool, fs = self._get_share_datasets(self.share)
-        fs_path = '%2F'.join([pool, fs, snapshot_vol['name']])
-        url = ('storage/snapshots/%s/clone') % (
-            '@'.join([fs_path, snapshot['name']]))
-        path = '/'.join([pool, fs, volume['name']])
-        data = {'targetPath': path}
-        self.nef.post(url, data)
-
-        self.nef.post(
-            'storage/filesystems/%s/unmount' % urllib.parse.quote_plus(path))
-        self.nef.post(
-            'storage/filesystems/%s/mount' % urllib.parse.quote_plus(path))
-        dataset_path = '%s/%s' % (pool, fs)
-        try:
-            self._share_folder(fs, volume['name'])
-
-        except exception.NexentaException as ex:
-            try:
-                url = ('storage/filesystems/') % (
-                    '%2F'.join([pool, fs, volume['name']]))
-                self.nef.delete(url)
-            except exception.NexentaException:
-                LOG.warning('Cannot destroy cloned filesystem: '
-                            '%(volume)s/%(filesystem)s',
-                            {'volume': dataset_path,
-                             'filesystem': volume['name']})
-            raise ex
+                  {'volume': volume['name'], 'snapshot': snapshot['name']})
+        snapshot_path = self._get_snapshot_path(snapshot)
+        clone_path = self._get_volume_path(volume)
+        payload = {'targetPath': clone_path}
+        self.nef.snapshots.clone(snapshot_path, payload)
+        self._remount_volume(volume)
+        self._set_volume_acl(volume)
         if volume['size'] > snapshot['volume_size']:
             new_size = volume['size']
             volume['size'] = snapshot['volume_size']
             self.extend_volume(volume, new_size)
             volume['size'] = new_size
-        return {'provider_location': volume['provider_location']}
 
     def create_cloned_volume(self, volume, src_vref):
         """Creates a clone of the specified volume.
@@ -635,160 +638,1067 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: new volume reference
         :param src_vref: source volume reference
         """
-        snapshot = {'volume_name': src_vref['name'],
-                    'volume_id': src_vref['id'],
-                    'volume_size': src_vref['size'],
-                    'name': self._get_clone_snapshot_name(volume)}
-        LOG.debug('Create temporary snapshot %(snapshot)s '
-                  'for the original volume %(volume)s',
-                  {'snapshot': snapshot['name'],
-                   'volume': snapshot['volume_name']})
+        snapshot = {
+            'name': self.origin_snapshot_template % volume['id'],
+            'volume_id': src_vref['id'],
+            'volume_name': src_vref['name'],
+            'volume_size': src_vref['size']
+        }
         self.create_snapshot(snapshot)
         try:
-            pl = self.create_volume_from_snapshot(volume, snapshot)
-            return pl
-        except exception.NexentaException as ex:
-            LOG.debug('Volume creation failed, deleting temporary '
-                      'snapshot %(volume)s@%(snapshot)s',
-                      {'volume': snapshot['volume_name'],
-                       'snapshot': snapshot['name']})
+            self.create_volume_from_snapshot(volume, snapshot)
+        except jsonrpc.NefException as error:
+            LOG.debug('Failed to create clone %(clone)s '
+                      'from volume %(volume)s: %(error)s',
+                      {'clone': volume['name'],
+                       'volume': src_vref['name'],
+                       'error': error})
+            raise
+        finally:
             try:
                 self.delete_snapshot(snapshot)
-            except (exception.NexentaException, exception.SnapshotIsBusy):
+            except jsonrpc.NefException as error:
                 LOG.debug('Failed to delete temporary snapshot '
-                          '%(volume)s@%(snapshot)s',
-                          {'volume': snapshot['volume_name'],
-                           'snapshot': snapshot['name']})
-            raise ex
+                          '%(volume)s@%(snapshot)s: %(error)s',
+                          {'volume': src_vref['name'],
+                           'snapshot': snapshot['name'],
+                           'error': error})
 
-    def _get_share_path(self, nas_host, share, volume_name):
-        url = 'storage/filesystems/%s' % urllib.parse.quote_plus(
-            '%s/%s' % (share, volume_name))
-        return '%s:%s' % (nas_host, self.nef.get(url)['mountPoint'])
+    def create_consistencygroup(self, context, group):
+        """Creates a consistency group.
+
+        :param context: the context of the caller.
+        :param group: the dictionary of the consistency group to be created.
+        :returns: group_model_update
+        """
+        group_model_update = {}
+        return group_model_update
+
+    def create_group(self, context, group):
+        """Creates a group.
+
+        :param context: the context of the caller.
+        :param group: the group object.
+        :returns: model_update
+        """
+        return self.create_consistencygroup(context, group)
+
+    def delete_consistencygroup(self, context, group, volumes):
+        """Deletes a consistency group.
+
+        :param context: the context of the caller.
+        :param group: the dictionary of the consistency group to be deleted.
+        :param volumes: a list of volume dictionaries in the group.
+        :returns: group_model_update, volumes_model_update
+        """
+        group_model_update = {}
+        volumes_model_update = []
+        for volume in volumes:
+            self.delete_volume(volume)
+        return group_model_update, volumes_model_update
+
+    def delete_group(self, context, group, volumes):
+        """Deletes a group.
+
+        :param context: the context of the caller.
+        :param group: the group object.
+        :param volumes: a list of volume objects in the group.
+        :returns: model_update, volumes_model_update
+        """
+        return self.delete_consistencygroup(context, group, volumes)
+
+    def update_consistencygroup(self, context, group, add_volumes=None,
+                                remove_volumes=None):
+        """Updates a consistency group.
+
+        :param context: the context of the caller.
+        :param group: the dictionary of the consistency group to be updated.
+        :param add_volumes: a list of volume dictionaries to be added.
+        :param remove_volumes: a list of volume dictionaries to be removed.
+        :returns: group_model_update, add_volumes_update, remove_volumes_update
+        """
+        group_model_update = {}
+        add_volumes_update = []
+        remove_volumes_update = []
+        return group_model_update, add_volumes_update, remove_volumes_update
+
+    def update_group(self, context, group, add_volumes=None,
+                     remove_volumes=None):
+        """Updates a group.
+
+        :param context: the context of the caller.
+        :param group: the group object.
+        :param add_volumes: a list of volume objects to be added.
+        :param remove_volumes: a list of volume objects to be removed.
+        :returns: model_update, add_volumes_update, remove_volumes_update
+        """
+        return self.update_consistencygroup(context, group, add_volumes,
+                                            remove_volumes)
+
+    def create_cgsnapshot(self, context, cgsnapshot, snapshots):
+        """Creates a consistency group snapshot.
+
+        :param context: the context of the caller.
+        :param cgsnapshot: the dictionary of the cgsnapshot to be created.
+        :param snapshots: a list of snapshot dictionaries in the cgsnapshot.
+        :returns: group_model_update, snapshots_model_update
+        """
+        group_model_update = {}
+        snapshots_model_update = []
+        cgsnapshot_name = self.group_snapshot_template % cgsnapshot['id']
+        cgsnapshot_path = '%s@%s' % (self.root_path, cgsnapshot_name)
+        create_payload = {'path': cgsnapshot_path, 'recursive': True}
+        self.nef.snapshots.create(create_payload)
+        for snapshot in snapshots:
+            volume_name = snapshot['volume_name']
+            volume_path = posixpath.join(self.root_path, volume_name)
+            snapshot_name = snapshot['name']
+            snapshot_path = '%s@%s' % (volume_path, cgsnapshot_name)
+            rename_payload = {'newName': snapshot_name}
+            self.nef.snapshots.rename(snapshot_path, rename_payload)
+        delete_payload = {'defer': True, 'recursive': True}
+        self.nef.snapshots.delete(cgsnapshot_path, delete_payload)
+        return group_model_update, snapshots_model_update
+
+    def create_group_snapshot(self, context, group_snapshot, snapshots):
+        """Creates a group_snapshot.
+
+        :param context: the context of the caller.
+        :param group_snapshot: the GroupSnapshot object to be created.
+        :param snapshots: a list of Snapshot objects in the group_snapshot.
+        :returns: model_update, snapshots_model_update
+        """
+        return self.create_cgsnapshot(context, group_snapshot, snapshots)
+
+    def delete_cgsnapshot(self, context, cgsnapshot, snapshots):
+        """Deletes a consistency group snapshot.
+
+        :param context: the context of the caller.
+        :param cgsnapshot: the dictionary of the cgsnapshot to be created.
+        :param snapshots: a list of snapshot dictionaries in the cgsnapshot.
+        :returns: group_model_update, snapshots_model_update
+        """
+        group_model_update = {}
+        snapshots_model_update = []
+        for snapshot in snapshots:
+            self.delete_snapshot(snapshot)
+        return group_model_update, snapshots_model_update
+
+    def delete_group_snapshot(self, context, group_snapshot, snapshots):
+        """Deletes a group_snapshot.
+
+        :param context: the context of the caller.
+        :param group_snapshot: the GroupSnapshot object to be deleted.
+        :param snapshots: a list of snapshot objects in the group_snapshot.
+        :returns: model_update, snapshots_model_update
+        """
+        return self.delete_cgsnapshot(context, group_snapshot, snapshots)
+
+    def create_consistencygroup_from_src(self, context, group, volumes,
+                                         cgsnapshot=None, snapshots=None,
+                                         source_cg=None, source_vols=None):
+        """Creates a consistency group from source.
+
+        :param context: the context of the caller.
+        :param group: the dictionary of the consistency group to be created.
+        :param volumes: a list of volume dictionaries in the group.
+        :param cgsnapshot: the dictionary of the cgsnapshot as source.
+        :param snapshots: a list of snapshot dictionaries in the cgsnapshot.
+        :param source_cg: the dictionary of a consistency group as source.
+        :param source_vols: a list of volume dictionaries in the source_cg.
+        :returns: group_model_update, volumes_model_update
+        """
+        group_model_update = {}
+        volumes_model_update = []
+        if cgsnapshot and snapshots:
+            for volume, snapshot in zip(volumes, snapshots):
+                self.create_volume_from_snapshot(volume, snapshot)
+        elif source_cg and source_vols:
+            snapshot_name = self.origin_snapshot_template % group['id']
+            snapshot_path = '%s@%s' % (self.root_path, snapshot_name)
+            create_payload = {'path': snapshot_path, 'recursive': True}
+            self.nef.snapshots.create(create_payload)
+            for volume, source_vol in zip(volumes, source_vols):
+                snapshot = {
+                    'name': snapshot_name,
+                    'volume_id': source_vol['id'],
+                    'volume_name': source_vol['name'],
+                    'volume_size': source_vol['size']
+                }
+                self.create_volume_from_snapshot(volume, snapshot)
+            delete_payload = {'defer': True, 'recursive': True}
+            self.nef.snapshots.delete(snapshot_path, delete_payload)
+        return group_model_update, volumes_model_update
+
+    def create_group_from_src(self, context, group, volumes,
+                              group_snapshot=None, snapshots=None,
+                              source_group=None, source_vols=None):
+        """Creates a group from source.
+
+        :param context: the context of the caller.
+        :param group: the Group object to be created.
+        :param volumes: a list of Volume objects in the group.
+        :param group_snapshot: the GroupSnapshot object as source.
+        :param snapshots: a list of snapshot objects in group_snapshot.
+        :param source_group: the Group object as source.
+        :param source_vols: a list of volume objects in the source_group.
+        :returns: model_update, volumes_model_update
+        """
+        return self.create_consistencygroup_from_src(context, group, volumes,
+                                                     group_snapshot, snapshots,
+                                                     source_group, source_vols)
+
+    def _local_volume_dir(self, volume):
+        """Get volume dir (mounted locally fs path) for given volume.
+
+        :param volume: volume reference
+        """
+        share = self._get_volume_share(volume)
+        if six.PY3:
+            share = share.encode('utf-8')
+        path = hashlib.md5(share).hexdigest()
+        return os.path.join(self.mount_point_base, path)
 
     def local_path(self, volume):
         """Get volume path (mounted locally fs path) for given volume.
 
         :param volume: volume reference
         """
-        share_path = self._get_share_path(
-            self.nas_host, self.share, volume['name'])
-        return os.path.join(self._get_mount_point_for_share(share_path),
-                            'volume')
+        volume_dir = self._local_volume_dir(volume)
+        return os.path.join(volume_dir, 'volume')
 
-    def _get_mount_point_for_share(self, nfs_share):
-        """Returns path to mount point NFS share.
+    def _set_volume_acl(self, volume):
+        """Sets access permissions for given volume.
 
-        :param nfs_share: example 172.18.194.100:/var/nfs
+        :param volume: volume reference
         """
-        nfs_share = nfs_share.encode('utf-8')
-        return os.path.join(self.configuration.nexenta_mount_point_base,
-                            hashlib.md5(nfs_share).hexdigest())
-
-    def _share_folder(self, path, filesystem):
-        """Share NFS filesystem on NexentaStor Appliance.
-
-        :param path: path to parent filesystem
-        :param filesystem: filesystem that needs to be shared
-        """
-        pool = self.share.split('/')[0]
-        LOG.debug('Creating ACL for filesystem %(filesystem)s',
-                  {'filesystem': filesystem})
-        url = 'storage/filesystems/%s/acl' % (
-            '%2F'.join([pool, urllib.parse.quote_plus(path), filesystem]))
-        data = {
-            "type": "allow",
-            "principal": "everyone@",
-            "permissions": [
-                "list_directory",
-                "read_data",
-                "add_file",
-                "write_data",
-                "add_subdirectory",
-                "append_data",
-                "read_xattr",
-                "write_xattr",
-                "execute",
-                "delete_child",
-                "read_attributes",
-                "write_attributes",
-                "delete",
-                "read_acl",
-                "write_acl",
-                "write_owner",
-                "synchronize"
+        volume_path = self._get_volume_path(volume)
+        payload = {
+            'type': 'allow',
+            'principal': 'everyone@',
+            'permissions': [
+                'full_set'
             ],
-            "flags": [
-                "file_inherit",
-                "dir_inherit"
+            'flags': [
+                'file_inherit',
+                'dir_inherit'
             ]
         }
-        self.nef.post(url, data)
-        LOG.debug('Successfully shared filesystem %(path)s/%(filesystem)s',
-                  {'path': path,
-                   'filesystem': filesystem})
+        self.nef.filesystems.acl(volume_path, payload)
 
-    def _get_capacity_info(self, path):
-        """Calculate available space on the NFS share.
+    def _get_volume_share(self, volume):
+        """Return NFS share path for the volume."""
+        volume_path = self._get_volume_path(volume)
+        get_payload = {'fields': 'mountPoint,isMounted'}
+        filesystem = self.nef.filesystems.get(volume_path, get_payload)
+        if filesystem['mountPoint'] == 'none':
+            activate_payload = {'datasetName': volume_path}
+            self.nef.hpr.activate(activate_payload)
+            filesystem = self.nef.filesystems.get(volume_path, get_payload)
+        if not filesystem['isMounted']:
+            self.nef.filesystems.mount(volume_path)
+        share = '%s:%s' % (self.nas_host, filesystem['mountPoint'])
+        return share
 
-        :param path: example pool/nfs
+    def _get_volume_path(self, volume):
+        """Return ZFS dataset path for the volume."""
+        return posixpath.join(self.root_path, volume['name'])
+
+    def _get_snapshot_path(self, snapshot):
+        """Return ZFS snapshot path for the snapshot."""
+        volume_name = snapshot['volume_name']
+        snapshot_name = snapshot['name']
+        volume_path = posixpath.join(self.root_path, volume_name)
+        return '%s@%s' % (volume_path, snapshot_name)
+
+    def get_volume_stats(self, refresh=False):
+        """Get volume stats.
+
+        If 'refresh' is True, update the stats first.
         """
-        pool, fs = self._get_share_datasets(path)
-        url = 'storage/filesystems/%s' % '%2F'.join([pool, fs])
-        data = self.nef.get(url)
-        free = utils.str2size(data['bytesAvailable'])
-        allocated = utils.str2size(data['bytesUsed'])
-        total = free + allocated
-        return total, free, allocated
+        if refresh or not self._stats:
+            self._update_volume_stats()
 
-    def _get_snapshot_volume(self, snapshot):
-        ctxt = context.get_admin_context()
-        return db.volume_get(ctxt, snapshot['volume_id'])
-
-    def _get_share_datasets(self, nfs_share):
-        pool_name, fs = nfs_share.split('/', 1)
-        return pool_name, urllib.parse.quote_plus(fs)
-
-    def _get_dataset_name(self, volume):
-        """Returns ZFS dataset name for a volume."""
-        return '%s/%s' % (self.share, volume['name'])
-
-    def _get_clone_snapshot_name(self, volume):
-        """Return name for snapshot that will be used to clone the volume."""
-        return 'cinder-clone-snapshot-%(id)s' % volume
-
-    def _is_clone_snapshot_name(self, snapshot):
-        """Check if snapshot is created for cloning."""
-        name = snapshot.split('@')[-1]
-        return name.startswith('cinder-clone-snapshot-')
+        return self._stats
 
     def _update_volume_stats(self):
-        """Retrieve stats info for NexentaStor appliance."""
-        LOG.debug('Updating volume stats')
-        total, free, allocated = self._get_capacity_info(self.share)
-        total_space = utils.str2gib_size(total)
-        free_space = utils.str2gib_size(free)
-        share = ':/'.join([self.nas_host, self.share])
-
-        location_info = '%(driver)s:%(share)s' % {
-            'driver': self.__class__.__name__,
-            'share': share
+        """Retrieve stats info for NexentaStor Appliance."""
+        payload = {'fields': 'bytesAvailable,bytesUsed,pool'}
+        dataset = self.nef.filesystems.get(self.root_path, payload)
+        pool_name = dataset['pool']
+        free_capacity_gb = dataset['bytesAvailable'] // units.Gi
+        allocated_capacity_gb = dataset['bytesUsed'] // units.Gi
+        total_capacity_gb = free_capacity_gb + allocated_capacity_gb
+        provisioned_capacity_gb = total_volumes = 0
+        ctxt = context.get_admin_context()
+        volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        for volume in volumes:
+            provisioned_capacity_gb += volume['size']
+            total_volumes += 1
+        volume_backend_name = (
+            self.configuration.safe_get('volume_backend_name'))
+        if not volume_backend_name:
+            LOG.debug('Failed to get configured volume backend name')
+            volume_backend_name = '%(product)s_%(protocol)s' % {
+                'product': self.product_name,
+                'protocol': self.storage_protocol
+            }
+        description = (
+            self.configuration.safe_get('nexenta_dataset_description'))
+        if not description:
+            description = '%(product)s %(host)s:%(path)s' % {
+                'product': self.product_name,
+                'host': self.configuration.nas_host,
+                'path': self.configuration.nas_share_path
+            }
+        max_over_subscription_ratio = (
+            self.configuration.safe_get('max_over_subscription_ratio'))
+        reserved_percentage = (
+            self.configuration.safe_get('reserved_percentage'))
+        if reserved_percentage is None:
+            reserved_percentage = 0
+        location_info = '%(driver)s:%(host)s:%(path)s' % {
+            'driver': self.driver_name,
+            'host': self.configuration.nas_host,
+            'path': self.configuration.nas_share_path
         }
+        display_name = 'Capabilities of %(product)s %(protocol)s driver' % {
+            'product': self.product_name,
+            'protocol': self.storage_protocol
+        }
+        visibility = 'public'
         self._stats = {
-            'vendor_name': 'Nexenta',
-            'compression': self.dataset_compression,
-            'description': self.dataset_description,
-            'nef_url': self.nef_host,
-            'nef_port': self.nef_port,
             'driver_version': self.VERSION,
-            'storage_protocol': 'NFS',
-            'sparsed_volumes': self.sparsed_volumes,
-            'total_capacity_gb': total_space,
-            'free_capacity_gb': free_space,
-            'reserved_percentage': self.configuration.reserved_percentage,
-            'QoS_support': False,
-            'multiattach': True,
+            'vendor_name': self.vendor_name,
+            'storage_protocol': self.storage_protocol,
+            'volume_backend_name': volume_backend_name,
             'location_info': location_info,
-            'volume_backend_name': self.backend_name,
-            'nfs_mount_point_base': self.nfs_mount_point_base
+            'description': description,
+            'display_name': display_name,
+            'pool_name': pool_name,
+            'multiattach': True,
+            'QoS_support': False,
+            'consistencygroup_support': True,
+            'consistent_group_snapshot_enabled': True,
+            'online_extend_support': True,
+            'sparse_copy_volume': True,
+            'thin_provisioning_support': True,
+            'thick_provisioning_support': True,
+            'total_capacity_gb': total_capacity_gb,
+            'allocated_capacity_gb': allocated_capacity_gb,
+            'free_capacity_gb': free_capacity_gb,
+            'provisioned_capacity_gb': provisioned_capacity_gb,
+            'total_volumes': total_volumes,
+            'max_over_subscription_ratio': max_over_subscription_ratio,
+            'reserved_percentage': reserved_percentage,
+            'visibility': visibility,
+            'nef_port': self.nef.port,
+            'nef_url': self.nef.host
         }
+        LOG.debug('Updated volume backend statistics for host %(host)s '
+                  'and volume backend %(volume_backend_name)s: %(stats)s',
+                  {'host': self.host,
+                   'volume_backend_name': volume_backend_name,
+                   'stats': self._stats})
+
+    def _get_existing_volume(self, existing_ref):
+        types = {
+            'source-name': 'path',
+            'source-guid': 'guid'
+        }
+        if not any(key in types for key in existing_ref):
+            keys = ', '.join(types.keys())
+            message = (_('Manage existing volume failed '
+                         'due to invalid backend reference. '
+                         'Volume reference must contain '
+                         'at least one valid key: %(keys)s')
+                       % {'keys': keys})
+            raise jsonrpc.NefException(code='EINVAL', message=message)
+        payload = {
+            'parent': self.root_path,
+            'fields': 'path',
+            'recursive': False
+        }
+        for key, value in types.items():
+            if key in existing_ref:
+                if value == 'path':
+                    path = posixpath.join(self.root_path,
+                                          existing_ref[key])
+                else:
+                    path = existing_ref[key]
+                payload[value] = path
+        existing_volumes = self.nef.filesystems.list(payload)
+        if len(existing_volumes) == 1:
+            volume_path = existing_volumes[0]['path']
+            volume_name = posixpath.basename(volume_path)
+            existing_volume = {
+                'name': volume_name,
+                'path': volume_path
+            }
+            vid = utils.extract_id_from_volume_name(volume_name)
+            if utils.check_already_managed_volume(vid):
+                message = (_('Volume %(name)s already managed')
+                           % {'name': volume_name})
+                raise jsonrpc.NefException(code='EBUSY', message=message)
+            return existing_volume
+        elif not existing_volumes:
+            code = 'ENOENT'
+            reason = _('no matching volumes were found')
+        else:
+            code = 'EINVAL'
+            reason = _('too many volumes were found')
+        message = (_('Unable to manage existing volume by '
+                     'reference %(reference)s: %(reason)s')
+                   % {'reference': existing_ref, 'reason': reason})
+        raise jsonrpc.NefException(code=code, message=message)
+
+    def _check_already_managed_snapshot(self, snapshot_id):
+        """Check cinder database for already managed snapshot.
+
+        :param snapshot_id: snapshot id parameter
+        :returns: return True, if database entry with specified
+                  snapshot id exists, otherwise return False
+        """
+        if not isinstance(snapshot_id, six.string_types):
+            return False
+        try:
+            uuid.UUID(snapshot_id, version=4)
+        except ValueError:
+            return False
+        ctxt = context.get_admin_context()
+        return objects.Snapshot.exists(ctxt, snapshot_id)
+
+    def _get_existing_snapshot(self, snapshot, existing_ref):
+        types = {
+            'source-name': 'name',
+            'source-guid': 'guid'
+        }
+        if not any(key in types for key in existing_ref):
+            keys = ', '.join(types.keys())
+            message = (_('Manage existing snapshot failed '
+                         'due to invalid backend reference. '
+                         'Snapshot reference must contain '
+                         'at least one valid key: %(keys)s')
+                       % {'keys': keys})
+            raise jsonrpc.NefException(code='EINVAL', message=message)
+        volume_name = snapshot['volume_name']
+        volume_size = snapshot['volume_size']
+        volume = {'name': volume_name}
+        volume_path = self._get_volume_path(volume)
+        payload = {
+            'parent': volume_path,
+            'fields': 'name,path',
+            'recursive': False
+        }
+        for key, value in types.items():
+            if key in existing_ref:
+                payload[value] = existing_ref[key]
+        existing_snapshots = self.nef.snapshots.list(payload)
+        if len(existing_snapshots) == 1:
+            name = existing_snapshots[0]['name']
+            path = existing_snapshots[0]['path']
+            existing_snapshot = {
+                'name': name,
+                'path': path,
+                'volume_name': volume_name,
+                'volume_size': volume_size
+            }
+            sid = utils.extract_id_from_snapshot_name(name)
+            if self._check_already_managed_snapshot(sid):
+                message = (_('Snapshot %(name)s already managed')
+                           % {'name': name})
+                raise jsonrpc.NefException(code='EBUSY', message=message)
+            return existing_snapshot
+        elif not existing_snapshots:
+            code = 'ENOENT'
+            reason = _('no matching snapshots were found')
+        else:
+            code = 'EINVAL'
+            reason = _('too many snapshots were found')
+        message = (_('Unable to manage existing snapshot by '
+                     'reference %(reference)s: %(reason)s')
+                   % {'reference': existing_ref, 'reason': reason})
+        raise jsonrpc.NefException(code=code, message=message)
+
+    @jsonrpc.synchronized
+    def manage_existing(self, volume, existing_ref):
+        """Brings an existing backend storage object under Cinder management.
+
+        existing_ref is passed straight through from the API request's
+        manage_existing_ref value, and it is up to the driver how this should
+        be interpreted.  It should be sufficient to identify a storage object
+        that the driver should somehow associate with the newly-created cinder
+        volume structure.
+
+        There are two ways to do this:
+
+        1. Rename the backend storage object so that it matches the,
+           volume['name'] which is how drivers traditionally map between a
+           cinder volume and the associated backend storage object.
+
+        2. Place some metadata on the volume, or somewhere in the backend, that
+           allows other driver requests (e.g. delete, clone, attach, detach...)
+           to locate the backend storage object when required.
+
+        If the existing_ref doesn't make sense, or doesn't refer to an existing
+        backend storage object, raise a ManageExistingInvalidReference
+        exception.
+
+        The volume may have a volume_type, and the driver can inspect that and
+        compare against the properties of the referenced backend storage
+        object.  If they are incompatible, raise a
+        ManageExistingVolumeTypeMismatch, specifying a reason for the failure.
+
+        :param volume:       Cinder volume to manage
+        :param existing_ref: Driver-specific information used to identify a
+                             volume
+        """
+        existing_volume = self._get_existing_volume(existing_ref)
+        existing_volume_path = existing_volume['path']
+        if existing_volume['name'] != volume['name']:
+            volume_path = self._get_volume_path(volume)
+            payload = {'newPath': volume_path}
+            self.nef.filesystems.rename(existing_volume_path, payload)
+
+    def manage_existing_get_size(self, volume, existing_ref):
+        """Return size of volume to be managed by manage_existing.
+
+        When calculating the size, round up to the next GB.
+
+        :param volume:       Cinder volume to manage
+        :param existing_ref: Driver-specific information used to identify a
+                             volume
+        :returns size:       Volume size in GiB (integer)
+        """
+        existing_volume = self._get_existing_volume(existing_ref)
+        self._set_volume_acl(existing_volume)
+        self._mount_volume(existing_volume)
+        local_path = self.local_path(existing_volume)
+        try:
+            volume_size = os.path.getsize(local_path)
+        except OSError as error:
+            code = errno.errorcode[error.errno]
+            message = (_('Manage existing volume %(name)s failed: '
+                         'unable to get size of volume data file '
+                         '%(file)s: %(error)s')
+                       % {'name': existing_volume['name'],
+                          'file': local_path,
+                          'error': error.strerror})
+            raise jsonrpc.NefException(code=code, message=message)
+        finally:
+            self._unmount_volume(existing_volume)
+        return volume_size // units.Gi
+
+    def get_manageable_volumes(self, cinder_volumes, marker, limit, offset,
+                               sort_keys, sort_dirs):
+        """List volumes on the backend available for management by Cinder.
+
+        Returns a list of dictionaries, each specifying a volume in the host,
+        with the following keys:
+        - reference (dictionary): The reference for a volume, which can be
+          passed to "manage_existing".
+        - size (int): The size of the volume according to the storage
+          backend, rounded up to the nearest GB.
+        - safe_to_manage (boolean): Whether or not this volume is safe to
+          manage according to the storage backend. For example, is the volume
+          in use or invalid for any reason.
+        - reason_not_safe (string): If safe_to_manage is False, the reason why.
+        - cinder_id (string): If already managed, provide the Cinder ID.
+        - extra_info (string): Any extra information to return to the user
+
+        :param cinder_volumes: A list of volumes in this host that Cinder
+                               currently manages, used to determine if
+                               a volume is manageable or not.
+        :param marker:    The last item of the previous page; we return the
+                          next results after this value (after sorting)
+        :param limit:     Maximum number of items to return
+        :param offset:    Number of items to skip after marker
+        :param sort_keys: List of keys to sort results by (valid keys are
+                          'identifier' and 'size')
+        :param sort_dirs: List of directions to sort by, corresponding to
+                          sort_keys (valid directions are 'asc' and 'desc')
+        """
+        manageable_volumes = []
+        cinder_volume_names = {}
+        for cinder_volume in cinder_volumes:
+            key = cinder_volume['name']
+            value = cinder_volume['id']
+            cinder_volume_names[key] = value
+        payload = {
+            'parent': self.root_path,
+            'fields': 'guid,parent,path,bytesUsed',
+            'recursive': False
+        }
+        volumes = self.nef.filesystems.list(payload)
+        for volume in volumes:
+            safe_to_manage = True
+            reason_not_safe = None
+            cinder_id = None
+            extra_info = None
+            path = volume['path']
+            guid = volume['guid']
+            parent = volume['parent']
+            size = volume['bytesUsed'] // units.Gi
+            name = posixpath.basename(path)
+            if path == self.root_path:
+                continue
+            if parent != self.root_path:
+                continue
+            if name in cinder_volume_names:
+                cinder_id = cinder_volume_names[name]
+                safe_to_manage = False
+                reason_not_safe = _('Volume already managed')
+            reference = {
+                'source-name': name,
+                'source-guid': guid
+            }
+            manageable_volumes.append({
+                'reference': reference,
+                'size': size,
+                'safe_to_manage': safe_to_manage,
+                'reason_not_safe': reason_not_safe,
+                'cinder_id': cinder_id,
+                'extra_info': extra_info
+            })
+        return utils.paginate_entries_list(manageable_volumes,
+                                           marker, limit, offset,
+                                           sort_keys, sort_dirs)
+
+    def unmanage(self, volume):
+        """Removes the specified volume from Cinder management.
+
+        Does not delete the underlying backend storage object.
+
+        For most drivers, this will not need to do anything.  However, some
+        drivers might use this call as an opportunity to clean up any
+        Cinder-specific configuration that they have associated with the
+        backend storage object.
+
+        :param volume: Cinder volume to unmanage
+        """
+        pass
+
+    @jsonrpc.synchronized
+    def manage_existing_snapshot(self, snapshot, existing_ref):
+        """Brings an existing backend storage object under Cinder management.
+
+        existing_ref is passed straight through from the API request's
+        manage_existing_ref value, and it is up to the driver how this should
+        be interpreted.  It should be sufficient to identify a storage object
+        that the driver should somehow associate with the newly-created cinder
+        snapshot structure.
+
+        There are two ways to do this:
+
+        1. Rename the backend storage object so that it matches the
+           snapshot['name'] which is how drivers traditionally map between a
+           cinder snapshot and the associated backend storage object.
+
+        2. Place some metadata on the snapshot, or somewhere in the backend,
+           that allows other driver requests (e.g. delete) to locate the
+           backend storage object when required.
+
+        If the existing_ref doesn't make sense, or doesn't refer to an existing
+        backend storage object, raise a ManageExistingInvalidReference
+        exception.
+
+        :param snapshot:     Cinder volume snapshot to manage
+        :param existing_ref: Driver-specific information used to identify a
+                             volume snapshot
+        """
+        existing_snapshot = self._get_existing_snapshot(snapshot, existing_ref)
+        existing_snapshot_path = existing_snapshot['path']
+        if existing_snapshot['name'] != snapshot['name']:
+            payload = {'newName': snapshot['name']}
+            self.nef.snapshots.rename(existing_snapshot_path, payload)
+
+    def manage_existing_snapshot_get_size(self, snapshot, existing_ref):
+        """Return size of snapshot to be managed by manage_existing.
+
+        When calculating the size, round up to the next GB.
+
+        :param snapshot:     Cinder volume snapshot to manage
+        :param existing_ref: Driver-specific information used to identify a
+                             volume snapshot
+        :returns size:       Volume snapshot size in GiB (integer)
+        """
+        existing_snapshot = self._get_existing_snapshot(snapshot, existing_ref)
+        return existing_snapshot['volume_size']
+
+    def get_manageable_snapshots(self, cinder_snapshots, marker, limit, offset,
+                                 sort_keys, sort_dirs):
+        """List snapshots on the backend available for management by Cinder.
+
+        Returns a list of dictionaries, each specifying a snapshot in the host,
+        with the following keys:
+        - reference (dictionary): The reference for a snapshot, which can be
+          passed to "manage_existing_snapshot".
+        - size (int): The size of the snapshot according to the storage
+          backend, rounded up to the nearest GB.
+        - safe_to_manage (boolean): Whether or not this snapshot is safe to
+          manage according to the storage backend. For example, is the snapshot
+          in use or invalid for any reason.
+        - reason_not_safe (string): If safe_to_manage is False, the reason why.
+        - cinder_id (string): If already managed, provide the Cinder ID.
+        - extra_info (string): Any extra information to return to the user
+        - source_reference (string): Similar to "reference", but for the
+          snapshot's source volume.
+
+        :param cinder_snapshots: A list of snapshots in this host that Cinder
+                                 currently manages, used to determine if
+                                 a snapshot is manageable or not.
+        :param marker:    The last item of the previous page; we return the
+                          next results after this value (after sorting)
+        :param limit:     Maximum number of items to return
+        :param offset:    Number of items to skip after marker
+        :param sort_keys: List of keys to sort results by (valid keys are
+                          'identifier' and 'size')
+        :param sort_dirs: List of directions to sort by, corresponding to
+                          sort_keys (valid directions are 'asc' and 'desc')
+
+        """
+        manageable_snapshots = []
+        cinder_volume_names = {}
+        cinder_snapshot_names = {}
+        ctxt = context.get_admin_context()
+        cinder_volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        for cinder_volume in cinder_volumes:
+            key = self._get_volume_path(cinder_volume)
+            value = {
+                'name': cinder_volume['name'],
+                'size': cinder_volume['size']
+            }
+            cinder_volume_names[key] = value
+        for cinder_snapshot in cinder_snapshots:
+            key = cinder_snapshot['name']
+            value = {
+                'id': cinder_snapshot['id'],
+                'size': cinder_snapshot['volume_size'],
+                'parent': cinder_snapshot['volume_name']
+            }
+            cinder_snapshot_names[key] = value
+        payload = {
+            'parent': self.root_path,
+            'fields': 'name,guid,path,parent,hprService,snaplistId',
+            'recursive': True
+        }
+        snapshots = self.nef.snapshots.list(payload)
+        for snapshot in snapshots:
+            safe_to_manage = True
+            reason_not_safe = None
+            cinder_id = None
+            extra_info = None
+            name = snapshot['name']
+            guid = snapshot['guid']
+            path = snapshot['path']
+            parent = snapshot['parent']
+            if parent not in cinder_volume_names:
+                LOG.debug('Skip snapshot %(path)s: parent '
+                          'volume %(parent)s is unmanaged',
+                          {'path': path, 'parent': parent})
+                continue
+            if name.startswith(self.origin_snapshot_template):
+                LOG.debug('Skip temporary origin snapshot %(path)s',
+                          {'path': path})
+                continue
+            if name.startswith(self.group_snapshot_template):
+                LOG.debug('Skip temporary group snapshot %(path)s',
+                          {'path': path})
+                continue
+            if snapshot['hprService'] or snapshot['snaplistId']:
+                LOG.debug('Skip HPR/snapping snapshot %(path)s',
+                          {'path': path})
+                continue
+            if name in cinder_snapshot_names:
+                size = cinder_snapshot_names[name]['size']
+                cinder_id = cinder_snapshot_names[name]['id']
+                safe_to_manage = False
+                reason_not_safe = _('Snapshot already managed')
+            else:
+                size = cinder_volume_names[parent]['size']
+                payload = {'fields': 'clones'}
+                props = self.nef.snapshots.get(path)
+                clones = props['clones']
+                unmanaged_clones = []
+                for clone in clones:
+                    if clone not in cinder_volume_names:
+                        unmanaged_clones.append(clone)
+                if unmanaged_clones:
+                    safe_to_manage = False
+                    dependent_clones = ', '.join(unmanaged_clones)
+                    reason_not_safe = (_('Snapshot has unmanaged '
+                                         'dependent clone(s) %(clones)s')
+                                       % {'clones': dependent_clones})
+            reference = {
+                'source-name': name,
+                'source-guid': guid
+            }
+            source_reference = {
+                'name': cinder_volume_names[parent]['name']
+            }
+            manageable_snapshots.append({
+                'reference': reference,
+                'size': size,
+                'safe_to_manage': safe_to_manage,
+                'reason_not_safe': reason_not_safe,
+                'cinder_id': cinder_id,
+                'extra_info': extra_info,
+                'source_reference': source_reference
+            })
+        return utils.paginate_entries_list(manageable_snapshots,
+                                           marker, limit, offset,
+                                           sort_keys, sort_dirs)
+
+    def unmanage_snapshot(self, snapshot):
+        """Removes the specified snapshot from Cinder management.
+
+        Does not delete the underlying backend storage object.
+
+        For most drivers, this will not need to do anything. However, some
+        drivers might use this call as an opportunity to clean up any
+        Cinder-specific configuration that they have associated with the
+        backend storage object.
+
+        :param snapshot: Cinder volume snapshot to unmanage
+        """
+        pass
+
+    def update_migrated_volume(self, context, volume, new_volume,
+                               original_volume_status):
+        """Return model update for migrated volume.
+
+        This method should rename the back-end volume name on the
+        destination host back to its original name on the source host.
+
+        :param context: The context of the caller
+        :param volume: The original volume that was migrated to this backend
+        :param new_volume: The migration volume object that was created on
+                           this backend as part of the migration process
+        :param original_volume_status: The status of the original volume
+        :returns: model_update to update DB with any needed changes
+        """
+        name_id = None
+        path = self._get_volume_path(volume)
+        new_path = self._get_volume_path(new_volume)
+        payload = {'newPath': path}
+        try:
+            self.nef.filesystems.rename(new_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.debug('Failed to rename volume %(new_volume)s '
+                      'to %(volume)s after migration: %(error)s',
+                      {'new_volume': new_volume['name'],
+                       'volume': volume['name'],
+                       'error': error})
+            name_id = new_volume._name_id or new_volume.id
+        model_update = {'_name_id': name_id}
+        return model_update
+
+    def retype(self, context, volume, new_type, diff, host):
+        """Retype from one volume type to another."""
+        LOG.debug('Retype volume %(volume)s to host %(host)s '
+                  'and volume type %(type)s with diff %(diff)s',
+                  {'volume': volume['name'], 'host': host['host'],
+                   'type': new_type['name'], 'diff': diff})
+        retyped = False
+        migrated, model_update = self.migrate_volume(context, volume, host)
+        volume_path = self._get_volume_path(volume)
+        payload = {'source': True}
+        volume_specs = self.nef.filesystems.get(volume_path, payload)
+        payload = {}
+        extra_specs = volume_types.get_volume_type_extra_specs(new_type['id'])
+        vendor_specs = self.nef.filesystems.properties
+        for vendor_spec in vendor_specs:
+            property_name = vendor_spec['name']
+            api = vendor_spec['api']
+            if 'retype' in vendor_spec:
+                LOG.debug('Skip retype vendor volume property '
+                          '%(property_name)s. %(reason)s',
+                          {'property_name': property_name,
+                           'reason': vendor_spec['retype']})
+                continue
+            if property_name in extra_specs:
+                extra_spec = extra_specs[property_name]
+                value = self._get_vendor_value(extra_spec, vendor_spec)
+                payload[api] = value
+            elif (api in volume_specs and 'source' in volume_specs and
+                  api in volume_specs['source'] and
+                  volume_specs['source'][api] in ['local', 'received']):
+                if 'cfg' in vendor_spec:
+                    cfg = vendor_spec['cfg']
+                    value = self.configuration.safe_get(cfg)
+                    if volume_specs[api] != value:
+                        payload[api] = value
+                else:
+                    if 'inherit' in vendor_spec:
+                        LOG.debug('Skip inherit vendor volume property '
+                                  '%(property_name)s. %(reason)s',
+                                  {'property_name': property_name,
+                                   'reason': vendor_spec['inherit']})
+                        continue
+                    payload[api] = None
+        try:
+            self.nef.filesystems.set(volume_path, payload)
+            retyped = True
+        except jsonrpc.NefException as error:
+            LOG.debug('Failed to retype volume %(volume)s: %(error)s',
+                      {'volume': volume['name'], 'error': error})
+        return retyped or migrated, model_update
+
+    def _init_vendor_properties(self):
+        """Create a dictionary of vendor unique properties.
+
+        This method creates a dictionary of vendor unique properties
+        and returns both created dictionary and vendor name.
+        Returned vendor name is used to check for name of vendor
+        unique properties.
+
+        - Vendor name shouldn't include colon(:) because of the separator
+          and it is automatically replaced by underscore(_).
+          ex. abc:d -> abc_d
+        - Vendor prefix is equal to vendor name.
+          ex. abcd
+        - Vendor unique properties must start with vendor prefix + ':'.
+          ex. abcd:maxIOPS
+
+        Each backend driver needs to override this method to expose
+        its own properties using _set_property() like this:
+
+        self._set_property(
+            properties,
+            "vendorPrefix:specific_property",
+            "Title of property",
+            _("Description of property"),
+            "type")
+
+        : return dictionary of vendor unique properties
+        : return vendor name
+        """
+        properties = {}
+        vendor_properties = []
+        namespace = self.nef.filesystems.namespace
+        keys = ('enum', 'default', 'minimum', 'maximum')
+        vendor_properties += self.nef.filesystems.properties
+        for vendor_spec in vendor_properties:
+            property_spec = {}
+            for key in keys:
+                if key in vendor_spec:
+                    property_spec[key] = vendor_spec[key]
+            property_name = vendor_spec['name']
+            property_title = vendor_spec['title']
+            property_description = vendor_spec['description']
+            property_type = vendor_spec['type']
+            LOG.debug('Set %(product_name)s %(storage_protocol)s backend '
+                      '%(property_type)s property %(property_name)s: '
+                      '%(property_spec)s',
+                      {'product_name': self.product_name,
+                       'storage_protocol': self.storage_protocol,
+                       'property_type': property_type,
+                       'property_name': property_name,
+                       'property_spec': property_spec})
+            self._set_property(
+                properties,
+                property_name,
+                property_title,
+                property_description,
+                property_type,
+                **property_spec
+            )
+        return properties, namespace
+
+    def _get_vendor_properties(self, volume, vendor_specs):
+        properties = extra_specs = {}
+        type_id = volume.get('volume_type_id', None)
+        if type_id:
+            extra_specs = volume_types.get_volume_type_extra_specs(type_id)
+        for vendor_spec in vendor_specs:
+            property_name = vendor_spec['name']
+            if property_name in extra_specs:
+                extra_spec = extra_specs[property_name]
+                value = self._get_vendor_value(extra_spec, vendor_spec)
+            elif 'cfg' in vendor_spec:
+                cfg = vendor_spec['cfg']
+                value = self.configuration.safe_get(cfg)
+            else:
+                continue
+            api = vendor_spec['api']
+            properties[api] = value
+            LOG.debug('Get vendor property name %(property_name)s '
+                      'with API name %(api)s and %(type)s value '
+                      '%(value)s for volume %(volume)s',
+                      {'property_name': property_name,
+                       'api': api,
+                       'type': type(value).__name__,
+                       'value': value,
+                       'volume': volume['name']})
+        return properties
+
+    def _get_vendor_value(self, value, vendor_spec):
+        name = vendor_spec['name']
+        code = 'EINVAL'
+        if vendor_spec['type'] == 'integer':
+            try:
+                value = int(value)
+            except ValueError:
+                message = (_('Invalid non-integer value %(value)s for '
+                             'vendor property name %(name)s')
+                           % {'value': value, 'name': name})
+                raise jsonrpc.NefException(code=code, message=message)
+            if 'minimum' in vendor_spec:
+                minimum = vendor_spec['minimum']
+                if value < minimum:
+                    message = (_('Integer value %(value)s is less than '
+                                 'allowed minimum %(minimum)s for vendor '
+                                 'property name %(name)s')
+                               % {'value': value, 'minimum': minimum,
+                                  'name': name})
+                    raise jsonrpc.NefException(code=code, message=message)
+            if 'maximum' in vendor_spec:
+                maximum = vendor_spec['maximum']
+                if value > maximum:
+                    message = (_('Integer value %(value)s is greater than '
+                                 'allowed maximum %(maximum)s for vendor '
+                                 'property name %(name)s')
+                               % {'value': value, 'maximum': maximum,
+                                  'name': name})
+                    raise jsonrpc.NefException(code=code, message=message)
+        elif vendor_spec['type'] == 'string':
+            try:
+                value = str(value)
+            except UnicodeEncodeError:
+                message = (_('Invalid non-ASCII value %(value)s for vendor '
+                             'property name %(name)s')
+                           % {'value': value, 'name': name})
+                raise jsonrpc.NefException(code=code, message=message)
+        elif vendor_spec['type'] == 'boolean':
+            words = value.split()
+            if len(words) == 2 and words[0] == '<is>':
+                value = words[1]
+            try:
+                value = strutils.bool_from_string(value, strict=True)
+            except ValueError:
+                message = (_('Invalid non-boolean value %(value)s for vendor '
+                             'property name %(name)s')
+                           % {'value': value, 'name': name})
+                raise jsonrpc.NefException(code=code, message=message)
+        if 'enum' in vendor_spec:
+            enum = vendor_spec['enum']
+            if value not in enum:
+                message = (_('Value %(value)s is out of allowed enumeration '
+                             '%(enum)s for vendor property name %(name)s')
+                           % {'value': value, 'enum': enum, 'name': name})
+                raise jsonrpc.NefException(code=code, message=message)
+        return value
+
+    def _get_host_addresses(self):
+        """Return NexentaStor IP addresses list."""
+        addresses = []
+        items = self.nef.netaddrs.list()
+        for item in items:
+            cidr = six.text_type(item['address'])
+            addr, mask = cidr.split('/')
+            obj = ipaddress.ip_address(addr)
+            if not obj.is_loopback:
+                addresses.append(obj.exploded)
+        LOG.debug('Configured IP addresses: %(addresses)s',
+                  {'addresses': addresses})
+        return addresses

--- a/cinder/volume/drivers/nexenta/options.py
+++ b/cinder/volume/drivers/nexenta/options.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Nexenta Systems, Inc.
+# Copyright 2019 Nexenta Systems, Inc.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -15,7 +15,6 @@
 
 from oslo_config import cfg
 
-POLL_RETRIES = 5
 DEFAULT_ISCSI_PORT = 3260
 DEFAULT_HOST_GROUP = 'all'
 DEFAULT_TARGET_GROUP = 'all'
@@ -58,66 +57,92 @@ NEXENTA_EDGE_OPTS = [
 ]
 
 NEXENTA_CONNECTION_OPTS = [
-    cfg.StrOpt('nexenta_rest_address',
-               default='',
-               help='IP address of NexentaEdge management REST API endpoint'),
     cfg.StrOpt('nexenta_host',
                default='',
-               help='IP address of Nexenta SA'),
+               help='IP address of NexentaStor Appliance'),
+    cfg.StrOpt('nexenta_rest_address',
+               default='',
+               help='IP address of NexentaStor management REST API endpoint'),
     cfg.IntOpt('nexenta_rest_port',
                default=0,
-               help='HTTP(S) port to connect to Nexenta REST API server. '
-                    'If it is equal zero, 8443 for HTTPS and 8080 for HTTP '
-                    'is used'),
+               help='HTTP(S) port to connect to NexentaStor management '
+                    'REST API server. If it is equal zero, 8443 for '
+                    'HTTPS and 8080 for HTTP is used'),
     cfg.StrOpt('nexenta_rest_protocol',
                default='auto',
                choices=['http', 'https', 'auto'],
-               help='Use http or https for REST connection (default auto)'),
+               help='Use http or https for NexentaStor management '
+                    'REST API connection (default auto)'),
+    cfg.FloatOpt('nexenta_rest_connect_timeout',
+                 default=30,
+                 help='Specifies the time limit (in seconds), within '
+                      'which the connection to NexentaStor management '
+                      'REST API server must be established'),
+    cfg.FloatOpt('nexenta_rest_read_timeout',
+                 default=300,
+                 help='Specifies the time limit (in seconds), '
+                      'within which NexentaStor management '
+                      'REST API server must send a response'),
+    cfg.FloatOpt('nexenta_rest_backoff_factor',
+                 default=0.5,
+                 help='Specifies the backoff factor to apply '
+                      'between connection attempts to NexentaStor '
+                      'management REST API server'),
+    cfg.IntOpt('nexenta_rest_retry_count',
+               default=3,
+               help='Specifies the number of times to repeat NexentaStor '
+                    'management REST API call in case of connection errors '
+                    'and NexentaStor appliance EBUSY or ENOENT errors'),
     cfg.BoolOpt('nexenta_use_https',
                 default=True,
-                help='Use secure HTTP for REST connection (default True)'),
+                help='Use HTTP secure protocol for NexentaStor '
+                     'management REST API connections'),
     cfg.BoolOpt('nexenta_lu_writebackcache_disabled',
                 default=False,
                 help='Postponed write to backing store or not'),
     cfg.StrOpt('nexenta_user',
                default='admin',
-               help='User name to connect to Nexenta SA'),
+               help='User name to connect to NexentaStor '
+                    'management REST API server'),
     cfg.StrOpt('nexenta_password',
                default='nexenta',
-               help='Password to connect to Nexenta SA',
-               secret=True),
+               help='Password to connect to NexentaStor '
+                    'management REST API server',
+               secret=True)
 ]
 
 NEXENTA_ISCSI_OPTS = [
-    cfg.StrOpt('nexenta_iscsi_target_portal_groups',
-               default='',
-               help='Nexenta target portal groups'),
+    cfg.ListOpt('nexenta_iscsi_target_portal_groups',
+                default=[],
+                help='List of comma-separated NexentaStor4 iSCSI target '
+                     'portal groups'),
     cfg.StrOpt('nexenta_iscsi_target_portals',
                default='',
                help='Comma separated list of portals for NexentaStor5, in'
                     'format of IP1:port1,IP2:port2. Port is optional, '
                     'default=3260. Example: 10.10.10.1:3267,10.10.1.2'),
     cfg.StrOpt('nexenta_iscsi_target_host_group',
+               deprecated_for_removal=True,
                default='all',
                help='Group of hosts which are allowed to access volumes'),
     cfg.IntOpt('nexenta_iscsi_target_portal_port',
                default=3260,
-               help='Nexenta target portal port'),
+               help='NexentaStor iSCSI target portal port'),
     cfg.IntOpt('nexenta_luns_per_target',
                default=100,
-               help='Amount of iSCSI LUNs per each target'),
+               help='Limit of LUNs per iSCSI target'),
     cfg.StrOpt('nexenta_volume',
                default='cinder',
-               help='SA Pool that holds all volumes'),
+               help='NexentaStor pool name that holds all volumes'),
     cfg.StrOpt('nexenta_target_prefix',
-               default='iqn.1986-03.com.sun:02:cinder',
-               help='IQN prefix for iSCSI targets'),
+               default='iqn.2005-07.com.nexenta:01:cinder',
+               help='iqn prefix for NexentaStor iSCSI targets'),
     cfg.StrOpt('nexenta_target_group_prefix',
                default='cinder',
-               help='Prefix for iSCSI target groups on SA'),
+               help='Prefix for iSCSI target groups on NexentaStor'),
     cfg.StrOpt('nexenta_host_group_prefix',
                default='cinder',
-               help='Prefix for iSCSI host groups on SA'),
+               help='Prefix for iSCSI host groups on NexentaStor'),
     cfg.StrOpt('nexenta_volume_group',
                default='iscsi',
                help='Volume group for NexentaStor5 iSCSI'),
@@ -145,13 +170,13 @@ NEXENTA_NFS_OPTS = [
                 help='Create volumes as QCOW2 files rather than raw files'),
     cfg.BoolOpt('nexenta_nms_cache_volroot',
                 default=True,
-                help=('If set True cache NexentaStor appliance volroot option '
-                      'value.'))
+                help='If set True cache NexentaStor appliance volroot option '
+                     'value.')
 ]
 
 NEXENTA_DATASET_OPTS = [
     cfg.StrOpt('nexenta_dataset_compression',
-               default='on',
+               default='lz4',
                choices=['on', 'off', 'gzip', 'gzip-1', 'gzip-2', 'gzip-3',
                         'gzip-4', 'gzip-5', 'gzip-6', 'gzip-7', 'gzip-8',
                         'gzip-9', 'lzjb', 'zle', 'lz4'],
@@ -167,7 +192,7 @@ NEXENTA_DATASET_OPTS = [
                default='',
                help='Human-readable description for the folder.'),
     cfg.IntOpt('nexenta_blocksize',
-               default=4096,
+               default=32768,
                help='Block size for datasets'),
     cfg.IntOpt('nexenta_ns5_blocksize',
                default=32,
@@ -175,6 +200,22 @@ NEXENTA_DATASET_OPTS = [
     cfg.BoolOpt('nexenta_sparse',
                 default=False,
                 help='Enables or disables the creation of sparse datasets'),
+    cfg.IntOpt('nexenta_migration_throttle',
+               min=1,
+               max=2047,
+               help='Throttle migration throughput in MegaBytes per second'),
+    cfg.StrOpt('nexenta_migration_service_prefix',
+               default='cinder-migration',
+               help='Prefix for migration service name'),
+    cfg.StrOpt('nexenta_migration_snapshot_prefix',
+               default='migration-snapshot',
+               help='Prefix for migration snapshot name'),
+    cfg.StrOpt('nexenta_origin_snapshot_template',
+               default='origin-snapshot-%s',
+               help='Template string to generate origin name of clone'),
+    cfg.StrOpt('nexenta_group_snapshot_template',
+               default='group-snapshot-%s',
+               help='Template string to generate group snapshot name')
 ]
 
 NEXENTA_RRMGR_OPTS = [


### PR DESCRIPTION
    NEX-20582 Volume Attach fails - STMF_ERROR_INVALID_TG
    NEX-18892 Sync Cinder driver from Newton to another Openstack branches
    NEX-20387 Our provided openstack driver does not deal gracefully with a slow pool

**Pep8**
```
pep8 run-test-pre: PYTHONHASHSEED='0'
pep8 run-test: commands[0] | flake8 . cinder/common
pep8 run-test: commands[1] | bash -c 'find cinder -type f -regex '"'"'.*\.pot?'"'"' -print0|xargs -0 -n 1 msgfmt --check-format -o /dev/null'
pep8 run-test: commands[2] | /opt/stack/cinder/tools/config/check_uptodate.sh
/opt/stack/cinder/.tox/pep8/local/lib/python2.7/site-packages/setuptools/dist.py:45: DistDeprecationWarning: Do not call this function
  warnings.warn("Do not call this function", DistDeprecationWarning)
pep8 run-test: commands[3] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder
___________________________________ summary ____________________________________
  pep8: commands succeeded
  congratulations :)
```

**Tempest for NexentaStor4 NFS**
```
======
Totals
======
Ran: 296 tests in 1383.0000 sec.
 - Passed: 289
 - Skipped: 7
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 1015.2493 sec.
```

**Tempest for NexentaStor5 NFS**
```
======
Totals
======
Ran: 296 tests in 1921.0000 sec.
 - Passed: 289
 - Skipped: 7
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 1391.3497 sec.
```

**Tempest for NexentaStor4 iSCSI**
```
======
Totals
======
Ran: 296 tests in 1345.0000 sec.
 - Passed: 289
 - Skipped: 7
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 1056.5960 sec.
```

**Tempest for NexentaStor5 iSCSI**
```
======
Totals
======
Ran: 296 tests in 1971.0000 sec.
 - Passed: 289
 - Skipped: 7
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 1484.7020 sec.
```