### PR TITLE
NEX-21825 Cinder TypeError: encoding without a string argument

### DIFF
--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -31,8 +31,8 @@ from cinder.volume import driver
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 from cinder.volume.drivers.nexenta import options
 from cinder.volume.drivers.nexenta import utils as nexenta_utils
-from cinder.volume import volume_utils
 from cinder.volume import volume_types
+from cinder.volume import volume_utils
 
 LOG = logging.getLogger(__name__)
 
@@ -350,8 +350,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         image_checksum = image_meta['checksum']
         namespace = uuid.UUID(image_id, version=4)
         name = '%s:%s' % (image_checksum, volume_blocksize)
-        if isinstance(name, six.text_type):
-            name = name.encode('utf-8')
+        name = nexenta_utils.native_string(name)
         cache_uuid = uuid.uuid5(namespace, name)
         cache_id = six.text_type(cache_uuid)
         cache_name = self.cache_image_template % cache_id

--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -38,8 +38,8 @@ from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 from cinder.volume.drivers.nexenta import options
 from cinder.volume.drivers.nexenta import utils as nexenta_utils
 from cinder.volume.drivers import nfs
-from cinder.volume import volume_utils
 from cinder.volume import volume_types
+from cinder.volume import volume_utils
 
 LOG = logging.getLogger(__name__)
 
@@ -493,8 +493,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         image_checksum = image_meta['checksum']
         namespace = uuid.UUID(image_id, version=4)
         name = '%s:%s' % (image_checksum, volume_format)
-        if isinstance(name, six.text_type):
-            name = name.encode('utf-8')
+        name = nexenta_utils.native_string(name)
         cache_uuid = uuid.uuid5(namespace, name)
         cache_id = six.text_type(cache_uuid)
         cache_name = self.cache_image_template % cache_id

--- a/cinder/volume/drivers/nexenta/utils.py
+++ b/cinder/volume/drivers/nexenta/utils.py
@@ -19,6 +19,7 @@ import uuid
 from oslo_utils import units
 
 from cinder.i18n import _
+from cinder import utils as cinder_utils
 
 
 def str2size(s, scale=1024):
@@ -54,6 +55,18 @@ def str2gib_size(s):
     """Covert size-string to size in gigabytes."""
     size_in_bytes = str2size(s)
     return size_in_bytes // units.Gi
+
+
+def native_string(text):
+    """Convert to native string.
+
+    Convert bytes and Unicode strings to native strings:
+
+    * convert to bytes on Python 2:
+      encode Unicode using encodeutils.safe_encode()
+    * convert to Unicode on Python 3: decode bytes from UTF-8
+    """
+    return cinder_utils.convert_str(text)
 
 
 def divup(numerator, denominator):


### PR DESCRIPTION
**NexentaStor5 NFS**
```
======
Totals
======
Ran: 263 tests in 3379.1448 sec.
 - Passed: 259
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2595.8630 sec.
```

**NexentaStor5 iSCSI**
```
======
Totals
======
Ran: 263 tests in 3012.0000 sec.
 - Passed: 260
 - Skipped: 3
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2282.3874 sec.
```