### PR TITLE
NEX-20345, NEX-21462, NEX-21461, NEX-21463, NEX-21546, NEX-21547, NEX-21555, NEX-21593, NEX-21594 and NEX-21596

### DIFF
--- a/cinder/volume/drivers/nexenta/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/jsonrpc.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -27,6 +26,13 @@ from cinder import exception
 from cinder.i18n import _
 
 LOG = logging.getLogger(__name__)
+
+DEFAULT_REST_PORT = 8457
+HTTPS = 'https'
+HTTP = 'http'
+AUTO = 'auto'
+NFS = 'nfs'
+ISCSI = 'iscsi'
 
 
 class NmsException(exception.VolumeDriverException):
@@ -269,14 +275,14 @@ class NmsProxy(object):
         self.lock = 'nms'
         self.auto = False
         self.scheme = conf.nexenta_rest_protocol
-        if self.scheme == 'auto':
+        if self.scheme == AUTO:
             self.auto = True
-            self.scheme = 'http'
+            self.scheme = HTTP
         if conf.nexenta_rest_address:
             self.host = conf.nexenta_rest_address
-        elif conf.nexenta_host:
+        elif proto == ISCSI and conf.nexenta_host:
             self.host = conf.nexenta_host
-        elif proto == 'nfs' and conf.nas_host:
+        elif proto == NFS and conf.nas_host:
             self.host = conf.nas_host
         else:
             message = (_('NexentaStor Rest API address is not defined, '
@@ -287,7 +293,7 @@ class NmsProxy(object):
         if conf.nexenta_rest_port:
             self.port = conf.nexenta_rest_port
         else:
-            self.port = 8457
+            self.port = DEFAULT_REST_PORT
         self.headers = {
             'Content-Type': 'application/json',
             'X-Requested-With': 'XMLHttpRequest'

--- a/cinder/volume/drivers/nexenta/nexentaedge/iscsi.py
+++ b/cinder/volume/drivers/nexenta/nexentaedge/iscsi.py
@@ -1,5 +1,4 @@
-# Copyright 2015 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -24,7 +23,6 @@ from cinder.volume import driver
 from cinder.volume.drivers.nexenta.nexentaedge import jsonrpc
 from cinder.volume.drivers.nexenta import options
 from cinder.volume.drivers.nexenta import utils as nexenta_utils
-
 
 LOG = logging.getLogger(__name__)
 
@@ -51,13 +49,7 @@ class NexentaEdgeISCSIDriver(driver.ISCSIDriver):
         super(NexentaEdgeISCSIDriver, self).__init__(*args, **kwargs)
         if self.configuration:
             self.configuration.append_config_values(
-                options.NEXENTA_CONNECTION_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_ISCSI_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_DATASET_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_EDGE_OPTS)
+                options.NEXENTAEDGE_ISCSI_OPTS)
         if self.configuration.nexenta_rest_address:
             self.restapi_host = self.configuration.nexenta_rest_address
         else:
@@ -94,6 +86,10 @@ class NexentaEdgeISCSIDriver(driver.ISCSIDriver):
         self.iscsi_target_port = (self.configuration.
                                   nexenta_iscsi_target_portal_port)
         self.ha_vip = None
+
+    @staticmethod
+    def get_driver_options():
+        return options.NEXENTAEDGE_ISCSI_OPTS
 
     @property
     def backend_name(self):

--- a/cinder/volume/drivers/nexenta/nexentaedge/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/nexentaedge/jsonrpc.py
@@ -1,5 +1,4 @@
-# Copyright 2015 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain

--- a/cinder/volume/drivers/nexenta/nexentaedge/nbd.py
+++ b/cinder/volume/drivers/nexenta/nexentaedge/nbd.py
@@ -1,5 +1,4 @@
-# Copyright 2016 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain

--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -31,10 +30,15 @@ from cinder import objects
 from cinder.volume import driver
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 from cinder.volume.drivers.nexenta import options
-from cinder.volume import utils
+from cinder.volume.drivers.nexenta import utils as nexenta_utils
+from cinder.volume import utils as volume_utils
 from cinder.volume import volume_types
 
 LOG = logging.getLogger(__name__)
+
+DEFAULT_ISCSI_PORT = 3260
+DEFAULT_HOST_GROUP = 'all'
+DEFAULT_TARGET_GROUP = 'all'
 
 
 @interface.volumedriver
@@ -81,9 +85,13 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         1.4.7 - Improved error messages.
               - Improved compatibility with initial driver versions.
               - Added throttle for storage assisted volume migration.
+        1.4.8 - Fixed renaming volume after generic migration.
+              - Fixed properties for volumes created from snapshot.
+              - Added workaround for referenced reservation size.
+              - Allow retype volume to another provisioning type.
     """
 
-    VERSION = '1.4.7'
+    VERSION = '1.4.8'
     CI_WIKI_NAME = "Nexenta_CI"
 
     vendor_name = 'Nexenta'
@@ -100,13 +108,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                           'storage_protocol': self.storage_protocol})
             raise jsonrpc.NefException(code='ENODATA', message=message)
         self.configuration.append_config_values(
-            options.NEXENTA_CONNECTION_OPTS)
-        self.configuration.append_config_values(
-            options.NEXENTA_ISCSI_OPTS)
-        self.configuration.append_config_values(
-            options.NEXENTA_DATASET_OPTS)
-        self.nef = None
+            options.NEXENTASTOR5_ISCSI_OPTS)
         self.driver_name = self.__class__.__name__
+        self.nef = None
+        self.san_stat = None
         self.target_prefix = self.configuration.nexenta_target_prefix
         self.target_group_prefix = (
             self.configuration.nexenta_target_group_prefix)
@@ -114,14 +119,12 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         self.luns_per_target = self.configuration.nexenta_luns_per_target
         self.lu_writebackcache_disabled = (
             self.configuration.nexenta_lu_writebackcache_disabled)
-        self.iscsi_host = self.configuration.nexenta_host
-        self.pool = self.configuration.nexenta_volume
-        self.volume_group = self.configuration.nexenta_volume_group
-        self.portal_port = self.configuration.nexenta_iscsi_target_portal_port
+        self.san_host = self.configuration.nexenta_host
+        self.san_port = self.configuration.nexenta_iscsi_target_portal_port
+        self.san_path = posixpath.join(
+            self.configuration.nexenta_volume,
+            self.configuration.nexenta_volume_group)
         self.portals = self.configuration.nexenta_iscsi_target_portals
-        self.iscsi_target_portal_port = (
-            self.configuration.nexenta_iscsi_target_portal_port)
-        self.root_path = posixpath.join(self.pool, self.volume_group)
         self.group_snapshot_template = (
             self.configuration.nexenta_group_snapshot_template)
         self.origin_snapshot_template = (
@@ -133,37 +136,165 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
 
     @staticmethod
     def get_driver_options():
-        return (
-            options.NEXENTA_CONNECTION_OPTS +
-            options.NEXENTA_ISCSI_OPTS +
-            options.NEXENTA_DATASET_OPTS
-        )
+        return options.NEXENTASTOR5_ISCSI_OPTS
 
-    def do_setup(self, context):
+    def do_setup(self, ctxt):
         self.nef = jsonrpc.NefProxy(self.driver_volume_type,
-                                    self.root_path,
+                                    self.san_path,
                                     self.configuration)
 
     def check_for_setup_error(self):
         """Check root volume group and iSCSI target service."""
+        vendor_specs = self.nef.volumes.properties
+        names = [_['api'] for _ in vendor_specs if 'api' in _]
+        names.remove('sparseVolume')
+        fields = ','.join(names)
+        stat_payload = {'fields': fields}
         try:
-            self.nef.volumegroups.get(self.root_path)
+            self.san_stat = self.nef.volumegroups.get(self.san_path,
+                                                      stat_payload)
         except jsonrpc.NefException as error:
             if error.code != 'ENOENT':
                 raise
-            block_size = self.configuration.nexenta_ns5_blocksize
-            if block_size < 512:
-                block_size *= units.Ki
-            payload = {
-                'path': self.root_path,
+            block_size = self.configuration.nexenta_blocksize
+            create_payload = {
+                'path': self.san_path,
                 'volumeBlockSize': block_size
             }
-            self.nef.volumegroups.create(payload)
+            self.nef.volumegroups.create(create_payload)
+            self.san_stat = self.nef.volumegroups.get(self.san_path,
+                                                      stat_payload)
         service = self.nef.services.get('iscsit')
         if service['state'] != 'online':
             message = (_('iSCSI target service is not online: %(state)s')
                        % {'state': service['state']})
             raise jsonrpc.NefException(code='ESRCH', message=message)
+
+    def _get_volume_reservation(self, volume):
+        """Calculates the correct reservation size for given volume size.
+
+        Its purpose is to reserve additional space for volume metadata
+        so volume don't unexpectedly run out of room. This function is
+        a copy of the volsize_to_reservation function in libzfs_dataset.c
+
+        :param volume: volume reference
+        :returns: reservation size
+        """
+        volume_path = self._get_volume_path(volume)
+        payload = {'fields': 'volumeBlockSize,volumeSize,dataCopies'}
+        volume_specs = self.nef.volumes.get(volume_path, payload)
+        block_size = volume_specs['volumeBlockSize']
+        volume_size = volume_specs['volumeSize']
+        data_copies = volume_specs['dataCopies']
+        reservation = volume_size
+        numdb = 7
+        dn_max_indblkshift = 17
+        spa_blkptrshift = 7
+        spa_dvas_per_bp = 3
+        dnodes_per_level_shift = dn_max_indblkshift - spa_blkptrshift
+        dnodes_per_level = 1 << dnodes_per_level_shift
+        nblocks = reservation // block_size
+        while nblocks > 1:
+            nblocks += dnodes_per_level - 1
+            nblocks //= dnodes_per_level
+            numdb += nblocks
+        numdb *= min(spa_dvas_per_bp, data_copies + 1)
+        reservation *= data_copies
+        numdb *= 1 << dn_max_indblkshift
+        reservation += numdb
+        volume_meta = reservation - volume_size
+        LOG.debug('Reservation size for raw volume %(volume)s: '
+                  '%(reservation)s, volume data size: %(volume_size)s '
+                  'and volume metadata size: %(volume_meta)s',
+                  {'volume': volume['name'], 'reservation': reservation,
+                   'volume_size': volume_size, 'volume_meta': volume_meta})
+        return reservation
+
+    def _set_volume_reservation(self, volume, reservation=None):
+        if reservation is None:
+            reservation = self._get_volume_reservation(volume)
+        volume_path = self._get_volume_path(volume)
+        payload = {'fields': 'referencedReservationSize,volumeSize'}
+        volume_specs = self.nef.volumes.get(volume_path, payload)
+        volume_reservation = volume_specs['referencedReservationSize']
+        volume_size = volume_specs['volumeSize']
+        if volume_reservation == reservation:
+            return
+        if not reservation:
+            payload = {'referencedReservationSize': reservation}
+            try:
+                self.nef.volumes.set(volume_path, payload)
+            except jsonrpc.NefException as error:
+                LOG.error('Failed to reset volume reservation size from '
+                          '%(volume_reservation)s to %(reservation)s '
+                          'for volume %(volume)s: %(error)s',
+                          {'volume_reservation': volume_reservation,
+                           'reservation': reservation,
+                           'volume': volume['name'],
+                           'error': error})
+                raise
+            return
+        # Workaround for NEX-21586
+        connectors = self._get_volume_connectors(volume)
+        if connectors:
+            code = 'EINVAL'
+            message = (_('Volume provisioning type cannot be changed '
+                         'for attached volume %(volume)s, volume '
+                         'connectors are: %(connectors)s')
+                       % {'volume': volume['name'],
+                          'connectors': connectors})
+            raise jsonrpc.NefException(code=code, message=message)
+        temporay_size = nexenta_utils.roundup(reservation, units.Gi)
+        payload = {'volumeSize': temporay_size}
+        try:
+            self.nef.volumes.set(volume_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to temporarily change volume size from '
+                      '%(volume_size)s to %(temporay_size)s for volume '
+                      '%(volume)s: %(error)s',
+                      {'volume_size': volume_size,
+                       'temporay_size': temporay_size,
+                       'volume': volume['name'],
+                       'error': error})
+            raise
+        payload = {'referencedReservationSize': reservation}
+        try:
+            self.nef.volumes.set(volume_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to change volume reservation size from '
+                      '%(volume_reservation)s to %(reservation)s '
+                      'for volume %(volume)s: %(error)s',
+                      {'volume_reservation': volume_reservation,
+                       'reservation': reservation,
+                       'volume': volume['name'],
+                       'error': error})
+            raise
+        payload = {'volumeSize': volume_size}
+        try:
+            self.nef.volumes.set(volume_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to restore original volume size from '
+                      '%(temporay_size)s to %(volume_size)s for volume '
+                      '%(volume)s: %(error)s',
+                      {'temporay_size': temporay_size,
+                       'volume_size': volume_size,
+                       'volume': volume['name'],
+                       'error': error})
+            raise
+
+    def _update_volume_properties(self, volume):
+        """Updates the existing volume properties.
+
+        :param volume: volume reference
+        """
+        if not volume['volume_type_id']:
+            return
+        ctxt = context.get_admin_context()
+        volume_type_id = volume['volume_type_id']
+        volume_type = volume_types.get_volume_type(ctxt, volume_type_id)
+        diff = {}
+        host = volume['host']
+        self.retype(ctxt, volume, volume_type, diff, host)
 
     @coordination.synchronized('{self.nef.lock}')
     def create_volume(self, volume):
@@ -175,7 +306,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         volume_path = self._get_volume_path(volume)
         volume_size = volume['size'] * units.Gi
         properties = self.nef.volumes.properties
-        payload = self._get_vendor_properties(volume, properties)
+        payload = self._get_vendor_properties(properties, volume)
         payload.update({
             'path': volume_path,
             'volumeSize': volume_size
@@ -215,8 +346,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param new_size: volume new size in GB
         """
         volume_path = self._get_volume_path(volume)
-        payload = {'volumeSize': new_size * units.Gi}
+        volume_size = new_size * units.Gi
+        payload = {'volumeSize': volume_size}
         self.nef.volumes.set(volume_path, payload)
+        self._set_volume_reservation(volume)
 
     @coordination.synchronized('{self.nef.lock}')
     def create_snapshot(self, snapshot):
@@ -245,7 +378,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         # actually helpful.
         return False
 
-    def revert_to_snapshot(self, context, volume, snapshot):
+    def revert_to_snapshot(self, ctxt, volume, snapshot):
         """Revert volume to snapshot."""
         volume_path = self._get_volume_path(volume)
         payload = {'snapshot': snapshot['name']}
@@ -258,12 +391,16 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: reference of volume to be created
         :param snapshot: reference of source snapshot
         """
+        LOG.debug('Create volume %(volume)s from snapshot %(snapshot)s',
+                  {'volume': volume['name'], 'snapshot': snapshot['name']})
+        volume_path = self._get_volume_path(volume)
         snapshot_path = self._get_snapshot_path(snapshot)
-        clone_path = self._get_volume_path(volume)
-        payload = {'targetPath': clone_path}
-        self.nef.snapshots.clone(snapshot_path, payload)
+        payload = {'targetPath': volume_path}
         if volume['size'] > snapshot['volume_size']:
-            self.extend_volume(volume, volume['size'])
+            volume_size = volume['size'] * units.Gi
+            payload['volumeSize'] = volume_size
+        self.nef.snapshots.clone(snapshot_path, payload)
+        self._update_volume_properties(volume)
 
     def create_cloned_volume(self, volume, src_vref):
         """Creates a clone of the specified volume.
@@ -297,15 +434,15 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                            'snapshot': snapshot['name'],
                            'error': error})
 
-    def create_export(self, context, volume, connector):
+    def create_export(self, ctxt, volume, connector):
         """Driver entry point to get the export info for a new volume."""
         pass
 
-    def ensure_export(self, context, volume):
+    def ensure_export(self, ctxt, volume):
         """Driver entry point to get the export info for an existing volume."""
         pass
 
-    def remove_export(self, context, volume):
+    def remove_export(self, ctxt, volume):
         """Driver entry point to remove an export for a volume."""
         pass
 
@@ -321,15 +458,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         host_groups = []
         volume_path = self._get_volume_path(volume)
         if isinstance(connector, dict) and 'initiator' in connector:
-            connectors = []
-            if 'volume_attachment' in volume:
-                if isinstance(volume['volume_attachment'], list):
-                    for attachment in volume['volume_attachment']:
-                        if not isinstance(attachment, dict):
-                            continue
-                        if 'connector' not in attachment:
-                            continue
-                        connectors.append(attachment['connector'])
+            connectors = self._get_volume_connectors(volume)
             if connectors.count(connector) > 1:
                 LOG.info('Detected %(count)s connections from host '
                          '%(host_name)s (IP:%(host_ip)s) to volume '
@@ -340,7 +469,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                           'volume': volume['name']})
                 return True
             host_iqn = connector['initiator']
-            host_groups.append(options.DEFAULT_HOST_GROUP)
+            host_groups.append(DEFAULT_HOST_GROUP)
             host_group = self._get_host_group(host_iqn)
             if host_group is not None:
                 host_groups.append(host_group)
@@ -382,22 +511,25 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         """
         if refresh or not self._stats:
             self._update_volume_stats()
-
         return self._stats
 
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor appliance."""
         payload = {'fields': 'bytesAvailable,bytesUsed'}
-        dataset = self.nef.volumegroups.get(self.root_path, payload)
+        dataset = self.nef.volumegroups.get(self.san_path, payload)
         free_capacity_gb = dataset['bytesAvailable'] // units.Gi
         allocated_capacity_gb = dataset['bytesUsed'] // units.Gi
         total_capacity_gb = free_capacity_gb + allocated_capacity_gb
-        provisioned_capacity_gb = total_volumes = 0
+        provisioned_capacity_gb = total_volumes = total_snapshots = 0
         ctxt = context.get_admin_context()
         volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
         for volume in volumes:
             provisioned_capacity_gb += volume['size']
             total_volumes += 1
+        snapshots = objects.SnapshotList.get_by_host(ctxt, self.host)
+        for snapshot in snapshots:
+            provisioned_capacity_gb += snapshot['volume_size']
+            total_snapshots += 1
         volume_backend_name = (
             self.configuration.safe_get('volume_backend_name'))
         if not volume_backend_name:
@@ -409,11 +541,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         description = (
             self.configuration.safe_get('nexenta_dataset_description'))
         if not description:
-            description = '%(product)s %(host)s:%(pool)s/%(group)s' % {
+            description = '%(product)s %(host)s:%(path)s' % {
                 'product': self.product_name,
-                'host': self.configuration.nexenta_host,
-                'pool': self.configuration.nexenta_volume,
-                'group': self.configuration.nexenta_volume_group
+                'host': self.san_host,
+                'path': self.san_path
             }
         max_over_subscription_ratio = (
             self.configuration.safe_get('max_over_subscription_ratio'))
@@ -421,11 +552,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             self.configuration.safe_get('reserved_percentage'))
         if reserved_percentage is None:
             reserved_percentage = 0
-        location_info = '%(driver)s:%(host)s:%(pool)s/%(group)s' % {
+        location_info = '%(driver)s:%(host)s:%(path)s' % {
             'driver': self.driver_name,
-            'host': self.configuration.nexenta_host,
-            'pool': self.configuration.nexenta_volume,
-            'group': self.configuration.nexenta_volume_group
+            'host': self.san_host,
+            'path': self.san_path
         }
         display_name = 'Capabilities of %(product)s %(protocol)s driver' % {
             'product': self.product_name,
@@ -454,6 +584,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             'free_capacity_gb': free_capacity_gb,
             'provisioned_capacity_gb': provisioned_capacity_gb,
             'total_volumes': total_volumes,
+            'total_snapshots': total_snapshots,
             'max_over_subscription_ratio': max_over_subscription_ratio,
             'reserved_percentage': reserved_percentage,
             'visibility': visibility,
@@ -468,16 +599,36 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                    'volume_backend_name': volume_backend_name,
                    'stats': self._stats})
 
+    def _get_volume_connectors(self, volume):
+        """Return list of the volume connectors."""
+        connectors = []
+        if 'volume_attachment' not in volume:
+            return connectors
+        volume_attachments = volume['volume_attachment']
+        if not isinstance(volume_attachments, list):
+            return connectors
+        for volume_attachment in volume_attachments:
+            if not isinstance(volume_attachment, dict):
+                continue
+            if 'connector' not in volume_attachment:
+                continue
+            connector = volume_attachment['connector']
+            connectors.append(connector)
+        return connectors
+
     def _get_volume_path(self, volume):
         """Return ZFS datset path for the volume."""
-        return posixpath.join(self.root_path, volume['name'])
+        volume_name = volume['name']
+        volume_path = posixpath.join(self.san_path, volume_name)
+        return volume_path
 
     def _get_snapshot_path(self, snapshot):
         """Return ZFS snapshot path for the snapshot."""
         volume_name = snapshot['volume_name']
         snapshot_name = snapshot['name']
-        volume_path = posixpath.join(self.root_path, volume_name)
-        return '%s@%s' % (volume_path, snapshot_name)
+        volume_path = posixpath.join(self.san_path, volume_name)
+        snapshot_path = '%s@%s' % (volume_path, snapshot_name)
+        return snapshot_path
 
     def _get_target_group_name(self, target_name):
         """Return Nexenta iSCSI target group name for volume."""
@@ -494,38 +645,37 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         )
 
     def _get_host_addresses(self):
-        """Return Nexenta IP addresses list."""
-        host_addresses = []
-        items = self.nef.netaddrs.list()
-        for item in items:
-            ip_cidr = six.text_type(item['address'])
-            ip_addr, ip_mask = ip_cidr.split('/')
-            ip_obj = ipaddress.ip_address(ip_addr)
-            if not ip_obj.is_loopback:
-                host_addresses.append(ip_obj.exploded)
+        """Returns NexentaStor IP addresses list."""
+        addresses = []
+        netaddrs = self.nef.netaddrs.list()
+        for netaddr in netaddrs:
+            cidr = six.text_type(netaddr['address'])
+            ip = cidr.split('/')[0]
+            instance = ipaddress.ip_address(ip)
+            if not instance.is_loopback:
+                addresses.append(instance.exploded)
         LOG.debug('Configured IP addresses: %(addresses)s',
-                  {'addresses': host_addresses})
-        return host_addresses
+                  {'addresses': addresses})
+        return addresses
 
     def _get_host_portals(self):
         """Return configured iSCSI portals list."""
         host_portals = []
         host_addresses = self._get_host_addresses()
-        portal_host = self.iscsi_host
-        if portal_host:
-            if portal_host in host_addresses:
-                if self.portal_port:
-                    portal_port = int(self.portal_port)
+        if self.san_host:
+            if self.san_host in host_addresses:
+                if self.san_port:
+                    san_port = self.san_port
                 else:
-                    portal_port = options.DEFAULT_ISCSI_PORT
-                host_portal = '%s:%s' % (portal_host, portal_port)
+                    san_port = DEFAULT_ISCSI_PORT
+                host_portal = '%s:%s' % (self.san_host, san_port)
                 host_portals.append(host_portal)
             else:
-                LOG.debug('Skip not a local portal IP address %(portal)s',
-                          {'portal': portal_host})
+                LOG.debug('Skip not a local IP address %(san_host)s',
+                          {'san_host': self.san_host})
         else:
             LOG.debug('Configuration parameter nexenta_host is not defined')
-        for portal in self.portals.split(','):
+        for portal in self.portals:
             if not portal:
                 continue
             host_port = portal.split(':')
@@ -534,7 +684,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 if len(host_port) == 2:
                     portal_port = int(host_port[1])
                 else:
-                    portal_port = options.DEFAULT_ISCSI_PORT
+                    portal_port = DEFAULT_ISCSI_PORT
                 host_portal = '%s:%s' % (portal_host, portal_port)
                 if host_portal not in host_portals:
                     host_portals.append(host_portal)
@@ -611,7 +761,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                   'and initiator: %(initiator)s',
                   {'volume': volume_path, 'initiator': host_iqn})
 
-        host_groups = [options.DEFAULT_HOST_GROUP]
+        host_groups = [DEFAULT_HOST_GROUP]
         host_group = self._get_host_group(host_iqn)
         if host_group:
             host_groups.append(host_group)
@@ -627,7 +777,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             mapping_lu = mapping['lun']
             mapping_hg = mapping['hostGroup']
             mapping_tg = mapping['targetGroup']
-            if mapping_tg == options.DEFAULT_TARGET_GROUP:
+            if mapping_tg == DEFAULT_TARGET_GROUP:
                 LOG.debug('Delete LUN mapping %(id)s for target group %(tg)s',
                           {'id': mapping_id, 'tg': mapping_tg})
                 self._delete_lun_mapping(mapping_id)
@@ -758,7 +908,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         logicalunits = self.nef.logicalunits.list(payload)
         guid = logicalunits[0]['guid']
         properties = self.nef.logicalunits.properties
-        payload = self._get_vendor_properties(volume, properties)
+        payload = self._get_vendor_properties(properties, volume)
         self.nef.logicalunits.set(guid, payload)
 
         LOG.debug('Created new LUN mapping: %(props)s',
@@ -851,29 +1001,29 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             result.append('%s:%s' % (key_val['address'], key_val['port']))
         return result
 
-    def create_consistencygroup(self, context, group):
+    def create_consistencygroup(self, ctxt, group):
         """Creates a consistency group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the dictionary of the consistency group to be created.
         :returns: group_model_update
         """
         group_model_update = {}
         return group_model_update
 
-    def create_group(self, context, group):
+    def create_group(self, ctxt, group):
         """Creates a group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the group object.
         :returns: model_update
         """
-        return self.create_consistencygroup(context, group)
+        return self.create_consistencygroup(ctxt, group)
 
-    def delete_consistencygroup(self, context, group, volumes):
+    def delete_consistencygroup(self, ctxt, group, volumes):
         """Deletes a consistency group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the dictionary of the consistency group to be deleted.
         :param volumes: a list of volume dictionaries in the group.
         :returns: group_model_update, volumes_model_update
@@ -884,21 +1034,21 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             self.delete_volume(volume)
         return group_model_update, volumes_model_update
 
-    def delete_group(self, context, group, volumes):
+    def delete_group(self, ctxt, group, volumes):
         """Deletes a group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the group object.
         :param volumes: a list of volume objects in the group.
         :returns: model_update, volumes_model_update
         """
-        return self.delete_consistencygroup(context, group, volumes)
+        return self.delete_consistencygroup(ctxt, group, volumes)
 
-    def update_consistencygroup(self, context, group, add_volumes=None,
+    def update_consistencygroup(self, ctxt, group, add_volumes=None,
                                 remove_volumes=None):
         """Updates a consistency group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the dictionary of the consistency group to be updated.
         :param add_volumes: a list of volume dictionaries to be added.
         :param remove_volumes: a list of volume dictionaries to be removed.
@@ -909,23 +1059,23 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         remove_volumes_update = []
         return group_model_update, add_volumes_update, remove_volumes_update
 
-    def update_group(self, context, group,
+    def update_group(self, ctxt, group,
                      add_volumes=None, remove_volumes=None):
         """Updates a group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the group object.
         :param add_volumes: a list of volume objects to be added.
         :param remove_volumes: a list of volume objects to be removed.
         :returns: model_update, add_volumes_update, remove_volumes_update
         """
-        return self.update_consistencygroup(context, group, add_volumes,
+        return self.update_consistencygroup(ctxt, group, add_volumes,
                                             remove_volumes)
 
-    def create_cgsnapshot(self, context, cgsnapshot, snapshots):
+    def create_cgsnapshot(self, ctxt, cgsnapshot, snapshots):
         """Creates a consistency group snapshot.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param cgsnapshot: the dictionary of the cgsnapshot to be created.
         :param snapshots: a list of snapshot dictionaries in the cgsnapshot.
         :returns: group_model_update, snapshots_model_update
@@ -933,12 +1083,12 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         group_model_update = {}
         snapshots_model_update = []
         cgsnapshot_name = self.group_snapshot_template % cgsnapshot['id']
-        cgsnapshot_path = '%s@%s' % (self.root_path, cgsnapshot_name)
+        cgsnapshot_path = '%s@%s' % (self.san_path, cgsnapshot_name)
         create_payload = {'path': cgsnapshot_path, 'recursive': True}
         self.nef.snapshots.create(create_payload)
         for snapshot in snapshots:
             volume_name = snapshot['volume_name']
-            volume_path = posixpath.join(self.root_path, volume_name)
+            volume_path = posixpath.join(self.san_path, volume_name)
             snapshot_name = snapshot['name']
             snapshot_path = '%s@%s' % (volume_path, cgsnapshot_name)
             rename_payload = {'newName': snapshot_name}
@@ -947,20 +1097,20 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         self.nef.snapshots.delete(cgsnapshot_path, delete_payload)
         return group_model_update, snapshots_model_update
 
-    def create_group_snapshot(self, context, group_snapshot, snapshots):
+    def create_group_snapshot(self, ctxt, group_snapshot, snapshots):
         """Creates a group_snapshot.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group_snapshot: the GroupSnapshot object to be created.
         :param snapshots: a list of Snapshot objects in the group_snapshot.
         :returns: model_update, snapshots_model_update
         """
-        return self.create_cgsnapshot(context, group_snapshot, snapshots)
+        return self.create_cgsnapshot(ctxt, group_snapshot, snapshots)
 
-    def delete_cgsnapshot(self, context, cgsnapshot, snapshots):
+    def delete_cgsnapshot(self, ctxt, cgsnapshot, snapshots):
         """Deletes a consistency group snapshot.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param cgsnapshot: the dictionary of the cgsnapshot to be created.
         :param snapshots: a list of snapshot dictionaries in the cgsnapshot.
         :returns: group_model_update, snapshots_model_update
@@ -971,22 +1121,22 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             self.delete_snapshot(snapshot)
         return group_model_update, snapshots_model_update
 
-    def delete_group_snapshot(self, context, group_snapshot, snapshots):
+    def delete_group_snapshot(self, ctxt, group_snapshot, snapshots):
         """Deletes a group_snapshot.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group_snapshot: the GroupSnapshot object to be deleted.
         :param snapshots: a list of snapshot objects in the group_snapshot.
         :returns: model_update, snapshots_model_update
         """
-        return self.delete_cgsnapshot(context, group_snapshot, snapshots)
+        return self.delete_cgsnapshot(ctxt, group_snapshot, snapshots)
 
-    def create_consistencygroup_from_src(self, context, group, volumes,
+    def create_consistencygroup_from_src(self, ctxt, group, volumes,
                                          cgsnapshot=None, snapshots=None,
                                          source_cg=None, source_vols=None):
         """Creates a consistency group from source.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the dictionary of the consistency group to be created.
         :param volumes: a list of volume dictionaries in the group.
         :param cgsnapshot: the dictionary of the cgsnapshot as source.
@@ -1002,7 +1152,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 self.create_volume_from_snapshot(volume, snapshot)
         elif source_cg and source_vols:
             snapshot_name = self.origin_snapshot_template % group['id']
-            snapshot_path = '%s@%s' % (self.root_path, snapshot_name)
+            snapshot_path = '%s@%s' % (self.san_path, snapshot_name)
             create_payload = {'path': snapshot_path, 'recursive': True}
             self.nef.snapshots.create(create_payload)
             for volume, source_vol in zip(volumes, source_vols):
@@ -1017,12 +1167,12 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             self.nef.snapshots.delete(snapshot_path, delete_payload)
         return group_model_update, volumes_model_update
 
-    def create_group_from_src(self, context, group, volumes,
+    def create_group_from_src(self, ctxt, group, volumes,
                               group_snapshot=None, snapshots=None,
                               source_group=None, source_vols=None):
         """Creates a group from source.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the Group object to be created.
         :param volumes: a list of Volume objects in the group.
         :param group_snapshot: the GroupSnapshot object as source.
@@ -1031,7 +1181,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param source_vols: a list of volume objects in the source_group.
         :returns: model_update, volumes_model_update
         """
-        return self.create_consistencygroup_from_src(context, group, volumes,
+        return self.create_consistencygroup_from_src(ctxt, group, volumes,
                                                      group_snapshot, snapshots,
                                                      source_group, source_vols)
 
@@ -1049,7 +1199,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                        % {'keys': keys})
             raise jsonrpc.NefException(code='EINVAL', message=message)
         payload = {
-            'parent': self.root_path,
+            'parent': self.san_path,
             'fields': 'name,path,volumeSize'
         }
         for key, value in types.items():
@@ -1065,8 +1215,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 'path': volume_path,
                 'size': volume_size
             }
-            vid = utils.extract_id_from_volume_name(volume_name)
-            if utils.check_already_managed_volume(vid):
+            vid = volume_utils.extract_id_from_volume_name(volume_name)
+            if volume_utils.check_already_managed_volume(vid):
                 message = (_('Volume %(name)s already managed')
                            % {'name': volume_name})
                 raise jsonrpc.NefException(code='EBUSY', message=message)
@@ -1133,7 +1283,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 'volume_name': volume_name,
                 'volume_size': volume_size
             }
-            sid = utils.extract_id_from_snapshot_name(name)
+            sid = volume_utils.extract_id_from_snapshot_name(name)
             if self._check_already_managed_snapshot(sid):
                 message = (_('Snapshot %(name)s already managed')
                            % {'name': name})
@@ -1197,6 +1347,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             volume_path = self._get_volume_path(volume)
             payload = {'newPath': volume_path}
             self.nef.volumes.rename(existing_volume_path, payload)
+        self._update_volume_properties(volume)
 
     def manage_existing_get_size(self, volume, existing_ref):
         """Return size of volume to be managed by manage_existing.
@@ -1247,7 +1398,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             value = cinder_volume['id']
             cinder_volume_names[key] = value
         payload = {
-            'parent': self.root_path,
+            'parent': self.san_path,
             'fields': 'name,guid,path,volumeSize',
             'recursive': False
         }
@@ -1274,7 +1425,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 members = []
                 for mapping in mappings:
                     hostgroup = mapping['hostGroup']
-                    if hostgroup == options.DEFAULT_HOST_GROUP:
+                    if hostgroup == DEFAULT_HOST_GROUP:
                         members.append(hostgroup)
                     else:
                         group = self.nef.hostgroups.get(hostgroup)
@@ -1297,9 +1448,9 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 'cinder_id': cinder_id,
                 'extra_info': extra_info
             })
-        return utils.paginate_entries_list(manageable_volumes,
-                                           marker, limit, offset,
-                                           sort_keys, sort_dirs)
+        return volume_utils.paginate_entries_list(manageable_volumes,
+                                                  marker, limit, offset,
+                                                  sort_keys, sort_dirs)
 
     def unmanage(self, volume):
         """Removes the specified volume from Cinder management.
@@ -1415,7 +1566,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             }
             cinder_snapshot_names[key] = value
         payload = {
-            'parent': self.root_path,
+            'parent': self.san_path,
             'fields': 'name,guid,path,parent,hprService,snaplistId',
             'recursive': True
         }
@@ -1482,9 +1633,9 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 'extra_info': extra_info,
                 'source_reference': source_reference
             })
-        return utils.paginate_entries_list(manageable_snapshots,
-                                           marker, limit, offset,
-                                           sort_keys, sort_dirs)
+        return volume_utils.paginate_entries_list(manageable_snapshots,
+                                                  marker, limit, offset,
+                                                  sort_keys, sort_dirs)
 
     def unmanage_snapshot(self, snapshot):
         """Removes the specified snapshot from Cinder management.
@@ -1632,13 +1783,13 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                        'error': error})
         return True
 
-    def migrate_volume(self, context, volume, host):
+    def migrate_volume(self, ctxt, volume, host):
         """Migrate the volume to the specified host.
 
         Returns a boolean indicating whether the migration occurred,
         as well as model_update.
 
-        :param context: Security context
+        :param ctxt: Security context
         :param volume: A dictionary describing the volume to migrate
         :param host: A dictionary describing the host to migrate to, where
                      host['host'] is its name, and host['capabilities'] is a
@@ -1675,22 +1826,23 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             return false_ret
         location = capabilities['location_info']
         try:
-            driver, san_host, san_path = location.split(':')
+            driver_name, san_host, san_path = location.split(':')
         except ValueError as error:
             LOG.error('Failed to parse location info %(location)s '
                       'for the destination host %(host)s: %(error)s',
                       {'location': location, 'host': host['host'],
                        'error': error})
             return false_ret
-        if not (driver and san_host and san_path):
+        if not (driver_name and san_host and san_path):
             LOG.error('Incomplete location info %(location)s '
                       'found for the destination host %(host)s',
                       {'location': location, 'host': host['host']})
             return false_ret
-        if driver != self.driver_name:
-            LOG.error('Unsupported storage driver %(driver)s '
+        if driver_name != self.driver_name:
+            LOG.error('Unsupported storage driver %(driver_name)s '
                       'found for the destination host %(host)s',
-                      {'driver': driver, 'host': host['host']})
+                      {'driver_name': driver_name,
+                       'host': host['host']})
             return false_ret
         storage_protocol = capabilities['storage_protocol']
         if storage_protocol != self.storage_protocol:
@@ -1750,24 +1902,20 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             return (True, None)
         return false_ret
 
-    def update_migrated_volume(self, context, volume, new_volume,
+    def update_migrated_volume(self, ctxt, volume, new_volume,
                                original_volume_status):
         """Return model update for migrated volume.
 
         This method should rename the back-end volume name on the
         destination host back to its original name on the source host.
 
-        :param context: The context of the caller
+        :param ctxt: The context of the caller
         :param volume: The original volume that was migrated to this backend
         :param new_volume: The migration volume object that was created on
                            this backend as part of the migration process
         :param original_volume_status: The status of the original volume
         :returns: model_update to update DB with any needed changes
         """
-        name_id = None
-        path = self._get_volume_path(volume)
-        new_path = self._get_volume_path(new_volume)
-        payload = {'newPath': path}
         try:
             self.terminate_connection(new_volume, None)
         except jsonrpc.NefException as error:
@@ -1776,68 +1924,125 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                       'renaming: %(error)s',
                       {'volume': new_volume['name'],
                        'error': error})
+            raise
+        volume_renamed = False
+        volume_path = self._get_volume_path(volume)
+        new_volume_path = self._get_volume_path(new_volume)
+        bak_volume_path = '%s-backup' % volume_path
+        if volume['host'] == new_volume['host']:
+            volume['_name_id'] = new_volume['id']
+            payload = {'newPath': bak_volume_path}
+            try:
+                self.nef.volumes.rename(volume_path, payload)
+            except jsonrpc.NefException as error:
+                LOG.error('Failed to create backup copy of original '
+                          'volume %(volume)s: %(error)s',
+                          {'volume': volume['name'],
+                           'error': error})
+                if error.code != 'ENOENT':
+                    raise error
+            else:
+                volume_renamed = True
+        payload = {'newPath': volume_path}
         try:
-            self.nef.volumes.rename(new_path, payload)
-        except jsonrpc.NefException as error:
-            LOG.error('Failed to rename volume %(new_volume)s '
-                      'to %(volume)s after migration: %(error)s',
+            self.nef.volumes.rename(new_volume_path, payload)
+        except jsonrpc.NefException as rename_error:
+            LOG.error('Failed to rename temporary volume %(new_volume)s '
+                      'to original %(volume)s after migration: %(error)s',
                       {'new_volume': new_volume['name'],
                        'volume': volume['name'],
-                       'error': error})
-            name_id = new_volume._name_id or new_volume.id
-        model_update = {'_name_id': name_id}
-        return model_update
+                       'error': rename_error})
+            if volume_renamed:
+                payload = {'newPath': volume_path}
+                try:
+                    self.nef.volumes.rename(bak_volume_path, payload)
+                except jsonrpc.NefException as restore_error:
+                    LOG.error('Failed to restore backup copy of original '
+                              'volume %(volume)s: %(error)s',
+                              {'volume': volume['name'],
+                               'error': restore_error})
+            raise rename_error
+        if volume_renamed:
+            payload = {'newPath': new_volume_path}
+            try:
+                self.nef.volumes.rename(bak_volume_path, payload)
+            except jsonrpc.NefException as error:
+                LOG.error('Failed to rename backup copy of original '
+                          'volume %(volume)s to temporary volume '
+                          '%(new_volume)s: %(error)s',
+                          {'volume': volume['name'],
+                           'new_volume': new_volume['name'],
+                           'error': error})
+        return {'_name_id': None, 'provider_location': None}
 
-    def retype(self, context, volume, new_type, diff, host):
+    def retype(self, ctxt, volume, new_type, diff, host):
         """Retype from one volume type to another."""
         LOG.debug('Retype volume %(volume)s to host %(host)s '
                   'and volume type %(type)s with diff %(diff)s',
-                  {'volume': volume['name'], 'host': host['host'],
+                  {'volume': volume['name'], 'host': host,
                    'type': new_type['name'], 'diff': diff})
-        retyped = False
-        migrated, model_update = self.migrate_volume(context, volume, host)
         volume_path = self._get_volume_path(volume)
-        payload = {'source': True}
-        volume_specs = self.nef.volumes.get(volume_path, payload)
-        payload = {}
-        extra_specs = volume_types.get_volume_type_extra_specs(new_type['id'])
         vendor_specs = self.nef.volumes.properties
+        names = [_['api'] for _ in vendor_specs if 'api' in _]
+        names.append('source')
+        fields = ','.join(names)
+        payload = {'fields': fields, 'source': True}
+        volume_specs = self.nef.volumes.get(volume_path, payload)
+        volume_type_specs = self._get_vendor_properties(vendor_specs,
+                                                        volume,
+                                                        new_type)
+        sparse_volume = volume_type_specs['sparseVolume']
+        payload = {}
         for vendor_spec in vendor_specs:
-            property_name = vendor_spec['name']
             api = vendor_spec['api']
-            if 'retype' in vendor_spec:
-                LOG.debug('Skip retype vendor volume property '
-                          '%(property_name)s. %(reason)s',
-                          {'property_name': property_name,
-                           'reason': vendor_spec['retype']})
-                continue
-            if property_name in extra_specs:
-                extra_spec = extra_specs[property_name]
-                value = self._get_vendor_value(extra_spec, vendor_spec)
+            if api in volume_type_specs:
+                value = volume_type_specs[api]
+                if api in volume_specs:
+                    if volume_specs[api] == value:
+                        continue
+                if 'retype' in vendor_spec:
+                    code = 'EINVAL'
+                    message = (_('Failed to retype volume %(volume)s '
+                                 'to host %(host)s and volume type '
+                                 '%(type)s. %(reason)s')
+                               % {'volume': volume['name'],
+                                  'host': host,
+                                  'type': new_type['name'],
+                                  'reason': vendor_spec['retype']})
+                    raise jsonrpc.NefException(code=code, message=message)
                 payload[api] = value
             elif (api in volume_specs and 'source' in volume_specs and
                   api in volume_specs['source'] and
                   volume_specs['source'][api] in ['local', 'received']):
-                if 'cfg' in vendor_spec:
-                    cfg = vendor_spec['cfg']
-                    value = self.configuration.safe_get(cfg)
-                    if volume_specs[api] != value:
-                        payload[api] = value
-                else:
-                    if 'inherit' in vendor_spec:
-                        LOG.debug('Skip inherit vendor volume property '
-                                  '%(property_name)s. %(reason)s',
-                                  {'property_name': property_name,
-                                   'reason': vendor_spec['inherit']})
-                        continue
-                    payload[api] = None
+                if volume_specs[api] == vendor_spec['default']:
+                    continue
+                if 'inherit' in vendor_spec:
+                    LOG.debug('Unable to inherit property %(name)s '
+                              'from volume type %(type)s for volume '
+                              '%(volume)s. %(reason)s',
+                              {'name': api,
+                               'type': new_type['name'],
+                               'volume': volume['name'],
+                               'reason': vendor_spec['inherit']})
+                    continue
+                payload[api] = None
+        if 'sparseVolume' in payload:
+            sparse_volume = payload.pop('sparseVolume')
         try:
             self.nef.volumes.set(volume_path, payload)
-            retyped = True
         except jsonrpc.NefException as error:
-            LOG.error('Failed to retype volume %(volume)s: %(error)s',
-                      {'volume': volume['name'], 'error': error})
-        return retyped or migrated, model_update
+            LOG.error('Failed to retype volume %(volume)s to '
+                      'host %(host)s and volume type %(type)s '
+                      'with payload %(payload)s: %(error)s',
+                      {'volume': volume['name'],
+                       'host': host,
+                       'type': new_type['name'],
+                       'payload': payload,
+                       'error': error})
+            raise
+        reservation = 0 if sparse_volume else None
+        self._set_volume_reservation(volume, reservation)
+        return True, None
 
     def _init_vendor_properties(self):
         """Create a dictionary of vendor unique properties.
@@ -1871,14 +2076,24 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         properties = {}
         vendor_properties = []
         namespace = self.nef.volumes.namespace
-        keys = ('enum', 'default', 'minimum', 'maximum')
+        keys = ['enum', 'default', 'minimum', 'maximum']
         vendor_properties += self.nef.volumes.properties
         vendor_properties += self.nef.logicalunits.properties
         for vendor_spec in vendor_properties:
             property_spec = {}
             for key in keys:
                 if key in vendor_spec:
-                    property_spec[key] = vendor_spec[key]
+                    value = vendor_spec[key]
+                    property_spec[key] = value
+            api = vendor_spec['api']
+            if 'cfg' in vendor_spec:
+                key = vendor_spec['cfg']
+                value = self.configuration.safe_get(key)
+                if value not in [None, '']:
+                    property_spec['default'] = value
+            elif api in self.san_stat:
+                value = self.san_stat[api]
+                property_spec['default'] = value
             property_name = vendor_spec['name']
             property_title = vendor_spec['title']
             property_description = vendor_spec['description']
@@ -1901,29 +2116,36 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             )
         return properties, namespace
 
-    def _get_vendor_properties(self, volume, vendor_specs):
-        properties = extra_specs = {}
-        type_id = volume.get('volume_type_id', None)
-        if type_id:
-            extra_specs = volume_types.get_volume_type_extra_specs(type_id)
+    def _get_vendor_properties(self, vendor_specs, volume, volume_type=None):
+        properties = {}
+        extra_specs = {}
+        if volume_type:
+            volume_type_id = volume_type['id']
+        else:
+            volume_type_id = volume['volume_type_id']
+        if volume_type_id:
+            extra_specs = volume_types.get_volume_type_extra_specs(
+                volume_type_id)
         for vendor_spec in vendor_specs:
-            property_name = vendor_spec['name']
-            if property_name in extra_specs:
-                extra_spec = extra_specs[property_name]
+            api = vendor_spec['api']
+            name = vendor_spec['name']
+            if name in extra_specs:
+                extra_spec = extra_specs[name]
                 value = self._get_vendor_value(extra_spec, vendor_spec)
             elif 'cfg' in vendor_spec:
-                cfg = vendor_spec['cfg']
-                value = self.configuration.safe_get(cfg)
+                key = vendor_spec['cfg']
+                value = self.configuration.safe_get(key)
+                if value in [None, '']:
+                    continue
+            elif volume_type and api in self.san_stat:
+                value = self.san_stat[api]
             else:
                 continue
-            api = vendor_spec['api']
-            if api == 'volumeBlockSize' and value < 512:
-                value *= units.Ki
             properties[api] = value
-            LOG.debug('Get vendor property name %(property_name)s '
-                      'with API name %(api)s and %(type)s value '
+            LOG.debug('Get vendor property name %(name)s with '
+                      'API name %(api)s and %(type)s value '
                       '%(value)s for volume %(volume)s',
-                      {'property_name': property_name,
+                      {'name': name,
                        'api': api,
                        'type': type(value).__name__,
                        'value': value,

--- a/cinder/volume/drivers/nexenta/options.py
+++ b/cinder/volume/drivers/nexenta/options.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -17,15 +16,120 @@ from oslo_config import cfg
 
 from cinder.volume import configuration as conf
 
-DEFAULT_ISCSI_PORT = 3260
-DEFAULT_HOST_GROUP = 'all'
-DEFAULT_TARGET_GROUP = 'all'
+NEXENTASTOR_CONNECTION_OPTS = [
+    cfg.BoolOpt('nexenta_use_https',
+                deprecated_for_removal=True,
+                deprecated_reason='NexentaStor RESTful API interface '
+                                  'protocol should now be set using the '
+                                  'common parameter nexenta_rest_protocol.',
+                help='Use HTTP secure protocol for NexentaStor '
+                     'management REST API connections.'),
+    cfg.StrOpt('nexenta_rest_protocol',
+               default='auto',
+               choices=['http', 'https', 'auto'],
+               help='NexentaStor RESTful API interface protocol.'),
+    cfg.IntOpt('nexenta_rest_port',
+               deprecated_for_removal=True,
+               deprecated_reason='Rest address should now be set using '
+                                 'the common param san_api_port.',
+               default=0,
+               help='NexentaStor RESTful API interface port. If it is '
+                    'equal zero, 8443 for HTTPS and 8080 for HTTP will '
+                    'be used for NexentaStor5 and 8457 for NexentaStor4.'),
+    cfg.StrOpt('nexenta_user',
+               deprecated_for_removal=True,
+               deprecated_reason='Common user parameters should be used '
+                                 'depending on the driver type: '
+                                 'san_login or nas_login',
+               default='admin',
+               help='User name to connect to NexentaStor RESTful API '
+                    'interface.'),
+    cfg.StrOpt('nexenta_password',
+               deprecated_for_removal=True,
+               deprecated_reason='Common password parameters should be '
+                                 'used depending on the driver type: '
+                                 'san_password or nas_password.',
+               default='nexenta',
+               help='User password to connect to NexentaStor RESTful API '
+                    'interface.',
+               secret=True),
+    cfg.StrOpt('nexenta_rest_address',
+               deprecated_for_removal=True,
+               deprecated_reason='Rest address should now be set using '
+                                 'the common param depending on driver '
+                                 'type, san_ip or nas_host.',
+               default='',
+               help='IP address of NexentaStor RESTful API interface.'),
+    cfg.FloatOpt('nexenta_rest_connect_timeout',
+                 default=30,
+                 help='Specifies the time limit (in seconds), within '
+                      'which the connection to NexentaStor RESTful '
+                      'API interface must be established.'),
+    cfg.FloatOpt('nexenta_rest_read_timeout',
+                 default=300,
+                 help='Specifies the time limit (in seconds), '
+                      'within which NexentaStor RESTful API '
+                      'interface must send a response.'),
+    cfg.FloatOpt('nexenta_rest_backoff_factor',
+                 default=0.5,
+                 help='Specifies the backoff factor to apply between '
+                      'connection attempts to NexentaStor RESTful '
+                      'API interface.'),
+    cfg.IntOpt('nexenta_rest_retry_count',
+               default=3,
+               help='Specifies the number of times to repeat NexentaStor '
+                    'RESTful API calls in case of connection errors '
+                    'or NexentaStor appliance retryable errors.')
+]
 
-NEXENTA_EDGE_OPTS = [
+NEXENTASTOR_ISCSI_OPTS = [
+    cfg.StrOpt('nexenta_host',
+               default='',
+               help='IP address of NexentaStor iSCSI target.'),
+    cfg.StrOpt('nexenta_volume',
+               default='cinder',
+               help='NexentaStor pool name that holds all volumes.'),
+    cfg.IntOpt('nexenta_iscsi_target_portal_port',
+               default=3260,
+               help='NexentaStor default iSCSI target portal port.'),
+    cfg.StrOpt('nexenta_target_prefix',
+               default='iqn.2005-07.com.nexenta:01:cinder',
+               help='Prefix for NexentaStor iSCSI targets.'),
+    cfg.StrOpt('nexenta_target_group_prefix',
+               default='cinder',
+               help='Prefix for iSCSI target groups on NexentaStor.'),
+    cfg.StrOpt('nexenta_host_group_prefix',
+               default='cinder',
+               help='Prefix for iSCSI host groups on NexentaStor.'),
+    cfg.BoolOpt('nexenta_lu_writebackcache_disabled',
+                default=False,
+                help='iSCSI LUNs write-back cache disable behavior: '
+                     'postponed write to backing store is disabled or no.'),
+    cfg.IntOpt('nexenta_luns_per_target',
+               default=100,
+               help='Limit of LUNs per iSCSI target.'),
+    cfg.StrOpt('nexenta_iscsi_target_host_group',
+               deprecated_for_removal=True,
+               deprecated_reason='NexentaStor cinder driver has been '
+                                 'refactored and host groups are created '
+                                 'dynamically. So the configuration '
+                                 'parameter nexenta_iscsi_target_host_group '
+                                 'is no longer used.',
+               default='all',
+               help='Group of hosts which are allowed to access volumes.'),
+    cfg.BoolOpt('nexenta_sparse',
+                deprecated_for_removal=True,
+                deprecated_reason='Common provisioning parameter should '
+                                  'be used: nexenta_sparsed_volumes.',
+                default=False,
+                help='Enables or disables the creation of sparse datasets.')
+]
+
+NEXENTAEDGE_ISCSI_OPTS = [
     cfg.StrOpt('nexenta_nbd_symlinks_dir',
                default='/dev/disk/by-path',
                help='NexentaEdge logical path of directory to store symbolic '
-                    'links to NBDs'),
+                    'links to NBDs.'),
     cfg.StrOpt('nexenta_rest_user',
                default='admin',
                help='User name to connect to NexentaEdge.'),
@@ -35,10 +139,10 @@ NEXENTA_EDGE_OPTS = [
                secret=True),
     cfg.StrOpt('nexenta_lun_container',
                default='',
-               help='NexentaEdge logical path of bucket for LUNs'),
+               help='NexentaEdge logical path of bucket for LUNs.'),
     cfg.StrOpt('nexenta_iscsi_service',
                default='',
-               help='NexentaEdge iSCSI service name'),
+               help='NexentaEdge iSCSI service name.'),
     cfg.StrOpt('nexenta_client_address',
                deprecated_for_removal=True,
                deprecated_reason='iSCSI target address should now be set using'
@@ -48,10 +152,10 @@ NEXENTA_EDGE_OPTS = [
                'address for non-VIP service'),
     cfg.IntOpt('nexenta_iops_limit',
                default=0,
-               help='NexentaEdge iSCSI LUN object IOPS limit'),
+               help='NexentaEdge iSCSI LUN object IOPS limit.'),
     cfg.IntOpt('nexenta_chunksize',
                default=32768,
-               help='NexentaEdge iSCSI LUN object chunk size'),
+               help='NexentaEdge iSCSI LUN object chunk size.'),
     cfg.IntOpt('nexenta_replication_count',
                default=3,
                help='NexentaEdge iSCSI LUN object replication count.'),
@@ -61,201 +165,187 @@ NEXENTA_EDGE_OPTS = [
                      'has encryption enabled.')
 ]
 
-NEXENTA_CONNECTION_OPTS = [
-    cfg.StrOpt('nexenta_host',
+NEXENTASTOR4_ISCSI_OPTS = [
+    cfg.StrOpt('nexenta_folder',
                default='',
-               help='IP address of NexentaStor Appliance'),
-    cfg.StrOpt('nexenta_rest_address',
-               deprecated_for_removal=True,
-               deprecated_reason='Rest address should now be set using '
-                                 'the common param depending on driver type, '
-                                 'san_ip or nas_host',
-               default='',
-               help='IP address of NexentaStor management REST API endpoint'),
-    cfg.IntOpt('nexenta_rest_port',
-               deprecated_for_removal=True,
-               deprecated_reason='Rest address should now be set using '
-                                 'the common param san_api_port.',
-               default=0,
-               help='HTTP(S) port to connect to NexentaStor management '
-                    'REST API server. If it is equal zero, 8443 for '
-                    'HTTPS and 8080 for HTTP is used'),
-    cfg.StrOpt('nexenta_rest_protocol',
-               default='auto',
-               choices=['http', 'https', 'auto'],
-               help='Use http or https for NexentaStor management '
-                    'REST API connection (default auto)'),
-    cfg.FloatOpt('nexenta_rest_connect_timeout',
-                 default=30,
-                 help='Specifies the time limit (in seconds), within '
-                      'which the connection to NexentaStor management '
-                      'REST API server must be established'),
-    cfg.FloatOpt('nexenta_rest_read_timeout',
-                 default=300,
-                 help='Specifies the time limit (in seconds), '
-                      'within which NexentaStor management '
-                      'REST API server must send a response'),
-    cfg.FloatOpt('nexenta_rest_backoff_factor',
-                 default=0.5,
-                 help='Specifies the backoff factor to apply '
-                      'between connection attempts to NexentaStor '
-                      'management REST API server'),
-    cfg.IntOpt('nexenta_rest_retry_count',
-               default=3,
-               help='Specifies the number of times to repeat NexentaStor '
-                    'management REST API call in case of connection errors '
-                    'and NexentaStor appliance EBUSY or ENOENT errors'),
-    cfg.BoolOpt('nexenta_use_https',
-                default=True,
-                help='Use HTTP secure protocol for NexentaStor '
-                     'management REST API connections'),
-    cfg.BoolOpt('nexenta_lu_writebackcache_disabled',
-                default=False,
-                help='Postponed write to backing store or not'),
-    cfg.StrOpt('nexenta_user',
-               deprecated_for_removal=True,
-               deprecated_reason='Common user parameters should be used '
-                                 'depending on the driver type: '
-                                 'san_login or nas_login',
-               default='admin',
-               help='User name to connect to NexentaStor '
-                    'management REST API server'),
-    cfg.StrOpt('nexenta_password',
-               deprecated_for_removal=True,
-               deprecated_reason='Common password parameters should be used '
-                                 'depending on the driver type: '
-                                 'san_password or nas_password',
-               default='nexenta',
-               help='Password to connect to NexentaStor '
-                    'management REST API server',
-               secret=True)
-]
-
-NEXENTA_ISCSI_OPTS = [
+               help='NexentaStor folder name that holds all volumes.'),
     cfg.ListOpt('nexenta_iscsi_target_portal_groups',
                 default=[],
                 help='List of comma-separated NexentaStor4 iSCSI target '
-                     'portal groups'),
-    cfg.StrOpt('nexenta_iscsi_target_portals',
-               default='',
-               help='Comma separated list of portals for NexentaStor5, in'
-                    'format of IP1:port1,IP2:port2. Port is optional, '
-                    'default=3260. Example: 10.10.10.1:3267,10.10.1.2'),
-    cfg.StrOpt('nexenta_iscsi_target_host_group',
-               deprecated_for_removal=True,
-               deprecated_reason='NexentaStor cinder driver has been '
-                                 'refactored and host groups are created '
-                                 'dynamically. So the configuration '
-                                 'parameter nexenta_iscsi_target_host_group '
-                                 'is no longer used.',
-               default='all',
-               help='Group of hosts which are allowed to access volumes'),
-    cfg.IntOpt('nexenta_iscsi_target_portal_port',
-               default=3260,
-               help='NexentaStor iSCSI target portal port'),
-    cfg.IntOpt('nexenta_luns_per_target',
-               default=100,
-               help='Limit of LUNs per iSCSI target'),
-    cfg.StrOpt('nexenta_volume',
-               default='cinder',
-               help='NexentaStor pool name that holds all volumes'),
-    cfg.StrOpt('nexenta_target_prefix',
-               default='iqn.2005-07.com.nexenta:01:cinder',
-               help='iqn prefix for NexentaStor iSCSI targets'),
-    cfg.StrOpt('nexenta_target_group_prefix',
-               default='cinder',
-               help='Prefix for iSCSI target groups on NexentaStor'),
-    cfg.StrOpt('nexenta_host_group_prefix',
-               default='cinder',
-               help='Prefix for iSCSI host groups on NexentaStor'),
+                     'portal groups.')
+]
+
+NEXENTASTOR5_ISCSI_OPTS = [
     cfg.StrOpt('nexenta_volume_group',
                default='iscsi',
-               help='Volume group for NexentaStor5 iSCSI'),
+               help='NexentaStor volume group name that holds all volumes.'),
+    cfg.ListOpt('nexenta_iscsi_target_portals',
+                default='',
+                help='Comma separated list of portals for NexentaStor, in '
+                     'format of IP:port,IP:port. Port number is optional, '
+                     'default value is 3260.'),
+    cfg.IntOpt('nexenta_ns5_blocksize',
+               deprecated_for_removal=True,
+               deprecated_reason='Common block size parameter should be '
+                                 'used: nexenta_blocksize.',
+               default=32,
+               help='Block size for datasets.')
 ]
 
 NEXENTA_NFS_OPTS = [
+    cfg.StrOpt('nexenta_volume_format',
+               default='raw',
+               choices=['raw', 'qcow', 'qcow2', 'parallels',
+                        'vdi', 'vhdx', 'vmdk', 'vpc', 'qed'],
+               help='Volume image file format.'),
+    cfg.BoolOpt('nexenta_nbmand',
+                default=False,
+                help='Allow or disallow non-blocking mandatory locking '
+                     'semantics for a volume.'),
+    cfg.BoolOpt('nexenta_smart_compression',
+                default=False,
+                help='Allow or disallow dynamically tracks per-volume '
+                     'compression ratios to determine if a volume data '
+                     'is compressible or not.'),
+    cfg.BoolOpt('nexenta_qcow2_volumes',
+                deprecated_for_removal=True,
+                deprecated_reason='Volume format parameter should '
+                                  'be used: nexenta_volume_format.',
+                default=False,
+                help='Create volumes as QCOW2 files rather than raw files.'),
     cfg.StrOpt('nexenta_shares_config',
+               deprecated_for_removal=True,
+               deprecated_reason='NexentaStor cinder driver has been '
+                                 'refactored and the configuration '
+                                 'parameter nexenta_shares_config '
+                                 'is no longer used.',
                default='/etc/cinder/nfs_shares',
-               help='File with the list of available nfs shares'),
+               help='File with the list of available nfs shares.'),
     cfg.StrOpt('nexenta_mount_point_base',
                default='$state_path/mnt',
-               help='Base directory that contains NFS share mount points'),
-    cfg.BoolOpt('nexenta_sparsed_volumes',
-                default=True,
-                help='Enables or disables the creation of volumes as '
-                     'sparsed files that take no space. If disabled '
-                     '(False), volume is created as a regular file, '
-                     'which takes a long time.'),
-    cfg.BoolOpt('nexenta_qcow2_volumes',
-                default=False,
-                help='Create volumes as QCOW2 files rather than raw files'),
+               help='Base directory that contains NFS share mount points.'),
     cfg.BoolOpt('nexenta_nms_cache_volroot',
+                deprecated_for_removal=True,
+                deprecated_reason='NexentaStor cinder driver has been '
+                                  'refactored and the configuration '
+                                  'parameter nexenta_nms_cache_volroot '
+                                  'is no longer used.',
                 default=True,
-                help='If set True cache NexentaStor appliance volroot option '
-                     'value.')
+                help='If set True cache NexentaStor appliance volroot '
+                     'option value.')
 ]
 
-NEXENTA_DATASET_OPTS = [
+NEXENTASTOR_DATASET_OPTS = [
     cfg.StrOpt('nexenta_dataset_compression',
-               default='lz4',
-               choices=['on', 'off', 'gzip', 'gzip-1', 'gzip-2', 'gzip-3',
+               choices=['off', 'on', 'gzip', 'gzip-1', 'gzip-2', 'gzip-3',
                         'gzip-4', 'gzip-5', 'gzip-6', 'gzip-7', 'gzip-8',
                         'gzip-9', 'lzjb', 'zle', 'lz4'],
-               help='Compression value for new ZFS folders.'),
+               help='Compression algorithm used to compress volume data.'),
     cfg.StrOpt('nexenta_dataset_dedup',
-               default='off',
-               choices=['on', 'off', 'sha256', 'verify', 'sha256, verify'],
-               help='Deduplication value for new ZFS folders.'),
-    cfg.StrOpt('nexenta_folder',
-               default='',
-               help='A folder where cinder created datasets will reside.'),
-    cfg.StrOpt('nexenta_dataset_description',
-               default='',
-               help='Human-readable description for the folder.'),
+               choices=['off', 'on', 'sha256', 'verify', 'sha256,verify'],
+               help='Deduplication algorithm used to verify volume data '
+                    'integrity.'),
+    cfg.BoolOpt('nexenta_sparsed_volumes',
+                default=True,
+                help='Volumes space allocation behavior. Whether volume '
+                     'is created as sparse and grown as needed or fully '
+                     'allocated up front. The default and recommended '
+                     'value is true, which ensures volumes are initially '
+                     'created as sparse devices. Setting value to false '
+                     'will result in volumes being fully allocated at the '
+                     'time of creation.'),
     cfg.IntOpt('nexenta_blocksize',
                default=32768,
-               help='Block size for datasets'),
-    cfg.IntOpt('nexenta_ns5_blocksize',
-               default=32,
-               help='Block size for datasets'),
-    cfg.BoolOpt('nexenta_sparse',
-                default=False,
-                help='Enables or disables the creation of sparse datasets'),
+               help='Specifies a suggested block size for a volume. '
+                    'The size specified must be a power of two greater '
+                    'than or equal to 512 and less than or equal to 131072 '
+                    'bytes. For an NFS backend, the block size may be up '
+                    'to 1048576 bytes. For an iSCSI backend, the block size '
+                    'cannot be changed after the volume is created.'),
     cfg.IntOpt('nexenta_migration_throttle',
                min=1,
                max=2047,
-               help='Throttle migration throughput in MegaBytes per second'),
+               help='Throttle migration throughput in MegaBytes per second.'),
     cfg.StrOpt('nexenta_migration_service_prefix',
                default='cinder-migration',
-               help='Prefix for migration service name'),
+               help='Prefix for migration service name.'),
     cfg.StrOpt('nexenta_migration_snapshot_prefix',
                default='migration-snapshot',
-               help='Prefix for migration snapshot name'),
+               help='Prefix for migration snapshot name.'),
     cfg.StrOpt('nexenta_origin_snapshot_template',
                default='origin-snapshot-%s',
-               help='Template string to generate origin name of clone'),
+               help='Template string to generate origin name of clone.'),
     cfg.StrOpt('nexenta_group_snapshot_template',
                default='group-snapshot-%s',
-               help='Template string to generate group snapshot name')
+               help='Template string to generate group snapshot name.'),
+    cfg.StrOpt('nexenta_dataset_description',
+               default='',
+               help='Human-readable description for the backend.')
 ]
 
-NEXENTA_RRMGR_OPTS = [
+NEXENTASTOR4_RRMGR_OPTS = [
     cfg.IntOpt('nexenta_rrmgr_compression',
+               deprecated_for_removal=True,
+               deprecated_reason='NexentaStor cinder driver has been '
+                                 'refactored and the configuration '
+                                 'parameter nexenta_rrmgr_compression '
+                                 'is no longer used.',
                default=0,
-               help=('Enable stream compression, level 1..9. 1 - gives best '
-                     'speed; 9 - gives best compression.')),
+               help='Enable stream compression, level 1..9. 1 - gives best '
+                    'speed; 9 - gives best compression.'),
     cfg.IntOpt('nexenta_rrmgr_tcp_buf_size',
+               deprecated_for_removal=True,
+               deprecated_reason='NexentaStor cinder driver has been '
+                                 'refactored and the configuration '
+                                 'parameter nexenta_rrmgr_tcp_buf_size '
+                                 'is no longer used.',
                default=4096,
                help='TCP Buffer size in KiloBytes.'),
     cfg.IntOpt('nexenta_rrmgr_connections',
+               deprecated_for_removal=True,
+               deprecated_reason='NexentaStor cinder driver has been '
+                                 'refactored and the configuration '
+                                 'parameter nexenta_rrmgr_connections '
+                                 'is no longer used.',
                default=2,
-               help='Number of TCP connections.'),
+               help='Number of TCP connections.')
 ]
 
+NEXENTAEDGE_ISCSI_OPTS += (
+    NEXENTASTOR_CONNECTION_OPTS +
+    NEXENTASTOR_DATASET_OPTS +
+    NEXENTASTOR_ISCSI_OPTS
+)
+
+NEXENTASTOR4_ISCSI_OPTS += (
+    NEXENTASTOR_CONNECTION_OPTS +
+    NEXENTASTOR_DATASET_OPTS +
+    NEXENTASTOR_ISCSI_OPTS +
+    NEXENTASTOR4_RRMGR_OPTS
+)
+
+NEXENTASTOR5_ISCSI_OPTS += (
+    NEXENTASTOR_CONNECTION_OPTS +
+    NEXENTASTOR_DATASET_OPTS +
+    NEXENTASTOR_ISCSI_OPTS
+)
+
+NEXENTASTOR4_NFS_OPTS = (
+    NEXENTASTOR_CONNECTION_OPTS +
+    NEXENTASTOR_DATASET_OPTS +
+    NEXENTA_NFS_OPTS +
+    NEXENTASTOR4_RRMGR_OPTS
+)
+
+NEXENTASTOR5_NFS_OPTS = (
+    NEXENTASTOR_CONNECTION_OPTS +
+    NEXENTASTOR_DATASET_OPTS +
+    NEXENTA_NFS_OPTS
+)
+
 CONF = cfg.CONF
-CONF.register_opts(NEXENTA_CONNECTION_OPTS, group=conf.SHARED_CONF_GROUP)
-CONF.register_opts(NEXENTA_ISCSI_OPTS, group=conf.SHARED_CONF_GROUP)
-CONF.register_opts(NEXENTA_DATASET_OPTS, group=conf.SHARED_CONF_GROUP)
-CONF.register_opts(NEXENTA_NFS_OPTS, group=conf.SHARED_CONF_GROUP)
-CONF.register_opts(NEXENTA_RRMGR_OPTS, group=conf.SHARED_CONF_GROUP)
-CONF.register_opts(NEXENTA_EDGE_OPTS, group=conf.SHARED_CONF_GROUP)
+CONF.register_opts(NEXENTAEDGE_ISCSI_OPTS, group=conf.SHARED_CONF_GROUP)
+CONF.register_opts(NEXENTASTOR4_ISCSI_OPTS, group=conf.SHARED_CONF_GROUP)
+CONF.register_opts(NEXENTASTOR5_ISCSI_OPTS, group=conf.SHARED_CONF_GROUP)
+CONF.register_opts(NEXENTASTOR4_NFS_OPTS, group=conf.SHARED_CONF_GROUP)
+CONF.register_opts(NEXENTASTOR5_NFS_OPTS, group=conf.SHARED_CONF_GROUP)

--- a/cinder/volume/drivers/nexenta/utils.py
+++ b/cinder/volume/drivers/nexenta/utils.py
@@ -1,5 +1,4 @@
-# Copyright 2018 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -17,7 +16,6 @@ import re
 import six
 
 from oslo_utils import units
-import six.moves.urllib.parse as urlparse
 
 from cinder.i18n import _
 
@@ -57,71 +55,9 @@ def str2gib_size(s):
     return size_in_bytes // units.Gi
 
 
-def get_rrmgr_cmd(src, dst, compression=None, tcp_buf_size=None,
-                  connections=None):
-    """Returns rrmgr command for source and destination."""
-    cmd = ['rrmgr', '-s', 'zfs']
-    if compression:
-        cmd.extend(['-c', six.text_type(compression)])
-    cmd.append('-q')
-    cmd.append('-e')
-    if tcp_buf_size:
-        cmd.extend(['-w', six.text_type(tcp_buf_size)])
-    if connections:
-        cmd.extend(['-n', six.text_type(connections)])
-    cmd.extend([src, dst])
-    return ' '.join(cmd)
+def divup(numerator, denominator):
+    return (numerator + denominator - 1) // denominator
 
 
-def parse_nms_url(url):
-    """Parse NMS url into normalized parts like scheme, user, host and others.
-
-    Example NMS URL:
-        auto://admin:nexenta@192.168.1.1:2000/
-
-    NMS URL parts:
-
-    .. code-block:: none
-
-        auto                True if url starts with auto://, protocol
-                            will be automatically switched to https
-                            if http not supported;
-        scheme (auto)       connection protocol (http or https);
-        user (admin)        NMS user;
-        password (nexenta)  NMS password;
-        host (192.168.1.1)  NMS host;
-        port (2000)         NMS port.
-
-    :param url: url string
-    :return: tuple (auto, scheme, user, password, host, port, path)
-    """
-    pr = urlparse.urlparse(url)
-    scheme = pr.scheme
-    auto = scheme == 'auto'
-    if auto:
-        scheme = 'http'
-    user = 'admin'
-    password = 'nexenta'
-    if '@' not in pr.netloc:
-        host_and_port = pr.netloc
-    else:
-        user_and_password, host_and_port = pr.netloc.split('@', 1)
-        if ':' in user_and_password:
-            user, password = user_and_password.split(':')
-        else:
-            user = user_and_password
-    if ':' in host_and_port:
-        host, port = host_and_port.split(':', 1)
-    else:
-        host, port = host_and_port, '2000'
-    return auto, scheme, user, password, host, port, '/rest/nms/'
-
-
-def get_migrate_snapshot_name(volume):
-    """Return name for snapshot that will be used to migrate the volume."""
-    return 'cinder-migrate-snapshot-%(id)s' % volume
-
-
-def ex2err(ex):
-    """Convert a Cinder Exception to a Nexenta Error."""
-    return ex.msg
+def roundup(numerator, denominator):
+    return divup(numerator, denominator) * denominator


### PR DESCRIPTION
    NEX-20345 Nexenta NFS Cinder driver improperly extends QCOW2 volume size
    NEX-21462 Cinder NFS driver must remount volumes created with nbmand enabled
    NEX-21461 Cinder NFS driver ignores nexenta_mount_point_base configuration option
    NEX-21463 Generic volume migration error: dataset already exists
    NEX-21546 Cinder NFS options are available for iSCSI driver and vice versa
    NEX-21547 Creating a volume from a snapshot loses the volume type properties
    NEX-21555 Update copyrights for Nexenta Cinder drivers
    NEX-21593 Workaround for NEX-21577: set refreservation for cloned ZFS volumes
    NEX-21594 Workaround for NEX-21586: set correct refreservation thick-provisioned ZFS volumes
    NEX-21596 Workaround for NEX-21595: add 'source' to the requested fields

**Fixed flows:**
1. Creating a new volume using the given format: raw, qcow, qcow2, parallels, vdi, vhdx, vmdk, vpc and qed. The current driver version can create volume only in raw and qcow2 formats. 
2. For thick provisioned volumes we must reserve enough disk space. The current driver version allocates required disk space when creating the volume. Therefore thick volume creation operation takes a lot of time and does not guarantee that later there will be enough disk space for the volume. 
3. Extending an existing volume using volume format specific operation. The current driver version corrupts the volume if it is not in raw format. For thick provisioned volumes we must recalculate and reserve enough disk space. 
4. Manage an existing volume. The current driver version assumes that all volumes are created in raw format.
5. Attach an existing volume and specify correct information about its disk format. The current driver version does not specify volume's format. Therefore volume attaches as raw and corrupts by user workload.
6. Converting an existing volume to the specified format. The current driver version does not supports format conversion.
7. Creating a new volume from an existing image. The current driver version assumes that all volumes are in raw format.
8. Upload an existing volume to an image. The current driver version assumes that all volumes are in raw format.
9. Volume retype and retype+migration. The current driver version assumes that all volumes are in raw format.
10. Creating a new volume from an existing snapshot
11. Creating a new thick-provisioned volume with non-default *copies* parameter

**pep8**
```
pep8 run-test: commands[1] | doc8
setting PATH=/opt/stack/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[93617] /opt/stack/cinder$ /opt/stack/cinder/.tox/pep8/bin/doc8
Scanning...
Validating...
========
Total files scanned = 206
Total files ignored = 465
Total accumulated errors = 0
Detailed error counts:
    - CheckCarriageReturn = 0
    - CheckIndentationNoTab = 0
    - CheckMaxLineLength = 0
    - CheckNewlineEndOfFile = 0
    - CheckTrailingWhitespace = 0
    - CheckValidity = 0
pep8 run-test: commands[2] | /opt/stack/cinder/tools/config/check_uptodate.sh
setting PATH=/opt/stack/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[93620] /opt/stack/cinder$ /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 run-test: commands[3] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder /opt/stack/cinder/doc/source/ /opt/stack/cinder/releasenotes/notes
setting PATH=/opt/stack/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[93641] /opt/stack/cinder$ /opt/stack/cinder/tools/check_exec.py cinder doc/source releasenotes/notes
pep8 finish: run-test  after 212.88 seconds
pep8 start: run-test-post 
pep8 finish: run-test-post  after 0.00 seconds
_________________________________________________________________________________________________ summary _________________________________________________________________________________________________
  pep8: commands succeeded
  congratulations :)
```

**tempest NexentaStor5 NFS**
```
======
Totals
======
Ran: 262 tests in 2742.3176 sec.
 - Passed: 257
 - Skipped: 5
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2103.9799 sec.
```

**tempest NexentaStor5 iSCSI**
```
======
Totals
======
Ran: 262 tests in 3354.4728 sec.
 - Passed: 258
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2686.5060 sec.
```

**tempest NexentaStor4 NFS**
```
======
Totals
======
Ran: 262 tests in 3744.0000 sec.
 - Passed: 255
 - Skipped: 7
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2881.0496 sec.
```

**tempest NexentaStor4 iSCSI**
```
======
Totals
======
Ran: 262 tests in 3923.0000 sec.
 - Passed: 256
 - Skipped: 6
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3105.1011 sec.
```