### PR TITLE
NEX-20829 Workaround for NEX-18013

### DIFF
--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -77,9 +77,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 Added support for volume type extra specs.
                 Added vendor capabilities support.
         1.4.5 - Added report discard support.
+        1.4.6 - Added workaround for pagination.
     """
 
-    VERSION = '1.4.5'
+    VERSION = '1.4.6'
     CI_WIKI_NAME = "Nexenta_CI"
 
     vendor_name = 'Nexenta'
@@ -1740,8 +1741,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 value = self._get_vendor_value(extra_spec, vendor_spec)
                 payload[api] = value
             elif (api in volume_specs and 'source' in volume_specs and
-                    api in volume_specs['source'] and
-                    volume_specs['source'][api] in ['local', 'received']):
+                  api in volume_specs['source'] and
+                  volume_specs['source'][api] in ['local', 'received']):
                 if 'cfg' in vendor_spec:
                     cfg = vendor_spec['cfg']
                     value = self.configuration.safe_get(cfg)

--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -89,9 +89,10 @@ class NexentaNfsDriver(nfs.NfsDriver):
                 Added vendor capabilities support.
         1.8.5 - Fixed NFS protocol version for generic volume migration.
         1.8.6 - Fixed post-migration volume mount.
+        1.8.7 - Added workaround for pagination.
     """
 
-    VERSION = '1.8.6'
+    VERSION = '1.8.7'
     CI_WIKI_NAME = "Nexenta_CI"
 
     vendor_name = 'Nexenta'


### PR DESCRIPTION
**NEX-20829 Workaround for NEX-18013**

**Pep8**
```
pep8 start: run-test-pre 
pep8 run-test-pre: PYTHONHASHSEED='2911183928'
pep8 finish: run-test-pre  after 0.00 seconds
pep8 start: run-test 
pep8 run-test: commands[0] | flake8 .
setting PATH=/opt/stack/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[71651] /opt/stack/cinder$ /opt/stack/cinder/.tox/pep8/bin/flake8 .
pep8 run-test: commands[1] | /opt/stack/cinder/tools/config/check_uptodate.sh
setting PATH=/opt/stack/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[71701] /opt/stack/cinder$ /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 run-test: commands[2] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder /opt/stack/cinder/doc/source/ /opt/stack/cinder/releasenotes/notes
setting PATH=/opt/stack/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[71724] /opt/stack/cinder$ /opt/stack/cinder/tools/check_exec.py cinder doc/source releasenotes/notes
pep8 finish: run-test  after 163.29 seconds
pep8 start: run-test-post 
pep8 finish: run-test-post  after 0.00 seconds
_______________________________________________________________________________ summary ________________________________________________________________________________
  pep8: commands succeeded
  congratulations :)
```

**Unit tests for py27**
```
======
Totals
======
Ran: 207 tests in 2.0000 sec.
 - Passed: 207
 - Skipped: 0
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 9.8546 sec.
```

**Unit tests for py36**
```
======
Totals
======
Ran: 207 tests in 2.4800 sec.
 - Passed: 207
 - Skipped: 0
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 8.3102 sec.
```

**Tempest NFS**
```
======
Totals
======
Ran: 262 tests in 3139.0000 sec.
 - Passed: 256
 - Skipped: 6
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2354.9302 sec.
```