### PR TITLE
NEX-22103 Unable to create Cinder bootable volumes from large Glance images

### DIFF
--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -25,6 +25,7 @@ import six
 from cinder import context
 from cinder import coordination
 from cinder.i18n import _
+from cinder.image import image_utils
 from cinder import interface
 from cinder import objects
 from cinder.volume import driver
@@ -366,6 +367,80 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         })
         self.nef.volumes.create(payload)
 
+    def _verify_cache_image(self, ctxt, volume, image_meta, image_service):
+        properties = self.nef.volumes.properties
+        volume_type_specs = self._get_vendor_properties(properties, volume)
+        volume_blocksize = volume_type_specs['volumeBlockSize']
+        image_id = image_meta['id']
+        image_checksum = image_meta['checksum']
+        namespace = uuid.UUID(image_id, version=4)
+        name = '%s:%s' % (image_checksum, volume_blocksize)
+        name = nexenta_utils.native_string(name)
+        cache_uuid = uuid.uuid5(namespace, name)
+        cache_id = six.text_type(cache_uuid)
+        cache = {
+            'id': cache_id,
+            'name': self.cache_image_template % cache_id,
+            'volume_type_id': volume['volume_type_id']
+        }
+        cache_path = self._get_volume_path(cache)
+        payload = {'fields': 'volumeSize,readOnly'}
+        cache_exist = False
+        try:
+            cache_specs = self.nef.volumes.get(cache_path, payload)
+            image_size = cache_specs['volumeSize']
+            if not cache_specs['readOnly']:
+                self.delete_volume(cache)
+            else:
+                cache_exist = True
+        except jsonrpc.NefException as error:
+            if error.code != 'ENOENT':
+                raise
+        if not cache_exist:
+            with image_utils.TemporaryImages.fetch(image_service, ctxt,
+                                                   image_id) as image_file:
+                image_info = image_utils.qemu_img_info(image_file,
+                                                       force_share=True,
+                                                       run_as_root=True)
+                image_size = image_info.virtual_size
+        cache_size = nexenta_utils.roundup(image_size, units.Gi)
+        cache['size'] = cache_size // units.Gi
+        if cache['size'] > volume['size']:
+            code = 'ENOSPC'
+            message = (_('Unable to clone cache %(cache)s '
+                         'to volume %(volume)s: cache size '
+                         '%(cache_size)sGB is larger than '
+                         'volume size %(volume_size)sGB')
+                       % {'cache': cache['name'],
+                          'volume': volume['name'],
+                          'cache_size': cache['size'],
+                          'volume_size': volume['size']})
+            raise jsonrpc.NefException(code=code, message=message)
+        if not cache_exist:
+            self.create_volume(cache)
+            self.copy_image_to_volume(ctxt, cache, image_service, image_id)
+            payload = {'readOnly': True}
+            self.nef.volumes.set(cache_path, payload)
+        return cache
+
+    def _verify_cache_snapshot(self, cache):
+        snapshot = {
+            'id': cache['id'],
+            'name': self.cache_snapshot_template % cache['id'],
+            'volume_id': cache['id'],
+            'volume_name': cache['name'],
+            'volume_size': cache['size']
+        }
+        snapshot_path = self._get_snapshot_path(snapshot)
+        payload = {'fields': 'path'}
+        try:
+            self.nef.snapshots.get(snapshot_path, payload)
+        except jsonrpc.NefException as error:
+            if error.code != 'ENOENT':
+                raise
+            self.create_snapshot(snapshot)
+        return snapshot
+
     @coordination.synchronized('{self.nef.lock}-{image_meta[id]}')
     def clone_image(self, ctxt, volume, image_location, image_meta,
                     image_service):
@@ -389,132 +464,19 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         """
         if not self.image_cache:
             return None, False
-        properties = self.nef.volumes.properties
-        payload = self._get_vendor_properties(properties, volume)
-        volume_blocksize = payload['volumeBlockSize']
-        volume_size = volume['size'] * units.Gi
-        image_id = image_meta['id']
-        image_checksum = image_meta['checksum']
-        namespace = uuid.UUID(image_id, version=4)
-        name = '%s:%s' % (image_checksum, volume_blocksize)
-        name = nexenta_utils.native_string(name)
-        cache_uuid = uuid.uuid5(namespace, name)
-        cache_id = six.text_type(cache_uuid)
-        cache_name = self.cache_image_template % cache_id
-        cache_type_id = volume['volume_type_id']
-        if 'virtual_size' in image_meta and image_meta['virtual_size']:
-            image_size = image_meta['virtual_size']
-        else:
-            image_size = nexenta_utils.roundup(image_meta['size'], units.Gi)
-        if image_size > volume_size:
-            LOG.error('Unable to clone image %(image)s to volume '
-                      '%(volume)s: image size %(image_size)s is '
-                      'larger than volume size %(volume_size)s',
-                      {'image': image_id,
+        try:
+            cache = self._verify_cache_image(ctxt, volume,
+                                             image_meta,
+                                             image_service)
+            snapshot = self._verify_cache_snapshot(cache)
+            self.create_volume_from_snapshot(volume, snapshot)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to clone image %(image)s '
+                      'to volume %(volume)s: %(error)s',
+                      {'image': image_meta['id'],
                        'volume': volume['name'],
-                       'image_size': image_size,
-                       'volume_size': volume_size})
+                       'error': error})
             return None, False
-        LOG.debug('Clone image %(image)s (size: %(image_size)s, '
-                  'checksum: %(image_checksum)s) to volume '
-                  '%(volume)s (size: %(volume_size)s, '
-                  'block size: %(volume_blocksize)s)',
-                  {'image': image_id,
-                   'image_size': image_size,
-                   'image_checksum': image_checksum,
-                   'volume': volume['name'],
-                   'volume_size': volume_size,
-                   'volume_blocksize': volume_blocksize})
-        cache_size = image_size // units.Gi
-        cache = {
-            'id': cache_id,
-            'name': cache_name,
-            'volume_type_id': cache_type_id,
-            'size': cache_size
-        }
-        cache_path = self._get_volume_path(cache)
-        payload = {'fields': 'readOnly'}
-        cache_exist = False
-        try:
-            cache_specs = self.nef.volumes.get(cache_path, payload)
-        except jsonrpc.NefException as error:
-            if error.code != 'ENOENT':
-                LOG.error('Failed to get properties for image cache '
-                          '%(cache)s: %(error)s',
-                          {'cache': cache_name, 'error': error})
-                return None, False
-        else:
-            if cache_specs['readOnly']:
-                cache_exist = True
-        if not cache_exist:
-            LOG.debug('Create cache %(cache)s for image %(image)s',
-                      {'cache': cache_name, 'image': image_id})
-            payload = {'readOnly': True}
-            try:
-                self.delete_volume(cache)
-                self.create_volume(cache)
-                self.copy_image_to_volume(ctxt, cache,
-                                          image_service,
-                                          image_id)
-                self.nef.volumes.set(cache_path, payload)
-            except jsonrpc.NefException as error:
-                LOG.error('Failed to create cache %(cache)s for '
-                          'image %(image)s: %(error)s',
-                          {'cache': cache_name,
-                           'image': image_id,
-                           'error': error})
-            else:
-                cache_exist = True
-        if not cache_exist:
-            try:
-                self.delete_volume(cache)
-            except jsonrpc.NefException:
-                pass
-            return None, False
-        snapshot_name = self.cache_snapshot_template % cache_id
-        snapshot = {
-            'id': cache_id,
-            'name': snapshot_name,
-            'volume_id': cache_id,
-            'volume_name': cache_name,
-            'volume_size': cache_size
-        }
-        snapshot_path = self._get_snapshot_path(snapshot)
-        payload = {'fields': 'path'}
-        snapshot_exist = False
-        try:
-            self.nef.snapshots.get(snapshot_path, payload)
-        except jsonrpc.NefException as error:
-            if error.code != 'ENOENT':
-                LOG.error('Failed to get properties for image cache '
-                          'snapshot %(snapshot)s: %(error)s',
-                          {'snapshot': snapshot_name,
-                           'error': error})
-                return None, False
-        else:
-            snapshot_exist = True
-        if not snapshot_exist:
-            LOG.debug('Create snapshot %(snapshot)s for image cache '
-                      '%(cache)s',
-                      {'snapshot': snapshot_name,
-                       'cache': cache_name})
-            try:
-                self.create_snapshot(snapshot)
-            except jsonrpc.NefException as error:
-                LOG.error('Failed to create snapshot %(snapshot)s '
-                          'for image cache %(cache)s: %(error)s',
-                          {'snapshot': snapshot_name,
-                           'cache': cache_name,
-                           'error': error})
-            else:
-                snapshot_exist = True
-        if not snapshot_exist:
-            try:
-                self.delete_volume(cache)
-            except jsonrpc.NefException:
-                pass
-            return None, False
-        self.create_volume_from_snapshot(volume, snapshot)
         return None, True
 
     @coordination.synchronized('{self.nef.lock}')


### PR DESCRIPTION
**NEX-22103 Unable to create Cinder bootable volumes from large Glance images**

**Tempest NFS**
```
======
Totals
======
Ran: 263 tests in 4362.0000 sec.
 - Passed: 259
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3308.3455 sec.
```

**Tempest iSCSI**
```
======
Totals
======
Ran: 263 tests in 4191.0000 sec.
 - Passed: 260
 - Skipped: 3
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3166.7170 sec.
```

**Pep8**
```
pep8 run-test-pre: PYTHONHASHSEED='2023114913'
pep8 run-test: commands[0] | flake8 .
pep8 run-test: commands[1] | doc8
Scanning...
Validating...
========
Total files scanned = 209
Total files ignored = 463
Total accumulated errors = 0
Detailed error counts:
    - CheckCarriageReturn = 0
    - CheckIndentationNoTab = 0
    - CheckMaxLineLength = 0
    - CheckNewlineEndOfFile = 0
    - CheckTrailingWhitespace = 0
    - CheckValidity = 0
pep8 run-test: commands[2] | /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 run-test: commands[3] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder /opt/stack/cinder/doc/source/ /opt/stack/cinder/releasenotes/notes
___________________________________ summary ____________________________________
  pep8: commands succeeded
  congratulations :)

```