### PR TITLE
NEX-21119 [NexentaBugs #92360] Volume creation fails when one Nexenta server is down

### DIFF
--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -113,10 +113,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             raise jsonrpc.NefException(code='ENODATA', message=message)
         self.configuration.append_config_values(
             options.NEXENTASTOR5_ISCSI_OPTS)
-        self.driver_name = self.__class__.__name__
         self.nef = None
         self.san_stat = None
         self.backend_name = self._get_backend_name()
+        self.san_driver = self.__class__.__name__
         self.image_cache = self.configuration.nexenta_image_cache
         self.target_prefix = self.configuration.nexenta_target_prefix
         self.target_group_prefix = (
@@ -740,7 +740,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         if reserved_percentage is None:
             reserved_percentage = 0
         location_info = '%(driver)s:%(host)s:%(path)s' % {
-            'driver': self.driver_name,
+            'driver': self.san_driver,
             'host': self.san_host,
             'path': self.san_path
         }
@@ -2042,22 +2042,22 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             return false_ret
         location = capabilities['location_info']
         try:
-            driver_name, san_host, san_path = location.split(':')
+            san_driver, san_host, san_path = location.split(':')
         except ValueError as error:
             LOG.error('Failed to parse location info %(location)s '
                       'for the destination host %(host)s: %(error)s',
                       {'location': location, 'host': host['host'],
                        'error': error})
             return false_ret
-        if not (driver_name and san_host and san_path):
+        if not (san_driver and san_host and san_path):
             LOG.error('Incomplete location info %(location)s '
                       'found for the destination host %(host)s',
                       {'location': location, 'host': host['host']})
             return false_ret
-        if driver_name != self.driver_name:
-            LOG.error('Unsupported storage driver %(driver_name)s '
+        if san_driver != self.san_driver:
+            LOG.error('Unsupported storage driver %(san_driver)s '
                       'found for the destination host %(host)s',
-                      {'driver_name': driver_name,
+                      {'san_driver': san_driver,
                        'host': host['host']})
             return false_ret
         storage_protocol = capabilities['storage_protocol']

--- a/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
@@ -931,8 +931,8 @@ class NefProxy(object):
     def delay(self, attempt):
         if self.retries > 0:
             attempt %= self.retries
-        if attempt == 0:
-            attempt = 1
+            if attempt == 0:
+                attempt = self.retries
         interval = float(self.backoff_factor * (2 ** (attempt - 1)))
         LOG.debug('Waiting for %(interval)s seconds',
                   {'interval': interval})

--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -159,10 +159,10 @@ class NexentaNfsDriver(nfs.NfsDriver):
             root_helper, execute=execute,
             nfs_mount_point_base=self.mount_point_base,
             nfs_mount_options=self.mount_options)
-        self.driver_name = self.__class__.__name__
         self.nef = None
         self.nas_stat = None
         self.backend_name = self._get_backend_name()
+        self.nas_driver = self.__class__.__name__
         self.nas_host = self.configuration.nas_host
         self.nas_path = self.configuration.nas_share_path
         self.nas_pool = self.nas_path.split(posixpath.sep)[0]
@@ -918,22 +918,22 @@ class NexentaNfsDriver(nfs.NfsDriver):
             return false_ret
         location = capabilities['location_info']
         try:
-            driver_name, nas_host, nas_path = location.split(':')
+            nas_driver, nas_host, nas_path = location.split(':')
         except ValueError as error:
             LOG.error('Failed to parse location info %(location)s '
                       'for the destination host %(host)s: %(error)s',
                       {'location': location, 'host': host['host'],
                        'error': error})
             return false_ret
-        if not (driver_name and nas_host and nas_path):
+        if not (nas_driver and nas_host and nas_path):
             LOG.error('Incomplete location info %(location)s '
                       'found for the destination host %(host)s',
                       {'location': location, 'host': host['host']})
             return false_ret
-        if driver_name != self.driver_name:
-            LOG.error('Unsupported storage driver %(driver_name)s '
+        if nas_driver != self.nas_driver:
+            LOG.error('Unsupported storage driver %(nas_driver)s '
                       'found for the destination host %(host)s',
-                      {'driver_name': driver_name,
+                      {'nas_driver': nas_driver,
                        'host': host['host']})
             return false_ret
         storage_protocol = capabilities['storage_protocol']
@@ -1519,7 +1519,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         if reserved_percentage is None:
             reserved_percentage = 0
         location_info = '%(driver)s:%(host)s:%(path)s' % {
-            'driver': self.driver_name,
+            'driver': self.nas_driver,
             'host': self.nas_host,
             'path': self.nas_path
         }

--- a/cinder/volume/drivers/nexenta/utils.py
+++ b/cinder/volume/drivers/nexenta/utils.py
@@ -13,10 +13,10 @@
 #    under the License.
 
 import re
-import six
 import uuid
 
 from oslo_utils import units
+import six
 
 from cinder.i18n import _
 from cinder import utils as cinder_utils


### PR DESCRIPTION
**NEX-21119 [NexentaBugs #92360] Volume creation fails when one Nexenta server is down**

**Pep8**
```
+ tox -e pep8
pep8 run-test-pre: PYTHONHASHSEED='2157926149'
pep8 run-test: commands[0] | flake8 .
pep8 run-test: commands[1] | doc8
Scanning...
Validating...
========
Total files scanned = 209
Total files ignored = 463
Total accumulated errors = 0
Detailed error counts:
    - CheckCarriageReturn = 0
    - CheckIndentationNoTab = 0
    - CheckMaxLineLength = 0
    - CheckNewlineEndOfFile = 0
    - CheckTrailingWhitespace = 0
    - CheckValidity = 0
pep8 run-test: commands[2] | /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 run-test: commands[3] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder /opt/stack/cinder/doc/source/ /opt/stack/cinder/releasenotes/notes
___________________________________ summary ____________________________________
  pep8: commands succeeded
  congratulations :)
```

**NexentaStor5 iSCSI**
```
======
Totals
======
Ran: 263 tests in 3349.8908 sec.
 - Passed: 260
 - Skipped: 3
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2551.2327 sec.
```

**NexentaStor4 iSCSI**
```
======
Totals
======
Ran: 263 tests in 3929.9586 sec.
 - Passed: 258
 - Skipped: 5
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3234.8223 sec.
```

**NexentaStor5 NFS**
```
======
Totals
======
Ran: 263 tests in 3675.3236 sec.
 - Passed: 259
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2801.1496 sec.
```

**NexentaStor4 NFS**
```
======
Totals
======
Ran: 263 tests in 2636.4371 sec.
 - Passed: 257
 - Skipped: 6
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 1974.2403 sec.
```