### PR TITLE
NEX-21119 & NEX-22044

### DIFF
--- a/cinder/volume/drivers/nexenta/options.py
+++ b/cinder/volume/drivers/nexenta/options.py
@@ -71,12 +71,12 @@ NEXENTASTOR_CONNECTION_OPTS = [
                       'within which NexentaStor RESTful API '
                       'interface must send a response.'),
     cfg.FloatOpt('nexenta_rest_backoff_factor',
-                 default=0.5,
+                 default=1,
                  help='Specifies the backoff factor to apply between '
                       'connection attempts to NexentaStor RESTful '
                       'API interface.'),
     cfg.IntOpt('nexenta_rest_retry_count',
-               default=3,
+               default=5,
                help='Specifies the number of times to repeat NexentaStor '
                     'RESTful API calls in case of connection errors '
                     'or NexentaStor appliance retryable errors.')


### PR DESCRIPTION
**NEX-21119 & NEX-22044**
* NEX-22044 Workaround for NEX-22043 NEF RESTful API returns HTTP error 401/Unauthorized on expired license
* NEX-21119 [NexentaBugs #92360] Volume creation fails when one Nexenta server is down

**Changelog**
* Added flag backend_state to report backend status, possible values: **up/down**
  Reference: https://specs.openstack.org/openstack/cinder-specs/specs/queens/report-backend-state-in-service-list.html
  Status of pool/backend is available for a OpenStack administrator:
```
$ cinder  get-pools --detail
+-----------------------------------+--------------------------------------------------+
| Property                          | Value                                            |
+-----------------------------------+--------------------------------------------------+
| QoS_support                       | False                                            |
| allocated_capacity_gb             | 6                                                |
| backend_state                     | down                                             |
| consistencygroup_support          | True                                             |
| consistent_group_snapshot_enabled | True                                             |
| description                       | NexentaStor5 10.3.35.53:pool1/vg                 |
| display_name                      | Capabilities of NexentaStor5 iSCSI driver        |
| driver_version                    | 1.5.0                                            |
| filter_function                   | None                                             |
| free_capacity_gb                  | unknown                                          |
| goodness_function                 | None                                             |
| location_info                     | NexentaISCSIDriver:10.3.35.53:pool1/vg           |
| max_over_subscription_ratio       | 20.0                                             |
| multiattach                       | True                                             |
| name                              | openstack-master-ns5-iscsi@ns5_iscsi1#ns5_iscsi1 |
| nef_hosts                         | 10.3.35.51,10.3.35.52                            |
| nef_port                          | 8443                                             |
| nef_scheme                        | https                                            |
| nef_url                           | https://10.3.35.52:8443                          |
| online_extend_support             | True                                             |
| pool_name                         | pool1                                            |
| provisioned_capacity_gb           | 6                                                |
| reserved_percentage               | 0                                                |
| sparse_copy_volume                | True                                             |
| storage_protocol                  | iSCSI                                            |
| thick_provisioning_support        | True                                             |
| thin_provisioning_support         | True                                             |
| timestamp                         | 2019-11-04T14:06:36.056771                       |
| total_capacity_gb                 | unknown                                          |
| total_snapshots                   | 0                                                |
| total_volumes                     | 2                                                |
| vendor_name                       | Nexenta                                          |
| volume_backend_name               | ns5_iscsi1                                       |
+-----------------------------------+--------------------------------------------------+
```
* Added retry on driver initialization failure: repeat driver initialization in case of NEF API errors.
* Added workaround for license expiration: valid error message w/o re-authentication:
```
Nov 03 21:24:32 openstack-master-ns5-iscsi cinder-volume[89514]: ERROR cinder.volume.drivers.nexenta.ns5.iscsi [None req-45a1ea4e-656d-4b60-ba67-51734b84b93f None None] Failed to create SAN path pool2/vg: Volume driver reported an error: Valid license required to perform operation. (source: rest, name: NefError, code: ELICENSE): NefException: Volume driver reported an error: Valid license required to perform operation. (source: rest, name: NefError, code: ELICENSE)
```
* Added QoS support in terms of I/O throttling rate (NFS only).

**Pep8**
```
pep8 start: run-test-pre 
pep8 run-test-pre: PYTHONHASHSEED='466647270'
pep8 finish: run-test-pre  after 0.00 seconds
pep8 start: run-test 
pep8 run-test: commands[0] | flake8 .
setting PATH=/opt/stack/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[19279] /opt/stack/cinder$ /opt/stack/cinder/.tox/pep8/bin/flake8 .
pep8 run-test: commands[1] | doc8
setting PATH=/opt/stack/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[19346] /opt/stack/cinder$ /opt/stack/cinder/.tox/pep8/bin/doc8
Scanning...
Validating...
========
Total files scanned = 209
Total files ignored = 1829
Total accumulated errors = 0
Detailed error counts:
    - CheckCarriageReturn = 0
    - CheckIndentationNoTab = 0
    - CheckMaxLineLength = 0
    - CheckNewlineEndOfFile = 0
    - CheckTrailingWhitespace = 0
    - CheckValidity = 0
pep8 run-test: commands[2] | /opt/stack/cinder/tools/config/check_uptodate.sh
setting PATH=/opt/stack/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[19363] /opt/stack/cinder$ /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 run-test: commands[3] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder /opt/stack/cinder/doc/source/ /opt/stack/cinder/releasenotes/notes
setting PATH=/opt/stack/cinder/.tox/pep8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
[19382] /opt/stack/cinder$ /opt/stack/cinder/tools/check_exec.py cinder doc/source releasenotes/notes
pep8 finish: run-test  after 268.27 seconds
pep8 start: run-test-post 
pep8 finish: run-test-post  after 0.00 seconds
______________________________________________________________________________________ summary ______________________________________________________________________________________
  pep8: commands succeeded
  congratulations :)

```

**Tempest iSCSI**
```
======
Totals
======
Ran: 263 tests in 3657.0000 sec.
 - Passed: 260
 - Skipped: 3
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2818.4104 sec.
```

**Tempest NFS**
```
======
Totals
======
Ran: 263 tests in 4002.0000 sec.
 - Passed: 259
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3058.5744 sec.
```