### PR TITLE
NEX-22069 Sync NexentaStor Cinder NFS/iSCSI drivers: Master => Train

### DIFF
--- a/cinder/volume/drivers/nexenta/iscsi.py
+++ b/cinder/volume/drivers/nexenta/iscsi.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc. All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -13,7 +13,6 @@
 #    under the License.
 
 import datetime
-import difflib
 import ipaddress
 import posixpath
 import random
@@ -33,8 +32,14 @@ from cinder import objects
 from cinder.volume import driver
 from cinder.volume.drivers.nexenta import jsonrpc
 from cinder.volume.drivers.nexenta import options
+from cinder.volume.drivers.nexenta import utils as nexenta_utils
 
 LOG = logging.getLogger(__name__)
+
+DEFAULT_HOST_GROUP = 'All'
+DEFAULT_TARGET_GROUP = 'All'
+DEFAULT_RETRY_COUNT = 10
+DEFAULT_RETRY_DELAY = 30
 
 
 @interface.volumedriver
@@ -78,10 +83,12 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
               - Added configuration parameter for LUN writeback cache.
               - Improved collection of backend statistics.
         1.4.1 - Added retries on timeouts, network connection errors,
-                SSL errors, proxy and NMS errors.
+              - SSL errors, proxy and NMS errors.
+        1.4.2 - Added flag backend_state to report backend status.
+              - Added retry on driver initialization failure.
     """
 
-    VERSION = '1.4.1'
+    VERSION = '1.4.2'
     CI_WIKI_NAME = "Nexenta_CI"
 
     vendor_name = 'Nexenta'
@@ -98,9 +105,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                           'storage_protocol': self.storage_protocol})
             raise jsonrpc.NmsException(code='EINVAL', message=message)
         self.configuration.append_config_values(
-            options.NEXENTA_CONNECTION_OPTS)
-        self.configuration.append_config_values(options.NEXENTA_ISCSI_OPTS)
-        self.configuration.append_config_values(options.NEXENTA_DATASET_OPTS)
+            options.NEXENTASTOR4_ISCSI_OPTS)
         required_options = ['nexenta_host', 'nexenta_volume', 'nexenta_user',
                             'nexenta_password']
         for option in required_options:
@@ -113,13 +118,16 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                               'option': option})
                 raise jsonrpc.NmsException(code='EINVAL', message=message)
         self.nms = None
+        self.san_stat = None
         self.mappings = {}
-        self.driver_name = self.__class__.__name__
+        self.backend_name = self._get_backend_name()
+        self.san_driver = self.__class__.__name__
         self.san_host = self.configuration.nexenta_host
-        self.volume = self.configuration.nexenta_volume
-        self.folder = self.configuration.nexenta_folder
+        self.san_pool = self.configuration.nexenta_volume
+        self.san_group = self.configuration.nexenta_folder
         self.volume_compression = (
             self.configuration.nexenta_dataset_compression)
+        self.volume_dedup = self.configuration.nexenta_dataset_dedup
         self.volume_blocksize = self.configuration.nexenta_blocksize
         self.volume_sparse = self.configuration.nexenta_sparse
         self.tpgs = self.configuration.nexenta_iscsi_target_portal_groups
@@ -128,7 +136,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             self.configuration.nexenta_target_group_prefix)
         self.host_group_prefix = self.configuration.nexenta_host_group_prefix
         self.lpt = self.configuration.nexenta_luns_per_target
-        self.portal_port = self.configuration.nexenta_iscsi_target_portal_port
+        self.san_port = self.configuration.nexenta_iscsi_target_portal_port
         self.origin_snapshot_template = (
             self.configuration.nexenta_origin_snapshot_template)
         self.migration_snapshot_prefix = (
@@ -137,69 +145,82 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             self.configuration.nexenta_migration_service_prefix)
         self.migration_throttle = (
             self.configuration.nexenta_migration_throttle)
-        if self.folder:
-            self.root_path = posixpath.join(self.volume, self.folder)
+        if self.san_group:
+            self.san_path = posixpath.join(self.san_pool, self.san_group)
         else:
-            self.root_path = self.volume
+            self.san_path = self.san_pool
 
     @staticmethod
     def get_driver_options():
-        return (
-            options.NEXENTA_CONNECTION_OPTS +
-            options.NEXENTA_ISCSI_OPTS +
-            options.NEXENTA_DATASET_OPTS
-        )
+        return options.NEXENTASTOR4_ISCSI_OPTS
 
-    def do_setup(self, context):
-        self.nms = jsonrpc.NmsProxy(self.driver_volume_type,
-                                    self.root_path,
-                                    self.configuration)
+    def do_setup(self, ctxt):
+        while not self._do_setup():
+            greenthread.sleep(DEFAULT_RETRY_DELAY)
+
+    def _do_setup(self):
+        try:
+            self.nms = jsonrpc.NmsProxy(self.driver_volume_type,
+                                        self.san_path,
+                                        self.configuration)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to initialize RESTful API for backend '
+                      '%(backend_name)s on host %(host)s: %(error)s',
+                      {'backend_name': self.backend_name,
+                       'host': self.host,
+                       'error': error})
+            return False
+        return True
 
     def check_for_setup_error(self):
-        """Verify that the volume, folder and tpgs exists."""
-        if not self.nms.volume.object_exists(self.volume):
-            message = (_('Volume %(volume)s not found')
-                       % {'volume': self.volume})
-            raise jsonrpc.NmsException(code='ENOENT', message=message)
-        if not self.nms.folder.object_exists(self.root_path):
-            message = (_('Folder %(folder)s not found')
-                       % {'folder': self.root_path})
-            raise jsonrpc.NmsException(code='ENOENT', message=message)
-        host_tpgs = self.nms.iscsitarget.list_tpg()
+        while not self._check_for_setup_error():
+            greenthread.sleep(DEFAULT_RETRY_DELAY)
+
+    def _check_for_setup_error(self):
+        """Check root volume group and iSCSI target service."""
+        fmri = 'svc:/network/iscsi/target:default'
+        try:
+            self.san_stat = self.nms.folder.get_child_props(self.san_path, '')
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get stat of SAN path %(san_path)s: %(error)s',
+                      {'san_path': self.san_path, 'error': error})
+            return False
+        try:
+            service_state = self.nms.netsvc.get_state(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get state of iSCSI service: %(error)s',
+                      {'error': error})
+            return False
+        if service_state != 'online':
+            LOG.error('iSCSI service is not online: %(state)s',
+                      {'state': service_state})
+            return False
+        try:
+            host_tpgs = self.nms.iscsitarget.list_tpg()
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get target portal groups: %(error)s',
+                      {'error': error})
+            return False
         for tpg in self.tpgs:
-            if tpg in host_tpgs:
-                continue
-            message = (_('Target portal group %(tpg)s not found')
-                       % {'tpg': tpg})
-            raise jsonrpc.NmsException(code='ENOENT', message=message)
+            if tpg not in host_tpgs:
+                LOG.error('Target portal group %(tpg)s not found',
+                          {'tpg': tpg})
+                return False
+        return True
 
     def _get_volume_path(self, volume):
         """Return ZFS datset path for the volume."""
-        return posixpath.join(self.root_path, volume['name'])
+        volume_name = volume['name']
+        volume_path = posixpath.join(self.san_path, volume_name)
+        return volume_path
 
     def _get_snapshot_path(self, snapshot):
         """Return ZFS snapshot path for the snapshot."""
         volume_name = snapshot['volume_name']
         snapshot_name = snapshot['name']
-        volume_path = posixpath.join(self.root_path, volume_name)
-        return '%s@%s' % (volume_path, snapshot_name)
-
-    @staticmethod
-    def _match_template(template, name):
-        sequence = difflib.SequenceMatcher(None, name, template)
-        added = deleted = result = ''
-        for tag, a1, a2, b1, b2 in sequence.get_opcodes():
-            if tag == 'equal':
-                result += ''.join(sequence.a[a1:a2])
-            elif tag == 'delete':
-                deleted += ''.join(sequence.a[a1:a2])
-            elif tag == 'insert':
-                added += ''.join(sequence.b[b1:b2])
-            elif tag == 'replace':
-                result += ''.join(sequence.b[b1:b2])
-        if result == template and not (added or deleted):
-            return True
-        return False
+        volume_path = posixpath.join(self.san_path, volume_name)
+        snapshot_path = '%s@%s' % (volume_path, snapshot_name)
+        return snapshot_path
 
     def _create_target_group(self, group, target):
         """Create a new target group with target member.
@@ -229,7 +250,9 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         volume_size = '%sG' % volume['size']
         volume_blocksize = six.text_type(self.volume_blocksize)
         volume_sparsed = self.volume_sparse
-        volume_options = {'compression': self.volume_compression}
+        volume_options = {}
+        if self.volume_compression:
+            volume_options['compression'] = self.volume_compression
         self.nms.zvol.create_with_props(volume_path, volume_size,
                                         volume_blocksize,
                                         volume_sparsed,
@@ -262,7 +285,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             return
         template = self.origin_snapshot_template
         parent_path, snapshot_name = origin.split('@')
-        if not self._match_template(template, snapshot_name):
+        if not nexenta_utils.match_template(template, snapshot_name):
             return
         try:
             self.nms.snapshot.destroy(origin, '-d')
@@ -327,10 +350,9 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         return None
 
     def _svc_state(self, fmri, state):
-        retries = 10
-        delay = 30
+        retries = DEFAULT_RETRY_COUNT
         while retries:
-            greenthread.sleep(delay)
+            greenthread.sleep(DEFAULT_RETRY_DELAY)
             retries -= 1
             try:
                 status = self.nms.autosvc.get_state(fmri)
@@ -358,8 +380,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                           '%(fmri)s to %(state)s: %(error)s',
                           {'fmri': fmri, 'state': state, 'error': error})
         LOG.error('Unable to change state of migration service %(fmri)s '
-                  'to %(state)s: maximum retries exceeded',
-                  {'fmri': fmri, 'state': state})
+                  'to %(state)s: maximum retries exceeded (%(retries)s)',
+                  {'fmri': fmri, 'state': state, 'retries': retries})
         return False
 
     def _svc_progress(self, fmri):
@@ -474,7 +496,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 except jsonrpc.NmsException as error:
                     if error.code == 'ENOENT':
                         break
-                greenthread.sleep(30)
+                greenthread.sleep(DEFAULT_RETRY_DELAY)
         if migrated:
             return
         path = props.get('restarter/logfile')
@@ -492,8 +514,6 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                   {'fmri': fmri, 'log': log})
 
     def _migrate_volume(self, volume, host, path):
-        delay = 30
-        retries = 10
         src_path = self._get_volume_path(volume)
         dst_path = posixpath.join(path, volume['name'])
         hosts = self._get_host_addresses()
@@ -603,10 +623,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             self._svc_cleanup(fmri)
             return False
         service_history = None
-        service_retries = retries
+        service_retries = DEFAULT_RETRY_COUNT
         service_progress = 0
         while service_retries and not service_history:
-            greenthread.sleep(delay)
+            greenthread.sleep(DEFAULT_RETRY_DELAY)
             service_retries -= 1
             try:
                 service_props = self.nms.autosvc.get_child_props(fmri, '')
@@ -622,7 +642,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             progress = self._svc_progress(fmri)
             if progress > service_progress:
                 service_progress = progress
-                service_retries = retries
+                service_retries = DEFAULT_RETRY_COUNT
             LOG.info('Migration service %(fmri)s replication progress: '
                      '%(service_progress)s%%',
                      {'fmri': fmri, 'service_progress': service_progress})
@@ -640,13 +660,13 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                           {'volume': volume['name'], 'error': error})
         return volume_migrated
 
-    def migrate_volume(self, context, volume, host):
+    def migrate_volume(self, ctxt, volume, host):
         """Migrate the volume to the specified host.
 
         Returns a boolean indicating whether the migration occurred,
         as well as model_update.
 
-        :param context: Security context
+        :param ctxt: Security context
         :param volume: A dictionary describing the volume to migrate
         :param host: A dictionary describing the host to migrate to, where
                      host['host'] is its name, and host['capabilities'] is a
@@ -683,22 +703,23 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             return false_ret
         location = capabilities['location_info']
         try:
-            driver, san_host, san_path = location.split(':')
+            san_driver, san_host, san_path = location.split(':')
         except ValueError as error:
             LOG.error('Failed to parse location info %(location)s '
                       'for the destination host %(host)s: %(error)s',
                       {'location': location, 'host': host['host'],
                        'error': error})
             return false_ret
-        if not (driver and san_host and san_path):
+        if not (san_driver and san_host and san_path):
             LOG.error('Incomplete location info %(location)s '
                       'found for the destination host %(host)s',
                       {'location': location, 'host': host['host']})
             return false_ret
-        if driver != self.driver_name:
-            LOG.error('Unsupported storage driver %(driver)s '
+        if san_driver != self.san_driver:
+            LOG.error('Unsupported storage driver %(san_driver)s '
                       'found for the destination host %(host)s',
-                      {'driver': driver, 'host': host['host']})
+                      {'san_driver': san_driver,
+                       'host': host['host']})
             return false_ret
         storage_protocol = capabilities['storage_protocol']
         if storage_protocol != self.storage_protocol:
@@ -721,7 +742,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             return (True, None)
         return false_ret
 
-    def retype(self, context, volume, new_type, diff, host):
+    def retype(self, ctxt, volume, new_type, diff, host):
         """Convert the volume to be of the new type."""
         pass
 
@@ -761,7 +782,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         # actually helpful.
         return False
 
-    def revert_to_snapshot(self, context, volume, snapshot):
+    def revert_to_snapshot(self, ctxt, volume, snapshot):
         """Revert volume to snapshot."""
         snapshot_path = self._get_snapshot_path(snapshot)
         self.nms.snapshot.rollback(snapshot_path, '-R')
@@ -827,15 +848,15 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 return False
             raise
 
-    def create_export(self, context, volume, connector):
+    def create_export(self, ctxt, volume, connector):
         """Driver entry point to get the export info for a new volume."""
         pass
 
-    def ensure_export(self, context, volume):
+    def ensure_export(self, ctxt, volume):
         """Driver entry point to get the export info for an existing volume."""
         pass
 
-    def remove_export(self, context, volume):
+    def remove_export(self, ctxt, volume):
         """Driver entry point to remove an export for a volume."""
         pass
 
@@ -858,7 +879,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         portals = []
         addresses = self._get_host_addresses()
         for address in addresses:
-            portal = '%s:%s' % (address, self.portal_port)
+            portal = '%s:%s' % (address, self.san_port)
             portals.append(portal)
         LOG.debug('Configured iSCSI portals: %(portals)s',
                   {'portals': portals})
@@ -867,7 +888,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
     def _get_host_portal_groups(self):
         """Return NexentaStor iSCSI portal groups dictionary."""
         portal_groups = {}
-        default_portal = '%s:%s' % (self.san_host, self.portal_port)
+        default_portal = '%s:%s' % (self.san_host, self.san_port)
         host_portals = self._get_host_portals()
         host_portal_groups = self.nms.iscsitarget.list_tpg()
         for group in host_portal_groups:
@@ -903,7 +924,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
     def _get_host_targets(self):
         """Return NexentaStor iSCSI targets dictionary."""
         targets = {}
-        default_portal = '%s:%s' % (self.san_host, self.portal_port)
+        default_portal = '%s:%s' % (self.san_host, self.san_port)
         host_portal_groups = self._get_host_portal_groups()
         stmf_targets = self.nms.stmf.list_targets()
         for name in stmf_targets:
@@ -998,7 +1019,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                   {'volume': volume['name'], 'initiator': host_iqn})
         suffix = uuid.uuid4().hex
         host_targets = self._get_host_targets()
-        host_groups = ['All']
+        host_groups = [DEFAULT_HOST_GROUP]
         host_group = self._get_host_group(host_iqn)
         if host_group:
             host_groups.append(host_group)
@@ -1013,7 +1034,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             mapping_hg = mapping['host_group']
             mapping_tg = mapping['target_group']
             mapping_id = mapping['entry_number']
-            if mapping_tg == 'All':
+            if mapping_tg == DEFAULT_TARGET_GROUP:
                 LOG.debug('Delete LUN mapping %(id)s for target group %(tg)s',
                           {'id': mapping_id, 'tg': mapping_tg})
                 self.nms.scsidisk.remove_lun_mapping_entry(volume_path,
@@ -1194,7 +1215,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                            'volume': volume['name']})
                 return True
             host_iqn = connector['initiator']
-            host_groups.append('All')
+            host_groups.append(DEFAULT_HOST_GROUP)
             host_group = self._get_host_group(host_iqn)
             if host_group is not None:
                 host_groups.append(host_group)
@@ -1234,14 +1255,14 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                            'tg': mapping_tg, 'hg': mapping_hg})
         return info
 
-    def update_migrated_volume(self, context, volume, new_volume,
+    def update_migrated_volume(self, ctxt, volume, new_volume,
                                original_volume_status):
         """Return model update for migrated volume.
 
         This method should rename the back-end volume name on the
         destination host back to its original name on the source host.
 
-        :param context: The context of the caller
+        :param ctxt: The context of the caller
         :param volume: The original volume that was migrated to this backend
         :param new_volume: The migration volume object that was created on
                            this backend as part of the migration process
@@ -1287,53 +1308,23 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
 
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor appliance."""
-        stats = {'available': None, 'used': None}
-        payload = '|'.join(stats.keys())
-        props = self.nms.folder.get_child_props(self.root_path, payload)
-        for key in stats:
-            if not props.get(key):
-                LOG.error('Unable to get %(key)s statistics for %(path)s '
-                          'from properties %(props)s',
-                          {'path': self.root_path, 'props': props})
-                continue
-            text = '%sB' % props[key]
-            try:
-                value = strutils.string_to_bytes(text, return_int=True)
-                stats[key] = value
-            except ValueError as error:
-                LOG.error('Failed to convert text value %(text)s to '
-                          'bytes for the %(key)s property: %(error)s',
-                          {'text': text, 'key': key, 'error': error})
-        if None in stats.values():
-            allocated_capacity_gb = 'unknown'
-            free_capacity_gb = 'unknown'
-            total_capacity_gb = 'unknown'
-        else:
-            free_capacity_gb = stats['available'] // units.Gi
-            allocated_capacity_gb = stats['used'] // units.Gi
-            total_capacity_gb = free_capacity_gb + allocated_capacity_gb
-        provisioned_capacity_gb = total_volumes = 0
+        provisioned_capacity_gb = total_volumes = total_snapshots = 0
         ctxt = context.get_admin_context()
         volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
         for volume in volumes:
             provisioned_capacity_gb += volume['size']
             total_volumes += 1
-        volume_backend_name = (
-            self.configuration.safe_get('volume_backend_name'))
-        if not volume_backend_name:
-            LOG.error('Failed to get configured volume backend name')
-            volume_backend_name = '%(product)s_%(protocol)s' % {
-                'product': self.product_name,
-                'protocol': self.storage_protocol
-            }
+        snapshots = objects.SnapshotList.get_by_host(ctxt, self.host)
+        for snapshot in snapshots:
+            provisioned_capacity_gb += snapshot['volume_size']
+            total_snapshots += 1
         description = (
             self.configuration.safe_get('nexenta_dataset_description'))
         if not description:
-            description = '%(product)s %(host)s:%(pool)s/%(group)s' % {
+            description = '%(product)s %(host)s:%(path)s' % {
                 'product': self.product_name,
-                'host': self.configuration.nexenta_host,
-                'pool': self.configuration.nexenta_volume,
-                'group': self.configuration.nexenta_folder
+                'host': self.san_host,
+                'path': self.san_path
             }
         max_over_subscription_ratio = (
             self.configuration.safe_get('max_over_subscription_ratio'))
@@ -1342,24 +1333,32 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         if reserved_percentage is None:
             reserved_percentage = 0
         location_info = '%(driver)s:%(host)s:%(path)s' % {
-            'driver': self.driver_name,
-            'host': self.configuration.nexenta_host,
-            'path': self.root_path
+            'driver': self.san_driver,
+            'host': self.san_host,
+            'path': self.san_path
         }
         display_name = 'Capabilities of %(product)s %(protocol)s driver' % {
             'product': self.product_name,
             'protocol': self.storage_protocol
         }
-        visibility = 'public'
-        self._stats = {
+        if self.volume_compression:
+            compression = self.volume_compression
+        else:
+            compression = self.san_stat['compression']
+        if self.volume_dedup:
+            dedup = self.volume_dedup
+        else:
+            dedup = self.san_stat['dedup']
+        stats = {
+            'backend_state': 'down',
             'driver_version': self.VERSION,
             'vendor_name': self.vendor_name,
             'storage_protocol': self.storage_protocol,
-            'volume_backend_name': volume_backend_name,
+            'volume_backend_name': self.backend_name,
             'location_info': location_info,
             'description': description,
             'display_name': display_name,
-            'pool_name': self.configuration.nexenta_volume,
+            'pool_name': self.san_pool,
             'multiattach': True,
             'QoS_support': False,
             'consistencygroup_support': False,
@@ -1368,21 +1367,56 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             'sparse_copy_volume': True,
             'thin_provisioning_support': True,
             'thick_provisioning_support': True,
-            'total_capacity_gb': total_capacity_gb,
-            'allocated_capacity_gb': allocated_capacity_gb,
-            'free_capacity_gb': free_capacity_gb,
+            'total_capacity_gb': 'unknown',
+            'allocated_capacity_gb': 'unknown',
+            'free_capacity_gb': 'unknown',
             'provisioned_capacity_gb': provisioned_capacity_gb,
             'total_volumes': total_volumes,
+            'total_snapshots': total_snapshots,
             'max_over_subscription_ratio': max_over_subscription_ratio,
             'reserved_percentage': reserved_percentage,
-            'visibility': visibility,
-            'dedup': self.configuration.nexenta_dataset_dedup,
-            'compression': self.configuration.nexenta_dataset_compression,
-            'iscsi_target_portal_port': self.portal_port,
+            'dedup': dedup,
+            'compression': compression,
+            'iscsi_target_portal_port': self.san_port,
             'nms_url': self.nms.url
         }
+        stats_props = {
+            'free_capacity_gb': 'available',
+            'allocated_capacity_gb': 'used'
+        }
+        payload = '|'.join(stats_props.values())
+        try:
+            san_props = self.nms.folder.get_child_props(self.san_path, payload)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get backend statistics for host %(host)s '
+                      'and volume backend %(backend_name)s: %(error)s',
+                      {'host': self.host,
+                       'backend_name': self.backend_name,
+                       'error': error})
+        else:
+            stats['backend_state'] = 'up'
+            stats['total_capacity_gb'] = 0
+            for stat, prop in stats_props.items():
+                try:
+                    text = '%sB' % san_props[prop]
+                    size = strutils.string_to_bytes(text, return_int=True)
+                    stats[stat] = size // units.Gi
+                    stats['total_capacity_gb'] += stats[stat]
+                except (KeyError, TypeError, ValueError) as error:
+                    stats['total_capacity_gb'] = 'unknown'
+        self._stats = stats
         LOG.debug('Updated volume backend statistics for host %(host)s '
-                  'and volume backend %(volume_backend_name)s: %(stats)s',
+                  'and volume backend %(backend_name)s: %(stats)s',
                   {'host': self.host,
-                   'volume_backend_name': volume_backend_name,
+                   'backend_name': self.backend_name,
                    'stats': self._stats})
+
+    def _get_backend_name(self):
+        backend_name = self.configuration.safe_get('volume_backend_name')
+        if not backend_name:
+            LOG.error('Failed to get configured volume backend name')
+            backend_name = '%(product)s_%(protocol)s' % {
+                'product': self.product_name,
+                'protocol': self.storage_protocol
+            }
+        return backend_name

--- a/cinder/volume/drivers/nexenta/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/jsonrpc.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -27,6 +26,13 @@ from cinder import exception
 from cinder.i18n import _
 
 LOG = logging.getLogger(__name__)
+
+DEFAULT_REST_PORT = 8457
+HTTPS = 'https'
+HTTP = 'http'
+AUTO = 'auto'
+NFS = 'nfs'
+ISCSI = 'iscsi'
 
 
 class NmsException(exception.VolumeDriverException):
@@ -98,8 +104,6 @@ class NmsRequest(object):
         data = json.dumps(payload)
         message = None
         for attempt in range(attempts):
-            if attempt == attempts - 1:
-                raise NmsException(code='EAGAIN', message=message)
             if message:
                 self.nms.proxy.delay(attempt, message)
                 LOG.warning('NMS request retry %(attempt)s: post %(url)s '
@@ -196,6 +200,7 @@ class NmsRequest(object):
                       {'payload': payload, 'result': result})
 
             return result
+        raise NmsException(code='EAGAIN', message=message)
 
     def check_error(self, message):
         source = self.nms.proxy.url
@@ -269,14 +274,14 @@ class NmsProxy(object):
         self.lock = 'nms'
         self.auto = False
         self.scheme = conf.nexenta_rest_protocol
-        if self.scheme == 'auto':
+        if self.scheme == AUTO:
             self.auto = True
-            self.scheme = 'http'
+            self.scheme = HTTP
         if conf.nexenta_rest_address:
             self.host = conf.nexenta_rest_address
-        elif conf.nexenta_host:
+        elif proto == ISCSI and conf.nexenta_host:
             self.host = conf.nexenta_host
-        elif proto == 'nfs' and conf.nas_host:
+        elif proto == NFS and conf.nas_host:
             self.host = conf.nas_host
         else:
             message = (_('NexentaStor Rest API address is not defined, '
@@ -287,7 +292,7 @@ class NmsProxy(object):
         if conf.nexenta_rest_port:
             self.port = conf.nexenta_rest_port
         else:
-            self.port = 8457
+            self.port = DEFAULT_REST_PORT
         self.headers = {
             'Content-Type': 'application/json',
             'X-Requested-With': 'XMLHttpRequest'
@@ -387,7 +392,7 @@ class NmsProxy(object):
         if not signature:
             signature = self.host
         lock = '%s:%s' % (signature, self.path)
-        if six.PY3:
+        if isinstance(lock, six.text_type):
             lock = lock.encode('utf-8')
         self.lock = hashlib.md5(lock).hexdigest()
         LOG.debug('NMS coordination lock: %(lock)s',
@@ -397,8 +402,12 @@ class NmsProxy(object):
     def url(self):
         return '%s://%s:%s/rest/nms' % (self.scheme, self.host, self.port)
 
-    def delay(self, attempt, message):
-        interval = int(self.backoff_factor * (2 ** (attempt - 1)))
-        LOG.debug('Waiting for %(interval)s seconds, reason: %(message)s',
-                  {'interval': interval, 'message': message})
+    def delay(self, attempt, reason):
+        if self.retries > 0:
+            attempt %= self.retries
+            if attempt == 0:
+                attempt = self.retries
+        interval = float(self.backoff_factor * (2 ** (attempt - 1)))
+        LOG.debug('Waiting for %(interval)s seconds, reason: %(reason)s',
+                  {'interval': interval, 'reason': reason})
         greenthread.sleep(interval)

--- a/cinder/volume/drivers/nexenta/nexentaedge/iscsi.py
+++ b/cinder/volume/drivers/nexenta/nexentaedge/iscsi.py
@@ -1,5 +1,4 @@
-# Copyright 2015 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -51,13 +50,7 @@ class NexentaEdgeISCSIDriver(driver.ISCSIDriver):
         super(NexentaEdgeISCSIDriver, self).__init__(*args, **kwargs)
         if self.configuration:
             self.configuration.append_config_values(
-                options.NEXENTA_CONNECTION_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_ISCSI_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_DATASET_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_EDGE_OPTS)
+                options.NEXENTAEDGE_ISCSI_OPTS)
         if self.configuration.nexenta_rest_address:
             self.restapi_host = self.configuration.nexenta_rest_address
         else:
@@ -94,6 +87,10 @@ class NexentaEdgeISCSIDriver(driver.ISCSIDriver):
         self.iscsi_target_port = (self.configuration.
                                   nexenta_iscsi_target_portal_port)
         self.ha_vip = None
+
+    @staticmethod
+    def get_driver_options():
+        return options.NEXENTAEDGE_ISCSI_OPTS
 
     @property
     def backend_name(self):

--- a/cinder/volume/drivers/nexenta/nexentaedge/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/nexentaedge/jsonrpc.py
@@ -1,5 +1,4 @@
-# Copyright 2015 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain

--- a/cinder/volume/drivers/nexenta/nexentaedge/nbd.py
+++ b/cinder/volume/drivers/nexenta/nexentaedge/nbd.py
@@ -1,5 +1,4 @@
-# Copyright 2016 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -55,11 +54,7 @@ class NexentaEdgeNBDDriver(driver.VolumeDriver):
 
         if self.configuration:
             self.configuration.append_config_values(
-                options.NEXENTA_CONNECTION_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_DATASET_OPTS)
-            self.configuration.append_config_values(
-                options.NEXENTA_EDGE_OPTS)
+                options.NEXENTAEDGE_ISCSI_OPTS)
         self.restapi_protocol = self.configuration.nexenta_rest_protocol
         self.restapi_host = self.configuration.nexenta_rest_address
         self.restapi_port = self.configuration.nexenta_rest_port
@@ -75,6 +70,10 @@ class NexentaEdgeNBDDriver(driver.VolumeDriver):
         self.symlinks_dir = self.configuration.nexenta_nbd_symlinks_dir
         self.reserved_percentage = self.configuration.reserved_percentage
         LOG.debug('NexentaEdgeNBDDriver. Initialized successfully.')
+
+    @staticmethod
+    def get_driver_options():
+        return options.NEXENTAEDGE_ISCSI_OPTS
 
     @property
     def backend_name(self):

--- a/cinder/volume/drivers/nexenta/nfs.py
+++ b/cinder/volume/drivers/nexenta/nfs.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -14,13 +13,14 @@
 #    under the License.
 
 import datetime
-import difflib
 import hashlib
 import ipaddress
 import os
 import posixpath
 
 from eventlet import greenthread
+from os_brick.remotefs import remotefs
+from oslo_concurrency import processutils
 from oslo_log import log as logging
 from oslo_utils import strutils
 from oslo_utils import timeutils
@@ -32,11 +32,16 @@ from cinder.i18n import _
 from cinder import interface
 from cinder import objects
 from cinder.privsep import fs
+from cinder import utils as cinder_utils
 from cinder.volume.drivers.nexenta import jsonrpc
 from cinder.volume.drivers.nexenta import options
+from cinder.volume.drivers.nexenta import utils as nexenta_utils
 from cinder.volume.drivers import nfs
 
 LOG = logging.getLogger(__name__)
+
+DEFAULT_RETRY_COUNT = 10
+DEFAULT_RETRY_DELAY = 30
 
 
 @interface.volumedriver
@@ -72,10 +77,12 @@ class NexentaNfsDriver(nfs.NfsDriver):
               - Added informative exception messages for REST API.
               - Improved collection of backend statistics.
         1.4.1 - Added retries on timeouts, network connection errors,
-                SSL errors, proxy and NMS errors.
+              - SSL errors, proxy and NMS errors.
+        1.4.2 - Added flag backend_state to report backend status.
+              - Added retry on driver initialization failure.
     """
 
-    VERSION = '1.4.1'
+    VERSION = '1.4.2'
     CI_WIKI_NAME = 'Nexenta_CI'
 
     vendor_name = 'Nexenta'
@@ -83,7 +90,8 @@ class NexentaNfsDriver(nfs.NfsDriver):
     storage_protocol = 'NFS'
     driver_volume_type = 'nfs'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, execute=processutils.execute, *args, **kwargs):
+        self._remotefsclient = None
         super(NexentaNfsDriver, self).__init__(*args, **kwargs)
         if not self.configuration:
             message = (_('%(product_name)s %(storage_protocol)s '
@@ -91,10 +99,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
                        % {'product_name': self.product_name,
                           'storage_protocol': self.storage_protocol})
             raise jsonrpc.NmsException(code='EINVAL', message=message)
-        self.configuration.append_config_values(
-            options.NEXENTA_CONNECTION_OPTS)
-        self.configuration.append_config_values(options.NEXENTA_NFS_OPTS)
-        self.configuration.append_config_values(options.NEXENTA_DATASET_OPTS)
+        self.configuration.append_config_values(options.NEXENTASTOR4_NFS_OPTS)
         required_options = ['nas_host', 'nas_share_path', 'nexenta_user',
                             'nexenta_password']
         for option in required_options:
@@ -106,13 +111,38 @@ class NexentaNfsDriver(nfs.NfsDriver):
                               'storage_protocol': self.storage_protocol,
                               'option': option})
                 raise jsonrpc.NmsException(code='EINVAL', message=message)
+        root_helper = cinder_utils.get_root_helper()
+        mount_point_base = self.configuration.nexenta_mount_point_base
+        self.mount_point_base = os.path.realpath(mount_point_base)
+        nfs_options = self.configuration.safe_get('nfs_mount_options')
+        nas_options = self.configuration.safe_get('nas_mount_options')
+        if nfs_options and nas_options:
+            LOG.debug('Overriding NFS mount options: '
+                      'nfs_mount_options = "%(nfs_options)s" with '
+                      'nas_mount_options = "%(nas_options)s"',
+                      {'nfs_options': nfs_options,
+                       'nas_options': nas_options})
+        if nas_options:
+            self.mount_options = nas_options
+        elif nfs_options:
+            self.mount_options = nfs_options
+        else:
+            self.mount_options = None
+        self._remotefsclient = remotefs.RemoteFsClient(
+            self.driver_volume_type,
+            root_helper, execute=execute,
+            nfs_mount_point_base=self.mount_point_base,
+            nfs_mount_options=self.mount_options)
+        self.backend_name = self._get_backend_name()
         self.nms = None
-        self.driver_name = self.__class__.__name__
+        self.nas_stat = None
+        self.nas_driver = self.__class__.__name__
         self.nas_host = self.configuration.nas_host
-        self.root_path = self.configuration.nas_share_path
-        self.mount_point_base = self.configuration.nexenta_mount_point_base
+        self.nas_path = self.configuration.nas_share_path
+        self.nas_pool = self.nas_path.split('/')[0]
         self.volume_compression = (
             self.configuration.nexenta_dataset_compression)
+        self.volume_dedup = self.configuration.nexenta_dataset_dedup
         self.sparsed_volumes = self.configuration.nexenta_sparsed_volumes
         self.origin_snapshot_template = (
             self.configuration.nexenta_origin_snapshot_template)
@@ -122,48 +152,84 @@ class NexentaNfsDriver(nfs.NfsDriver):
             self.configuration.nexenta_migration_service_prefix)
         self.migration_throttle = (
             self.configuration.nexenta_migration_throttle)
+        self.nbmand = 'on' if self.configuration.nexenta_nbmand else 'off'
 
     @staticmethod
     def get_driver_options():
-        return (
-            options.NEXENTA_CONNECTION_OPTS +
-            options.NEXENTA_NFS_OPTS +
-            options.NEXENTA_DATASET_OPTS
-        )
+        return options.NEXENTASTOR4_NFS_OPTS
 
-    def do_setup(self, context):
-        self.nms = jsonrpc.NmsProxy(self.driver_volume_type,
-                                    self.root_path,
-                                    self.configuration)
+    def do_setup(self, ctxt):
+        while not self._do_setup():
+            greenthread.sleep(DEFAULT_RETRY_DELAY)
+
+    def _do_setup(self):
+        try:
+            self.nms = jsonrpc.NmsProxy(self.driver_volume_type,
+                                        self.nas_path,
+                                        self.configuration)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to initialize RESTful API for backend '
+                      '%(backend_name)s on host %(host)s: %(error)s',
+                      {'backend_name': self.backend_name,
+                       'host': self.host,
+                       'error': error})
+            return False
+        return True
 
     def check_for_setup_error(self):
+        while not self._check_for_setup_error():
+            greenthread.sleep(DEFAULT_RETRY_DELAY)
+
+    def _check_for_setup_error(self):
         """Check root filesystem, NFS service and NFS share."""
-        if not self.nms.folder.object_exists(self.root_path):
-            message = (_('NFS root filesystem %(path)s not found')
-                       % {'path': self.root_path})
-            raise jsonrpc.NmsException(code='ENOENT', message=message)
-        filesystem = self.nms.folder.get_child_props(self.root_path, '')
-        if filesystem['mountpoint'] == 'none':
-            message = (_('NFS root filesystem %(path)s is not writable')
-                       % {'path': self.root_path})
-            raise jsonrpc.NefException(code='ENOENT', message=message)
-        if filesystem['mounted'] == 'no':
-            message = (_('NFS root filesystem %(path)s is not mounted')
-                       % {'path': self.root_path})
-            raise jsonrpc.NefException(code='ENOTDIR', message=message)
-        if filesystem['nbmand'] == 'on':
-            self.nms.folder.set_child_prop(self.root_path, 'nbmand', 'off')
         fmri = 'svc:/network/nfs/server:default'
-        state = self.nms.netsvc.get_state(fmri)
-        if state != 'online':
-            message = (_('NFS service is not online: %(state)s')
-                       % {'state': state})
-            raise jsonrpc.NmsException(code='ESRCH', message=message)
-        shared = self.nms.netstorsvc.is_folder_shared(fmri, self.root_path)
+        try:
+            self.nas_stat = self.nms.folder.get_child_props(self.nas_path, '')
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get stat of SAN path %(nas_path)s: %(error)s',
+                      {'nas_path': self.nas_path, 'error': error})
+            return False
+        if self.nas_stat['mountpoint'] == 'none':
+            LOG.error('NAS path %(nas_path)s is not writable',
+                      {'nas_path': self.nas_path})
+            return False
+        if self.nas_stat['mounted'] == 'no':
+            LOG.error('NAS path %(nas_path)s is not mounted',
+                      {'nas_path': self.nas_path})
+            return False
+        try:
+            service_state = self.nms.netsvc.get_state(fmri)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get state of NFS service: %(error)s',
+                      {'error': error})
+            return False
+        if service_state != 'online':
+            LOG.error('NFS service is not online: %(state)s',
+                      {'state': service_state})
+            return False
+        try:
+            shared = self.nms.netstorsvc.is_folder_shared(fmri, self.nas_path)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get state of NFS share %(share)s: %(error)s',
+                      {'share': self.nas_path, 'error': error})
+            return False
         if not shared:
-            message = (_('NFS root filesystem %(path)s is not shared')
-                       % {'path': self.root_path})
-            raise jsonrpc.NmsException(code='ENOENT', message=message)
+            LOG.error('NAS path %(nas_path)s is not shared',
+                      {'nas_path': self.nas_path})
+            return False
+        if self.nas_stat['nbmand'] == self.nbmand:
+            return True
+        try:
+            self.nms.folder.set_child_prop(self.nas_path, 'nbmand',
+                                           self.nbmand)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to set NAS path %(nas_path)s property nbmand '
+                      'to value %(nbmand)s: %(error)s',
+                      {'nas_path': self.nas_path, 'nbmand': self.nbmand,
+                       'error': error})
+            return False
+        self.nas_stat['nbmand'] = self.nbmand
+        return True
 
     def create_volume(self, volume):
         """Creates a volume.
@@ -172,10 +238,10 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :return: model update dict for volume reference
         """
         volume_path = self._get_volume_path(volume)
-        volume_options = {
-            'compression': self.volume_compression
-        }
-        self.nms.folder.create_with_props(self.root_path,
+        volume_options = {}
+        if self.volume_compression:
+            volume_options['compression'] = self.volume_compression
+        self.nms.folder.create_with_props(self.nas_path,
                                           volume['name'],
                                           volume_options)
         try:
@@ -207,20 +273,20 @@ class NexentaNfsDriver(nfs.NfsDriver):
         finally:
             self._unmount_volume(volume)
 
-    def copy_image_to_volume(self, context, volume, image_service, image_id):
+    def copy_image_to_volume(self, ctxt, volume, image_service, image_id):
         LOG.debug('Copy image %(image)s to volume %(volume)s',
                   {'image': image_id, 'volume': volume['name']})
         self._mount_volume(volume)
         super(NexentaNfsDriver, self).copy_image_to_volume(
-            context, volume, image_service, image_id)
+            ctxt, volume, image_service, image_id)
         self._unmount_volume(volume)
 
-    def copy_volume_to_image(self, context, volume, image_service, image_meta):
+    def copy_volume_to_image(self, ctxt, volume, image_service, image_meta):
         LOG.debug('Copy volume %(volume)s to image %(image)s',
                   {'volume': volume['name'], 'image': image_meta['id']})
         self._mount_volume(volume)
         super(NexentaNfsDriver, self).copy_volume_to_image(
-            context, volume, image_service, image_meta)
+            ctxt, volume, image_service, image_meta)
         self._unmount_volume(volume)
 
     def extend_volume(self, volume, new_size):
@@ -267,7 +333,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
             return
         template = self.origin_snapshot_template
         parent_path, snapshot_name = origin.split('@')
-        if not self._match_template(template, snapshot_name):
+        if not nexenta_utils.match_template(template, snapshot_name):
             return
         try:
             self.nms.snapshot.destroy(origin, '-d')
@@ -354,7 +420,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
                           'retrying unmount %(share)s from %(path)s',
                           {'attempt': attempt, 'error': error,
                            'share': share, 'path': path})
-                greenthread.sleep(1)
+                greenthread.sleep(DEFAULT_RETRY_DELAY)
         self._delete(path)
 
     def _delete(self, path):
@@ -381,15 +447,15 @@ class NexentaNfsDriver(nfs.NfsDriver):
                 return
         self._ensure_share_unmounted(share)
 
-    def create_export(self, context, volume, connector):
+    def create_export(self, ctxt, volume, connector):
         """Driver entry point to get the export info for a new volume."""
         pass
 
-    def ensure_export(self, context, volume):
+    def ensure_export(self, ctxt, volume):
         """Driver entry point to get the export info for an existing volume."""
         pass
 
-    def remove_export(self, context, volume):
+    def remove_export(self, ctxt, volume):
         """Driver entry point to remove an export for a volume."""
         pass
 
@@ -418,19 +484,8 @@ class NexentaNfsDriver(nfs.NfsDriver):
             'export': share,
             'name': 'volume'
         }
-        nfs_options = self.configuration.safe_get('nfs_mount_options')
-        nas_options = self.configuration.safe_get('nas_mount_options')
-        if nfs_options and nas_options:
-            LOG.debug('Overriding NFS mount options for volume %(volume)s: '
-                      'nfs_mount_options = "%(nfs_options)s" with '
-                      'nas_mount_options = "%(nas_options)s"',
-                      {'volume': volume['name'],
-                       'nfs_options': nfs_options,
-                       'nas_options': nas_options})
-        if nas_options:
-            data['options'] = '-o %s' % nas_options
-        elif nfs_options:
-            data['options'] = '-o %s' % nfs_options
+        if self.mount_options:
+            data['options'] = '-o %s' % self.mount_options
         info = {
             'driver_volume_type': self.driver_volume_type,
             'mount_point_base': self.mount_point_base,
@@ -460,10 +515,9 @@ class NexentaNfsDriver(nfs.NfsDriver):
         return None
 
     def _svc_state(self, fmri, state):
-        retries = 10
-        delay = 30
+        retries = DEFAULT_RETRY_COUNT
         while retries:
-            greenthread.sleep(delay)
+            greenthread.sleep(DEFAULT_RETRY_DELAY)
             retries -= 1
             try:
                 status = self.nms.autosvc.get_state(fmri)
@@ -491,8 +545,8 @@ class NexentaNfsDriver(nfs.NfsDriver):
                           '%(fmri)s to %(state)s: %(error)s',
                           {'fmri': fmri, 'state': state, 'error': error})
         LOG.error('Unable to change state of migration service %(fmri)s '
-                  'to %(state)s: maximum retries exceeded',
-                  {'fmri': fmri, 'state': state})
+                  'to %(state)s: maximum retries exceeded (%(retries)s)',
+                  {'fmri': fmri, 'state': state, 'retries': retries})
         return False
 
     def _svc_progress(self, fmri):
@@ -607,7 +661,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
                 except jsonrpc.NmsException as error:
                     if error.code == 'ENOENT':
                         break
-                greenthread.sleep(30)
+                greenthread.sleep(DEFAULT_RETRY_DELAY)
         if migrated:
             return
         path = props.get('restarter/logfile')
@@ -625,8 +679,6 @@ class NexentaNfsDriver(nfs.NfsDriver):
                   {'fmri': fmri, 'log': log})
 
     def _migrate_volume(self, volume, host, path):
-        delay = 30
-        retries = 10
         src_path = self._get_volume_path(volume)
         dst_path = posixpath.join(path, volume['name'])
         hosts = self._get_host_addresses()
@@ -736,10 +788,10 @@ class NexentaNfsDriver(nfs.NfsDriver):
             self._svc_cleanup(fmri)
             return False
         service_history = None
-        service_retries = retries
+        service_retries = DEFAULT_RETRY_COUNT
         service_progress = 0
         while service_retries and not service_history:
-            greenthread.sleep(delay)
+            greenthread.sleep(DEFAULT_RETRY_DELAY)
             service_retries -= 1
             try:
                 service_props = self.nms.autosvc.get_child_props(fmri, '')
@@ -755,7 +807,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
             progress = self._svc_progress(fmri)
             if progress > service_progress:
                 service_progress = progress
-                service_retries = retries
+                service_retries = DEFAULT_RETRY_COUNT
             LOG.info('Migration service %(fmri)s replication progress: '
                      '%(service_progress)s%%',
                      {'fmri': fmri, 'service_progress': service_progress})
@@ -773,13 +825,13 @@ class NexentaNfsDriver(nfs.NfsDriver):
                           {'volume': volume['name'], 'error': error})
         return volume_migrated
 
-    def migrate_volume(self, context, volume, host):
+    def migrate_volume(self, ctxt, volume, host):
         """Migrate the volume to the specified host.
 
         Returns a boolean indicating whether the migration occurred,
         as well as model_update.
 
-        :param context: Security context
+        :param ctxt: Security context
         :param volume: A dictionary describing the volume to migrate
         :param host: A dictionary describing the host to migrate to, where
                      host['host'] is its name, and host['capabilities'] is a
@@ -816,22 +868,23 @@ class NexentaNfsDriver(nfs.NfsDriver):
             return false_ret
         location = capabilities['location_info']
         try:
-            driver, nas_host, nas_path = location.split(':')
+            nas_driver, nas_host, nas_path = location.split(':')
         except ValueError as error:
             LOG.error('Failed to parse location info %(location)s '
                       'for the destination host %(host)s: %(error)s',
                       {'location': location, 'host': host['host'],
                        'error': error})
             return false_ret
-        if not (driver and nas_host and nas_path):
+        if not (nas_driver and nas_host and nas_path):
             LOG.error('Incomplete location info %(location)s '
                       'found for the destination host %(host)s',
                       {'location': location, 'host': host['host']})
             return false_ret
-        if driver != self.driver_name:
-            LOG.error('Unsupported storage driver %(driver)s '
+        if nas_driver != self.nas_driver:
+            LOG.error('Unsupported storage driver %(nas_driver)s '
                       'found for the destination host %(host)s',
-                      {'driver': driver, 'host': host['host']})
+                      {'nas_driver': nas_driver,
+                       'host': host['host']})
             return false_ret
         storage_protocol = capabilities['storage_protocol']
         if storage_protocol != self.storage_protocol:
@@ -854,14 +907,14 @@ class NexentaNfsDriver(nfs.NfsDriver):
             return (True, None)
         return false_ret
 
-    def update_migrated_volume(self, context, volume, new_volume,
+    def update_migrated_volume(self, ctxt, volume, new_volume,
                                original_volume_status):
         """Return model update for migrated volume.
 
         This method should rename the back-end volume name on the
         destination host back to its original name on the source host.
 
-        :param context: The context of the caller
+        :param ctxt: The context of the caller
         :param volume: The original volume that was migrated to this backend
         :param new_volume: The migration volume object that was created on
                            this backend as part of the migration process
@@ -895,7 +948,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         model_update = {'_name_id': name_id}
         return model_update
 
-    def retype(self, context, volume, new_type, diff, host):
+    def retype(self, ctxt, volume, new_type, diff, host):
         """Convert the volume to be of the new type."""
         pass
 
@@ -923,7 +976,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         # actually helpful.
         return False
 
-    def revert_to_snapshot(self, context, volume, snapshot):
+    def revert_to_snapshot(self, ctxt, volume, snapshot):
         """Revert volume to snapshot."""
         snapshot_path = self._get_snapshot_path(snapshot)
         self.nms.snapshot.rollback(snapshot_path, '-Rf')
@@ -958,7 +1011,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: volume reference
         """
         share = self._get_volume_share(volume)
-        if six.PY3:
+        if isinstance(share, six.text_type):
             share = share.encode('utf-8')
         path = hashlib.md5(share).hexdigest()
         return os.path.join(self.mount_point_base, path)
@@ -983,53 +1036,23 @@ class NexentaNfsDriver(nfs.NfsDriver):
 
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor appliance."""
-        pool_name = self.root_path.split('/')[0]
-        stats = {'available': None, 'used': None}
-        payload = '|'.join(stats.keys())
-        props = self.nms.folder.get_child_props(self.root_path, payload)
-        for key in stats:
-            if not props.get(key):
-                LOG.error('Unable to get %(key)s statistics for %(path)s '
-                          'from properties %(props)s',
-                          {'path': self.root_path, 'props': props})
-                continue
-            text = '%sB' % props[key]
-            try:
-                value = strutils.string_to_bytes(text, return_int=True)
-                stats[key] = value
-            except ValueError as error:
-                LOG.error('Failed to convert text value %(text)s to '
-                          'bytes for the %(key)s property: %(error)s',
-                          {'text': text, 'key': key, 'error': error})
-        if None in stats.values():
-            allocated_capacity_gb = 'unknown'
-            free_capacity_gb = 'unknown'
-            total_capacity_gb = 'unknown'
-        else:
-            free_capacity_gb = stats['available'] // units.Gi
-            allocated_capacity_gb = stats['used'] // units.Gi
-            total_capacity_gb = free_capacity_gb + allocated_capacity_gb
-        provisioned_capacity_gb = total_volumes = 0
+        provisioned_capacity_gb = total_volumes = total_snapshots = 0
         ctxt = context.get_admin_context()
         volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
         for volume in volumes:
             provisioned_capacity_gb += volume['size']
             total_volumes += 1
-        volume_backend_name = (
-            self.configuration.safe_get('volume_backend_name'))
-        if not volume_backend_name:
-            LOG.error('Failed to get configured volume backend name')
-            volume_backend_name = '%(product)s_%(protocol)s' % {
-                'product': self.product_name,
-                'protocol': self.storage_protocol
-            }
+        snapshots = objects.SnapshotList.get_by_host(ctxt, self.host)
+        for snapshot in snapshots:
+            provisioned_capacity_gb += snapshot['volume_size']
+            total_snapshots += 1
         description = (
             self.configuration.safe_get('nexenta_dataset_description'))
         if not description:
             description = '%(product)s %(host)s:%(path)s' % {
                 'product': self.product_name,
-                'host': self.configuration.nas_host,
-                'path': self.configuration.nas_share_path
+                'host': self.nas_host,
+                'path': self.nas_path
             }
         max_over_subscription_ratio = (
             self.configuration.safe_get('max_over_subscription_ratio'))
@@ -1038,24 +1061,32 @@ class NexentaNfsDriver(nfs.NfsDriver):
         if reserved_percentage is None:
             reserved_percentage = 0
         location_info = '%(driver)s:%(host)s:%(path)s' % {
-            'driver': self.driver_name,
-            'host': self.configuration.nas_host,
-            'path': self.configuration.nas_share_path
+            'driver': self.nas_driver,
+            'host': self.nas_host,
+            'path': self.nas_path
         }
         display_name = 'Capabilities of %(product)s %(protocol)s driver' % {
             'product': self.product_name,
             'protocol': self.storage_protocol
         }
-        visibility = 'public'
-        self._stats = {
+        if self.volume_compression:
+            compression = self.volume_compression
+        else:
+            compression = self.nas_stat['compression']
+        if self.volume_dedup:
+            dedup = self.volume_dedup
+        else:
+            dedup = self.nas_stat['dedup']
+        stats = {
+            'backend_state': 'down',
             'driver_version': self.VERSION,
             'vendor_name': self.vendor_name,
             'storage_protocol': self.storage_protocol,
-            'volume_backend_name': volume_backend_name,
+            'volume_backend_name': self.backend_name,
             'location_info': location_info,
             'description': description,
             'display_name': display_name,
-            'pool_name': pool_name,
+            'pool_name': self.nas_pool,
             'multiattach': True,
             'QoS_support': False,
             'consistencygroup_support': False,
@@ -1064,34 +1095,62 @@ class NexentaNfsDriver(nfs.NfsDriver):
             'sparse_copy_volume': True,
             'thin_provisioning_support': True,
             'thick_provisioning_support': True,
-            'total_capacity_gb': total_capacity_gb,
-            'allocated_capacity_gb': allocated_capacity_gb,
-            'free_capacity_gb': free_capacity_gb,
+            'total_capacity_gb': 'unknown',
+            'allocated_capacity_gb': 'unknown',
+            'free_capacity_gb': 'unknown',
             'provisioned_capacity_gb': provisioned_capacity_gb,
             'total_volumes': total_volumes,
+            'total_snapshots': total_snapshots,
             'max_over_subscription_ratio': max_over_subscription_ratio,
             'reserved_percentage': reserved_percentage,
-            'visibility': visibility,
-            'dedup': self.configuration.nexenta_dataset_dedup,
-            'compression': self.configuration.nexenta_dataset_compression,
+            'dedup': dedup,
+            'compression': compression,
             'nms_url': self.nms.url
         }
+        stats_props = {
+            'free_capacity_gb': 'available',
+            'allocated_capacity_gb': 'used'
+        }
+        payload = '|'.join(stats_props.values())
+        try:
+            nas_props = self.nms.folder.get_child_props(self.nas_path, payload)
+        except jsonrpc.NmsException as error:
+            LOG.error('Failed to get backend statistics for host %(host)s '
+                      'and volume backend %(backend_name)s: %(error)s',
+                      {'host': self.host,
+                       'backend_name': self.backend_name,
+                       'error': error})
+        else:
+            stats['backend_state'] = 'up'
+            stats['total_capacity_gb'] = 0
+            for stat, prop in stats_props.items():
+                try:
+                    text = '%sB' % nas_props[prop]
+                    size = strutils.string_to_bytes(text, return_int=True)
+                    stats[stat] = size // units.Gi
+                    stats['total_capacity_gb'] += stats[stat]
+                except (KeyError, TypeError, ValueError) as error:
+                    stats['total_capacity_gb'] = 'unknown'
+        self._stats = stats
         LOG.debug('Updated volume backend statistics for host %(host)s '
-                  'and volume backend %(volume_backend_name)s: %(stats)s',
+                  'and volume backend %(backend_name)s: %(stats)s',
                   {'host': self.host,
-                   'volume_backend_name': volume_backend_name,
+                   'backend_name': self.backend_name,
                    'stats': self._stats})
 
     def _get_volume_path(self, volume):
         """Return ZFS datset path for the volume."""
-        return posixpath.join(self.root_path, volume['name'])
+        volume_name = volume['name']
+        volume_path = posixpath.join(self.nas_path, volume_name)
+        return volume_path
 
     def _get_snapshot_path(self, snapshot):
         """Return ZFS snapshot path for the snapshot."""
         volume_name = snapshot['volume_name']
         snapshot_name = snapshot['name']
-        volume_path = posixpath.join(self.root_path, volume_name)
-        return '%s@%s' % (volume_path, snapshot_name)
+        volume_path = posixpath.join(self.nas_path, volume_name)
+        snapshot_path = '%s@%s' % (volume_path, snapshot_name)
+        return snapshot_path
 
     def _get_host_addresses(self):
         """Return NexentaStor IP addresses list."""
@@ -1107,19 +1166,12 @@ class NexentaNfsDriver(nfs.NfsDriver):
                   {'addresses': addresses})
         return addresses
 
-    @staticmethod
-    def _match_template(template, name):
-        sequence = difflib.SequenceMatcher(None, name, template)
-        added = deleted = result = ''
-        for tag, a1, a2, b1, b2 in sequence.get_opcodes():
-            if tag == 'equal':
-                result += ''.join(sequence.a[a1:a2])
-            elif tag == 'delete':
-                deleted += ''.join(sequence.a[a1:a2])
-            elif tag == 'insert':
-                added += ''.join(sequence.b[b1:b2])
-            elif tag == 'replace':
-                result += ''.join(sequence.b[b1:b2])
-        if result == template and not (added or deleted):
-            return True
-        return False
+    def _get_backend_name(self):
+        backend_name = self.configuration.safe_get('volume_backend_name')
+        if not backend_name:
+            LOG.error('Failed to get configured volume backend name')
+            backend_name = '%(product)s_%(protocol)s' % {
+                'product': self.product_name,
+                'protocol': self.storage_protocol
+            }
+        return backend_name

--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -26,15 +25,21 @@ import six
 from cinder import context
 from cinder import coordination
 from cinder.i18n import _
+from cinder.image import image_utils
 from cinder import interface
 from cinder import objects
 from cinder.volume import driver
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 from cinder.volume.drivers.nexenta import options
+from cinder.volume.drivers.nexenta import utils as nexenta_utils
 from cinder.volume import volume_types
 from cinder.volume import volume_utils
 
 LOG = logging.getLogger(__name__)
+
+DEFAULT_ISCSI_PORT = 3260
+DEFAULT_HOST_GROUP = 'all'
+DEFAULT_TARGET_GROUP = 'all'
 
 
 @interface.volumedriver
@@ -77,9 +82,20 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 Added support for volume type extra specs.
                 Added vendor capabilities support.
         1.4.5 - Added report discard support.
+        1.4.6 - Added workaround for pagination.
+        1.4.7 - Improved error messages.
+              - Improved compatibility with initial driver versions.
+              - Added throttle for storage assisted volume migration.
+        1.4.8 - Fixed renaming volume after generic migration.
+              - Fixed properties for volumes created from snapshot.
+              - Added workaround for referenced reservation size.
+              - Allow retype volume to another provisioning type.
+        1.4.9 - Added image caching using clone_image method.
+        1.5.0 - Added flag backend_state to report backend status.
+              - Added retry on driver initialization failure.
     """
 
-    VERSION = '1.4.5'
+    VERSION = '1.5.0'
     CI_WIKI_NAME = "Nexenta_CI"
 
     vendor_name = 'Nexenta'
@@ -96,66 +112,243 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                           'storage_protocol': self.storage_protocol})
             raise jsonrpc.NefException(code='ENODATA', message=message)
         self.configuration.append_config_values(
-            options.NEXENTA_CONNECTION_OPTS)
-        self.configuration.append_config_values(
-            options.NEXENTA_ISCSI_OPTS)
-        self.configuration.append_config_values(
-            options.NEXENTA_DATASET_OPTS)
+            options.NEXENTASTOR5_ISCSI_OPTS)
         self.nef = None
-        self.driver_name = self.__class__.__name__
+        self.san_stat = None
+        self.backend_name = self._get_backend_name()
+        self.san_driver = self.__class__.__name__
+        self.image_cache = self.configuration.nexenta_image_cache
         self.target_prefix = self.configuration.nexenta_target_prefix
         self.target_group_prefix = (
             self.configuration.nexenta_target_group_prefix)
+        self.block_size = self.configuration.nexenta_blocksize
         self.host_group_prefix = self.configuration.nexenta_host_group_prefix
         self.luns_per_target = self.configuration.nexenta_luns_per_target
         self.lu_writebackcache_disabled = (
             self.configuration.nexenta_lu_writebackcache_disabled)
-        self.iscsi_host = self.configuration.nexenta_host
-        self.pool = self.configuration.nexenta_volume
-        self.volume_group = self.configuration.nexenta_volume_group
-        self.portal_port = self.configuration.nexenta_iscsi_target_portal_port
+        self.san_host = self.configuration.nexenta_host
+        self.san_port = self.configuration.nexenta_iscsi_target_portal_port
+        self.san_path = posixpath.join(
+            self.configuration.nexenta_volume,
+            self.configuration.nexenta_volume_group)
+        self.san_pool = self.configuration.nexenta_volume
         self.portals = self.configuration.nexenta_iscsi_target_portals
-        self.iscsi_target_portal_port = (
-            self.configuration.nexenta_iscsi_target_portal_port)
-        self.root_path = posixpath.join(self.pool, self.volume_group)
         self.group_snapshot_template = (
             self.configuration.nexenta_group_snapshot_template)
         self.origin_snapshot_template = (
             self.configuration.nexenta_origin_snapshot_template)
+        self.cache_image_template = (
+            self.configuration.nexenta_cache_image_template)
+        self.cache_snapshot_template = (
+            self.configuration.nexenta_cache_snapshot_template)
+        self.migration_service_prefix = (
+            self.configuration.nexenta_migration_service_prefix)
+        self.migration_throttle = (
+            self.configuration.nexenta_migration_throttle)
 
     @staticmethod
     def get_driver_options():
-        return (
-            options.NEXENTA_CONNECTION_OPTS +
-            options.NEXENTA_ISCSI_OPTS +
-            options.NEXENTA_DATASET_OPTS
-        )
+        return options.NEXENTASTOR5_ISCSI_OPTS
 
-    def do_setup(self, context):
-        self.nef = jsonrpc.NefProxy(self.driver_volume_type,
-                                    self.root_path,
-                                    self.configuration)
+    def do_setup(self, ctxt):
+        retries = 0
+        while not self._do_setup():
+            retries += 1
+            self.nef.delay(retries)
+
+    def _do_setup(self):
+        try:
+            self.nef = jsonrpc.NefProxy(self.driver_volume_type,
+                                        self.san_pool,
+                                        self.san_path,
+                                        self.configuration)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to initialize RESTful API for backend '
+                      '%(backend_name)s on host %(host)s: %(error)s',
+                      {'backend_name': self.backend_name,
+                       'host': self.host,
+                       'error': error})
+            return False
+        return True
 
     def check_for_setup_error(self):
+        retries = 0
+        while not self._check_for_setup_error():
+            retries += 1
+            self.nef.delay(retries)
+
+    def _check_for_setup_error(self):
         """Check root volume group and iSCSI target service."""
+        payload = {'fields': 'path'}
         try:
-            self.nef.volumegroups.get(self.root_path)
+            self.nef.filesystems.get(self.san_pool, payload)
         except jsonrpc.NefException as error:
-            if error.code != 'ENOENT':
-                raise
-            block_size = self.configuration.nexenta_ns5_blocksize
-            if block_size < 512:
-                block_size *= units.Ki
-            payload = {
-                'path': self.root_path,
-                'volumeBlockSize': block_size
-            }
-            self.nef.volumegroups.create(payload)
-        service = self.nef.services.get('iscsit')
+            LOG.error('Failed to get stat of SAN pool %(san_pool)s: %(error)s',
+                      {'san_pool': self.san_pool, 'error': error})
+            return False
+        specs = self.nef.volumes.properties
+        names = [spec['api'] for spec in specs if 'api' in spec]
+        names.remove('sparseVolume')
+        fields = ','.join(names)
+        payload = {'fields': fields}
+        try:
+            self.san_stat = self.nef.volumegroups.get(self.san_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to get stat of SAN path %(san_path)s: %(error)s',
+                      {'san_path': self.san_path, 'error': error})
+            if error.code == 'ENOENT':
+                self._create_san_path()
+            return False
+        if not self.san_stat:
+            return False
+        try:
+            service = self.nef.services.get('iscsit')
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to get state of iSCSI target service: %(error)s',
+                      {'error': error})
+            return False
         if service['state'] != 'online':
-            message = (_('iSCSI target service is not online: %(state)s')
-                       % {'state': service['state']})
-            raise jsonrpc.NefException(code='ESRCH', message=message)
+            LOG.error('iSCSI target service is not online: %(state)s',
+                      {'state': service['state']})
+            return False
+        return True
+
+    def _create_san_path(self):
+        payload = {
+            'path': self.san_path,
+            'volumeBlockSize': self.block_size
+        }
+        try:
+            self.nef.volumegroups.create(payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to create SAN path %(san_path)s: %(error)s',
+                      {'san_path': self.san_path, 'error': error})
+
+    def _get_volume_reservation(self, volume):
+        """Calculates the correct reservation size for given volume size.
+
+        Its purpose is to reserve additional space for volume metadata
+        so volume don't unexpectedly run out of room. This function is
+        a copy of the volsize_to_reservation function in libzfs_dataset.c
+
+        :param volume: volume reference
+        :returns: reservation size
+        """
+        volume_path = self._get_volume_path(volume)
+        payload = {'fields': 'volumeBlockSize,volumeSize,dataCopies'}
+        volume_specs = self.nef.volumes.get(volume_path, payload)
+        block_size = volume_specs['volumeBlockSize']
+        volume_size = volume_specs['volumeSize']
+        data_copies = volume_specs['dataCopies']
+        reservation = volume_size
+        numdb = 7
+        dn_max_indblkshift = 17
+        spa_blkptrshift = 7
+        spa_dvas_per_bp = 3
+        dnodes_per_level_shift = dn_max_indblkshift - spa_blkptrshift
+        dnodes_per_level = 1 << dnodes_per_level_shift
+        nblocks = reservation // block_size
+        while nblocks > 1:
+            nblocks += dnodes_per_level - 1
+            nblocks //= dnodes_per_level
+            numdb += nblocks
+        numdb *= min(spa_dvas_per_bp, data_copies + 1)
+        reservation *= data_copies
+        numdb *= 1 << dn_max_indblkshift
+        reservation += numdb
+        volume_meta = reservation - volume_size
+        LOG.debug('Reservation size for raw volume %(volume)s: '
+                  '%(reservation)s, volume data size: %(volume_size)s '
+                  'and volume metadata size: %(volume_meta)s',
+                  {'volume': volume['name'], 'reservation': reservation,
+                   'volume_size': volume_size, 'volume_meta': volume_meta})
+        return reservation
+
+    def _set_volume_reservation(self, volume, reservation=None):
+        if reservation is None:
+            reservation = self._get_volume_reservation(volume)
+        volume_path = self._get_volume_path(volume)
+        payload = {'fields': 'referencedReservationSize,volumeSize'}
+        volume_specs = self.nef.volumes.get(volume_path, payload)
+        volume_reservation = volume_specs['referencedReservationSize']
+        volume_size = volume_specs['volumeSize']
+        if volume_reservation == reservation:
+            return
+        if not reservation:
+            payload = {'referencedReservationSize': reservation}
+            try:
+                self.nef.volumes.set(volume_path, payload)
+            except jsonrpc.NefException as error:
+                LOG.error('Failed to reset volume reservation size from '
+                          '%(volume_reservation)s to %(reservation)s '
+                          'for volume %(volume)s: %(error)s',
+                          {'volume_reservation': volume_reservation,
+                           'reservation': reservation,
+                           'volume': volume['name'],
+                           'error': error})
+                raise
+            return
+        # Workaround for NEX-21586
+        connectors = self._get_volume_connectors(volume)
+        if connectors:
+            code = 'EINVAL'
+            message = (_('Volume provisioning type cannot be changed '
+                         'for attached volume %(volume)s, volume '
+                         'connectors are: %(connectors)s')
+                       % {'volume': volume['name'],
+                          'connectors': connectors})
+            raise jsonrpc.NefException(code=code, message=message)
+        temporay_size = nexenta_utils.roundup(reservation, units.Gi)
+        payload = {'volumeSize': temporay_size}
+        try:
+            self.nef.volumes.set(volume_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to temporarily change volume size from '
+                      '%(volume_size)s to %(temporay_size)s for volume '
+                      '%(volume)s: %(error)s',
+                      {'volume_size': volume_size,
+                       'temporay_size': temporay_size,
+                       'volume': volume['name'],
+                       'error': error})
+            raise
+        payload = {'referencedReservationSize': reservation}
+        try:
+            self.nef.volumes.set(volume_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to change volume reservation size from '
+                      '%(volume_reservation)s to %(reservation)s '
+                      'for volume %(volume)s: %(error)s',
+                      {'volume_reservation': volume_reservation,
+                       'reservation': reservation,
+                       'volume': volume['name'],
+                       'error': error})
+            raise
+        payload = {'volumeSize': volume_size}
+        try:
+            self.nef.volumes.set(volume_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to restore original volume size from '
+                      '%(temporay_size)s to %(volume_size)s for volume '
+                      '%(volume)s: %(error)s',
+                      {'temporay_size': temporay_size,
+                       'volume_size': volume_size,
+                       'volume': volume['name'],
+                       'error': error})
+            raise
+
+    def _update_volume_properties(self, volume):
+        """Updates the existing volume properties.
+
+        :param volume: volume reference
+        """
+        if not volume['volume_type_id']:
+            return
+        ctxt = context.get_admin_context()
+        volume_type_id = volume['volume_type_id']
+        volume_type = volume_types.get_volume_type(ctxt, volume_type_id)
+        diff = {}
+        host = volume['host']
+        self.retype(ctxt, volume, volume_type, diff, host)
 
     @coordination.synchronized('{self.nef.lock}')
     def create_volume(self, volume):
@@ -167,38 +360,184 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         volume_path = self._get_volume_path(volume)
         volume_size = volume['size'] * units.Gi
         properties = self.nef.volumes.properties
-        payload = self._get_vendor_properties(volume, properties)
+        payload = self._get_vendor_properties(properties, volume)
         payload.update({
             'path': volume_path,
             'volumeSize': volume_size
         })
         self.nef.volumes.create(payload)
 
+    def _verify_cache_image(self, ctxt, volume, image_meta, image_service):
+        properties = self.nef.volumes.properties
+        volume_type_specs = self._get_vendor_properties(properties, volume)
+        volume_blocksize = volume_type_specs['volumeBlockSize']
+        image_id = image_meta['id']
+        image_checksum = image_meta['checksum']
+        namespace = uuid.UUID(image_id, version=4)
+        name = '%s:%s' % (image_checksum, volume_blocksize)
+        name = nexenta_utils.native_string(name)
+        cache_uuid = uuid.uuid5(namespace, name)
+        cache_id = six.text_type(cache_uuid)
+        cache = {
+            'id': cache_id,
+            'name': self.cache_image_template % cache_id,
+            'volume_type_id': volume['volume_type_id']
+        }
+        cache_path = self._get_volume_path(cache)
+        payload = {'fields': 'volumeSize,readOnly'}
+        cache_exist = False
+        try:
+            cache_specs = self.nef.volumes.get(cache_path, payload)
+            image_size = cache_specs['volumeSize']
+            if not cache_specs['readOnly']:
+                self.delete_volume(cache)
+            else:
+                cache_exist = True
+        except jsonrpc.NefException as error:
+            if error.code != 'ENOENT':
+                raise
+        if not cache_exist:
+            with image_utils.TemporaryImages.fetch(image_service, ctxt,
+                                                   image_id) as image_file:
+                image_info = image_utils.qemu_img_info(image_file,
+                                                       force_share=True,
+                                                       run_as_root=True)
+                image_size = image_info.virtual_size
+        cache_size = nexenta_utils.roundup(image_size, units.Gi)
+        cache['size'] = cache_size // units.Gi
+        if cache['size'] > volume['size']:
+            code = 'ENOSPC'
+            message = (_('Unable to clone cache %(cache)s '
+                         'to volume %(volume)s: cache size '
+                         '%(cache_size)sGB is larger than '
+                         'volume size %(volume_size)sGB')
+                       % {'cache': cache['name'],
+                          'volume': volume['name'],
+                          'cache_size': cache['size'],
+                          'volume_size': volume['size']})
+            raise jsonrpc.NefException(code=code, message=message)
+        if not cache_exist:
+            self.create_volume(cache)
+            self.copy_image_to_volume(ctxt, cache, image_service, image_id)
+            payload = {'readOnly': True}
+            self.nef.volumes.set(cache_path, payload)
+        return cache
+
+    def _verify_cache_snapshot(self, cache):
+        snapshot = {
+            'id': cache['id'],
+            'name': self.cache_snapshot_template % cache['id'],
+            'volume_id': cache['id'],
+            'volume_name': cache['name'],
+            'volume_size': cache['size']
+        }
+        snapshot_path = self._get_snapshot_path(snapshot)
+        payload = {'fields': 'path'}
+        try:
+            self.nef.snapshots.get(snapshot_path, payload)
+        except jsonrpc.NefException as error:
+            if error.code != 'ENOENT':
+                raise
+            self.create_snapshot(snapshot)
+        return snapshot
+
+    @coordination.synchronized('{self.nef.lock}-{image_meta[id]}')
+    def clone_image(self, ctxt, volume, image_location, image_meta,
+                    image_service):
+        """Create a volume efficiently from an existing image.
+
+        image_location is a string whose format depends on the
+        image service backend in use. The driver should use it
+        to determine whether cloning is possible.
+
+        image_meta is a dictionary that includes 'disk_format' (e.g.
+        raw, qcow2) and other image attributes that allow drivers to
+        decide whether they can clone the image without first requiring
+        conversion.
+
+        image_service is the reference of the image_service to use.
+        Note that this is needed to be passed here for drivers that
+        will want to fetch images from the image service directly.
+
+        Returns a dict of volume properties eg. provider_location,
+        boolean indicating whether cloning occurred.
+        """
+        if not self.image_cache:
+            return None, False
+        try:
+            cache = self._verify_cache_image(ctxt, volume,
+                                             image_meta,
+                                             image_service)
+            snapshot = self._verify_cache_snapshot(cache)
+            self.create_volume_from_snapshot(volume, snapshot)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to clone image %(image)s '
+                      'to volume %(volume)s: %(error)s',
+                      {'image': image_meta['id'],
+                       'volume': volume['name'],
+                       'error': error})
+            return None, False
+        return None, True
+
     @coordination.synchronized('{self.nef.lock}')
     def delete_volume(self, volume):
-        """Deletes a logical volume.
+        """Deletes a volume.
 
         :param volume: volume reference
         """
         volume_path = self._get_volume_path(volume)
-        delete_payload = {'snapshots': True}
+        payload = {'fields': 'originalSnapshot'}
         try:
-            self.nef.volumes.delete(volume_path, delete_payload)
+            volume_spec = self.nef.volumes.get(volume_path, payload)
+        except jsonrpc.NefException as error:
+            if error.code == 'ENOENT':
+                return
+            raise
+        volume_origin = volume_spec['originalSnapshot']
+        payload = {'snapshots': True}
+        try:
+            self.nef.volumes.delete(volume_path, payload)
         except jsonrpc.NefException as error:
             if error.code != 'EEXIST':
                 raise
-            snapshots_tree = {}
-            snapshots_payload = {'parent': volume_path, 'fields': 'path'}
-            snapshots = self.nef.snapshots.list(snapshots_payload)
+            snapshot_tree = {}
+            payload = {'parent': volume_path, 'fields': 'path'}
+            snapshots = self.nef.snapshots.list(payload)
             for snapshot in snapshots:
-                clones_payload = {'fields': 'clones,creationTxg'}
-                data = self.nef.snapshots.get(snapshot['path'], clones_payload)
-                if data['clones']:
-                    snapshots_tree[data['creationTxg']] = data['clones'][0]
-            if snapshots_tree:
-                clone_path = snapshots_tree[max(snapshots_tree)]
+                snapshot_path = snapshot['path']
+                payload = {'fields': 'clones,creationTxg'}
+                snapshot_spec = self.nef.snapshots.get(snapshot_path, payload)
+                if snapshot_spec['clones']:
+                    snapshot_txg = snapshot_spec['creationTxg']
+                    snapshot_clones = snapshot_spec['clones']
+                    first_clone = snapshot_clones[0]
+                    snapshot_tree[snapshot_txg] = first_clone
+            if snapshot_tree:
+                latest_txg = max(snapshot_tree)
+                clone_path = snapshot_tree[latest_txg]
                 self.nef.volumes.promote(clone_path)
-            self.nef.volumes.delete(volume_path, delete_payload)
+            payload = {'snapshots': True}
+            self.nef.volumes.delete(volume_path, payload)
+        if not volume_origin:
+            return
+        origin_path, snapshot_name = volume_origin.split('@')
+        origin_name = posixpath.basename(origin_path)
+        if nexenta_utils.match_template(self.origin_snapshot_template,
+                                        snapshot_name):
+            payload = {'defer': True}
+            try:
+                self.nef.snapshots.delete(volume_origin, payload)
+            except Exception:
+                pass
+        elif (nexenta_utils.match_template(self.cache_snapshot_template,
+                                           snapshot_name) and
+              nexenta_utils.match_template(self.cache_image_template,
+                                           origin_name)):
+            payload = {'snapshots': True}
+            try:
+                self.nef.volumes.delete(origin_path, payload)
+            except Exception:
+                pass
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -207,8 +546,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param new_size: volume new size in GB
         """
         volume_path = self._get_volume_path(volume)
-        payload = {'volumeSize': new_size * units.Gi}
+        volume_size = new_size * units.Gi
+        payload = {'volumeSize': volume_size}
         self.nef.volumes.set(volume_path, payload)
+        self._set_volume_reservation(volume)
 
     @coordination.synchronized('{self.nef.lock}')
     def create_snapshot(self, snapshot):
@@ -237,7 +578,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         # actually helpful.
         return False
 
-    def revert_to_snapshot(self, context, volume, snapshot):
+    def revert_to_snapshot(self, ctxt, volume, snapshot):
         """Revert volume to snapshot."""
         volume_path = self._get_volume_path(volume)
         payload = {'snapshot': snapshot['name']}
@@ -250,12 +591,16 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param volume: reference of volume to be created
         :param snapshot: reference of source snapshot
         """
+        LOG.debug('Create volume %(volume)s from snapshot %(snapshot)s',
+                  {'volume': volume['name'], 'snapshot': snapshot['name']})
+        volume_path = self._get_volume_path(volume)
         snapshot_path = self._get_snapshot_path(snapshot)
-        clone_path = self._get_volume_path(volume)
-        payload = {'targetPath': clone_path}
-        self.nef.snapshots.clone(snapshot_path, payload)
+        payload = {'targetPath': volume_path}
         if volume['size'] > snapshot['volume_size']:
-            self.extend_volume(volume, volume['size'])
+            volume_size = volume['size'] * units.Gi
+            payload['volumeSize'] = volume_size
+        self.nef.snapshots.clone(snapshot_path, payload)
+        self._update_volume_properties(volume)
 
     def create_cloned_volume(self, volume, src_vref):
         """Creates a clone of the specified volume.
@@ -273,7 +618,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         try:
             self.create_volume_from_snapshot(volume, snapshot)
         except jsonrpc.NefException as error:
-            LOG.debug('Failed to create clone %(clone)s '
+            LOG.error('Failed to create clone %(clone)s '
                       'from volume %(volume)s: %(error)s',
                       {'clone': volume['name'],
                        'volume': src_vref['name'],
@@ -283,21 +628,21 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             try:
                 self.delete_snapshot(snapshot)
             except jsonrpc.NefException as error:
-                LOG.debug('Failed to delete temporary snapshot '
+                LOG.error('Failed to delete temporary snapshot '
                           '%(volume)s@%(snapshot)s: %(error)s',
                           {'volume': src_vref['name'],
                            'snapshot': snapshot['name'],
                            'error': error})
 
-    def create_export(self, context, volume, connector):
+    def create_export(self, ctxt, volume, connector):
         """Driver entry point to get the export info for a new volume."""
         pass
 
-    def ensure_export(self, context, volume):
+    def ensure_export(self, ctxt, volume):
         """Driver entry point to get the export info for an existing volume."""
         pass
 
-    def remove_export(self, context, volume):
+    def remove_export(self, ctxt, volume):
         """Driver entry point to remove an export for a volume."""
         pass
 
@@ -313,26 +658,18 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         host_groups = []
         volume_path = self._get_volume_path(volume)
         if isinstance(connector, dict) and 'initiator' in connector:
-            connectors = []
-            if 'volume_attachment' in volume:
-                if isinstance(volume['volume_attachment'], list):
-                    for attachment in volume['volume_attachment']:
-                        if not isinstance(attachment, dict):
-                            continue
-                        if 'connector' not in attachment:
-                            continue
-                        connectors.append(attachment['connector'])
+            connectors = self._get_volume_connectors(volume)
             if connectors.count(connector) > 1:
-                LOG.debug('Detected %(count)s connections from host '
-                          '%(host_name)s (IP:%(host_ip)s) to volume '
-                          '%(volume)s, skip terminating connection',
-                          {'count': connectors.count(connector),
-                           'host_name': connector.get('host', 'unknown'),
-                           'host_ip': connector.get('ip', 'unknown'),
-                           'volume': volume['name']})
+                LOG.info('Detected %(count)s connections from host '
+                         '%(host_name)s (IP:%(host_ip)s) to volume '
+                         '%(volume)s, skip terminating connection',
+                         {'count': connectors.count(connector),
+                          'host_name': connector.get('host', 'unknown'),
+                          'host_ip': connector.get('ip', 'unknown'),
+                          'volume': volume['name']})
                 return True
             host_iqn = connector['initiator']
-            host_groups.append(options.DEFAULT_HOST_GROUP)
+            host_groups.append(DEFAULT_HOST_GROUP)
             host_group = self._get_host_group(host_iqn)
             if host_group is not None:
                 host_groups.append(host_group)
@@ -374,38 +711,27 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         """
         if refresh or not self._stats:
             self._update_volume_stats()
-
         return self._stats
 
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor appliance."""
-        payload = {'fields': 'bytesAvailable,bytesUsed'}
-        dataset = self.nef.volumegroups.get(self.root_path, payload)
-        free_capacity_gb = dataset['bytesAvailable'] // units.Gi
-        allocated_capacity_gb = dataset['bytesUsed'] // units.Gi
-        total_capacity_gb = free_capacity_gb + allocated_capacity_gb
-        provisioned_capacity_gb = total_volumes = 0
+        provisioned_capacity_gb = total_volumes = total_snapshots = 0
         ctxt = context.get_admin_context()
         volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
         for volume in volumes:
             provisioned_capacity_gb += volume['size']
             total_volumes += 1
-        volume_backend_name = (
-            self.configuration.safe_get('volume_backend_name'))
-        if not volume_backend_name:
-            LOG.debug('Failed to get configured volume backend name')
-            volume_backend_name = '%(product)s_%(protocol)s' % {
-                'product': self.product_name,
-                'protocol': self.storage_protocol
-            }
+        snapshots = objects.SnapshotList.get_by_host(ctxt, self.host)
+        for snapshot in snapshots:
+            provisioned_capacity_gb += snapshot['volume_size']
+            total_snapshots += 1
         description = (
             self.configuration.safe_get('nexenta_dataset_description'))
         if not description:
-            description = '%(product)s %(host)s:%(pool)s/%(group)s' % {
+            description = '%(product)s %(host)s:%(path)s' % {
                 'product': self.product_name,
-                'host': self.configuration.nexenta_host,
-                'pool': self.configuration.nexenta_volume,
-                'group': self.configuration.nexenta_volume_group
+                'host': self.san_host,
+                'path': self.san_path
             }
         max_over_subscription_ratio = (
             self.configuration.safe_get('max_over_subscription_ratio'))
@@ -413,26 +739,25 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             self.configuration.safe_get('reserved_percentage'))
         if reserved_percentage is None:
             reserved_percentage = 0
-        location_info = '%(driver)s:%(host)s:%(pool)s/%(group)s' % {
-            'driver': self.driver_name,
-            'host': self.configuration.nexenta_host,
-            'pool': self.configuration.nexenta_volume,
-            'group': self.configuration.nexenta_volume_group
+        location_info = '%(driver)s:%(host)s:%(path)s' % {
+            'driver': self.san_driver,
+            'host': self.san_host,
+            'path': self.san_path
         }
         display_name = 'Capabilities of %(product)s %(protocol)s driver' % {
             'product': self.product_name,
             'protocol': self.storage_protocol
         }
-        visibility = 'public'
-        self._stats = {
+        stats = {
+            'backend_state': 'down',
             'driver_version': self.VERSION,
             'vendor_name': self.vendor_name,
             'storage_protocol': self.storage_protocol,
-            'volume_backend_name': volume_backend_name,
+            'volume_backend_name': self.backend_name,
             'location_info': location_info,
             'description': description,
             'display_name': display_name,
-            'pool_name': self.configuration.nexenta_volume,
+            'pool_name': self.san_pool,
             'multiattach': True,
             'QoS_support': False,
             'consistencygroup_support': True,
@@ -441,33 +766,72 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             'sparse_copy_volume': True,
             'thin_provisioning_support': True,
             'thick_provisioning_support': True,
-            'total_capacity_gb': total_capacity_gb,
-            'allocated_capacity_gb': allocated_capacity_gb,
-            'free_capacity_gb': free_capacity_gb,
+            'total_capacity_gb': 'unknown',
+            'allocated_capacity_gb': 'unknown',
+            'free_capacity_gb': 'unknown',
             'provisioned_capacity_gb': provisioned_capacity_gb,
             'total_volumes': total_volumes,
+            'total_snapshots': total_snapshots,
             'max_over_subscription_ratio': max_over_subscription_ratio,
             'reserved_percentage': reserved_percentage,
-            'visibility': visibility,
+            'nef_scheme': self.nef.scheme,
+            'nef_hosts': ','.join(self.nef.hosts),
             'nef_port': self.nef.port,
-            'nef_url': self.nef.host
+            'nef_url': self.nef.url()
         }
+        payload = {'fields': 'bytesAvailable,bytesUsed'}
+        try:
+            san_stat = self.nef.volumegroups.get(self.san_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to get backend statistics for host %(host)s '
+                      'and volume backend %(backend_name)s: %(error)s',
+                      {'host': self.host,
+                       'backend_name': self.backend_name,
+                       'error': error})
+        else:
+            available = san_stat['bytesAvailable'] // units.Gi
+            used = san_stat['bytesUsed'] // units.Gi
+            stats['free_capacity_gb'] = available
+            stats['allocated_capacity_gb'] = used
+            stats['total_capacity_gb'] = available + used
+            stats['backend_state'] = 'up'
+        self._stats = stats
         LOG.debug('Updated volume backend statistics for host %(host)s '
-                  'and volume backend %(volume_backend_name)s: %(stats)s',
+                  'and volume backend %(backend_name)s: %(stats)s',
                   {'host': self.host,
-                   'volume_backend_name': volume_backend_name,
+                   'backend_name': self.backend_name,
                    'stats': self._stats})
+
+    def _get_volume_connectors(self, volume):
+        """Return list of the volume connectors."""
+        connectors = []
+        if 'volume_attachment' not in volume:
+            return connectors
+        volume_attachments = volume['volume_attachment']
+        if not isinstance(volume_attachments, list):
+            return connectors
+        for volume_attachment in volume_attachments:
+            if not isinstance(volume_attachment, dict):
+                continue
+            if 'connector' not in volume_attachment:
+                continue
+            connector = volume_attachment['connector']
+            connectors.append(connector)
+        return connectors
 
     def _get_volume_path(self, volume):
         """Return ZFS datset path for the volume."""
-        return posixpath.join(self.root_path, volume['name'])
+        volume_name = volume['name']
+        volume_path = posixpath.join(self.san_path, volume_name)
+        return volume_path
 
     def _get_snapshot_path(self, snapshot):
         """Return ZFS snapshot path for the snapshot."""
         volume_name = snapshot['volume_name']
         snapshot_name = snapshot['name']
-        volume_path = posixpath.join(self.root_path, volume_name)
-        return '%s@%s' % (volume_path, snapshot_name)
+        volume_path = posixpath.join(self.san_path, volume_name)
+        snapshot_path = '%s@%s' % (volume_path, snapshot_name)
+        return snapshot_path
 
     def _get_target_group_name(self, target_name):
         """Return Nexenta iSCSI target group name for volume."""
@@ -484,38 +848,37 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         )
 
     def _get_host_addresses(self):
-        """Return Nexenta IP addresses list."""
-        host_addresses = []
-        items = self.nef.netaddrs.list()
-        for item in items:
-            ip_cidr = six.text_type(item['address'])
-            ip_addr, ip_mask = ip_cidr.split('/')
-            ip_obj = ipaddress.ip_address(ip_addr)
-            if not ip_obj.is_loopback:
-                host_addresses.append(ip_obj.exploded)
+        """Returns NexentaStor IP addresses list."""
+        addresses = []
+        netaddrs = self.nef.netaddrs.list()
+        for netaddr in netaddrs:
+            cidr = six.text_type(netaddr['address'])
+            ip = cidr.split('/')[0]
+            instance = ipaddress.ip_address(ip)
+            if not instance.is_loopback:
+                addresses.append(instance.exploded)
         LOG.debug('Configured IP addresses: %(addresses)s',
-                  {'addresses': host_addresses})
-        return host_addresses
+                  {'addresses': addresses})
+        return addresses
 
     def _get_host_portals(self):
         """Return configured iSCSI portals list."""
         host_portals = []
         host_addresses = self._get_host_addresses()
-        portal_host = self.iscsi_host
-        if portal_host:
-            if portal_host in host_addresses:
-                if self.portal_port:
-                    portal_port = int(self.portal_port)
+        if self.san_host:
+            if self.san_host in host_addresses:
+                if self.san_port:
+                    san_port = self.san_port
                 else:
-                    portal_port = options.DEFAULT_ISCSI_PORT
-                host_portal = '%s:%s' % (portal_host, portal_port)
+                    san_port = DEFAULT_ISCSI_PORT
+                host_portal = '%s:%s' % (self.san_host, san_port)
                 host_portals.append(host_portal)
             else:
-                LOG.debug('Skip not a local portal IP address %(portal)s',
-                          {'portal': portal_host})
+                LOG.debug('Skip not a local IP address %(san_host)s',
+                          {'san_host': self.san_host})
         else:
             LOG.debug('Configuration parameter nexenta_host is not defined')
-        for portal in self.portals.split(','):
+        for portal in self.portals:
             if not portal:
                 continue
             host_port = portal.split(':')
@@ -524,7 +887,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 if len(host_port) == 2:
                     portal_port = int(host_port[1])
                 else:
-                    portal_port = options.DEFAULT_ISCSI_PORT
+                    portal_port = DEFAULT_ISCSI_PORT
                 host_portal = '%s:%s' % (portal_host, portal_port)
                 if host_portal not in host_portals:
                     host_portals.append(host_portal)
@@ -601,7 +964,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                   'and initiator: %(initiator)s',
                   {'volume': volume_path, 'initiator': host_iqn})
 
-        host_groups = [options.DEFAULT_HOST_GROUP]
+        host_groups = [DEFAULT_HOST_GROUP]
         host_group = self._get_host_group(host_iqn)
         if host_group:
             host_groups.append(host_group)
@@ -617,7 +980,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             mapping_lu = mapping['lun']
             mapping_hg = mapping['hostGroup']
             mapping_tg = mapping['targetGroup']
-            if mapping_tg == options.DEFAULT_TARGET_GROUP:
+            if mapping_tg == DEFAULT_TARGET_GROUP:
                 LOG.debug('Delete LUN mapping %(id)s for target group %(tg)s',
                           {'id': mapping_id, 'tg': mapping_tg})
                 self._delete_lun_mapping(mapping_id)
@@ -712,21 +1075,25 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 props_portals += portals
                 props_iqns += [target] * len(portals)
 
-        payload = {'volume': volume_path,
-                   'targetGroup': target_group,
-                   'hostGroup': host_group}
+        payload = {
+            'volume': volume_path,
+            'targetGroup': target_group,
+            'hostGroup': host_group
+        }
         self.nef.mappings.create(payload)
-        mapping = {}
-        for attempt in range(self.nef.retries):
-            mapping = self.nef.mappings.list(payload)
-            if mapping:
+        mappings = {}
+        for attempt in range(1, self.nef.retries + 1):
+            mappings = self.nef.mappings.list(payload)
+            if mappings:
                 break
             self.nef.delay(attempt)
-        if not mapping:
-            message = (_('Failed to get LUN number for %(volume)s')
-                       % {'volume': volume_path})
+        if not mappings:
+            message = (_('LUN mapping %(payload)s created for '
+                         'volume %(volume)s was not found')
+                       % {'payload': payload,
+                          'volume': volume['name']})
             raise jsonrpc.NefException(code='ENOTBLK', message=message)
-        lun = mapping[0]['lun']
+        lun = mappings[0]['lun']
         props_luns = [lun] * len(props_iqns)
 
         if multipath:
@@ -739,8 +1106,6 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             props['target_iqn'] = props_iqns[index]
             props['target_lun'] = props_luns[index]
 
-        LOG.debug('Set LUN properties for volume %(volume)s',
-                  {'volume': volume_path})
         payload = {
             'volume': volume_path,
             'fields': 'guid'
@@ -748,7 +1113,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         logicalunits = self.nef.logicalunits.list(payload)
         guid = logicalunits[0]['guid']
         properties = self.nef.logicalunits.properties
-        payload = self._get_vendor_properties(volume, properties)
+        payload = self._get_vendor_properties(properties, volume)
         self.nef.logicalunits.set(guid, payload)
 
         LOG.debug('Created new LUN mapping: %(props)s',
@@ -841,29 +1206,29 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             result.append('%s:%s' % (key_val['address'], key_val['port']))
         return result
 
-    def create_consistencygroup(self, context, group):
+    def create_consistencygroup(self, ctxt, group):
         """Creates a consistency group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the dictionary of the consistency group to be created.
         :returns: group_model_update
         """
         group_model_update = {}
         return group_model_update
 
-    def create_group(self, context, group):
+    def create_group(self, ctxt, group):
         """Creates a group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the group object.
         :returns: model_update
         """
-        return self.create_consistencygroup(context, group)
+        return self.create_consistencygroup(ctxt, group)
 
-    def delete_consistencygroup(self, context, group, volumes):
+    def delete_consistencygroup(self, ctxt, group, volumes):
         """Deletes a consistency group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the dictionary of the consistency group to be deleted.
         :param volumes: a list of volume dictionaries in the group.
         :returns: group_model_update, volumes_model_update
@@ -874,21 +1239,21 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             self.delete_volume(volume)
         return group_model_update, volumes_model_update
 
-    def delete_group(self, context, group, volumes):
+    def delete_group(self, ctxt, group, volumes):
         """Deletes a group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the group object.
         :param volumes: a list of volume objects in the group.
         :returns: model_update, volumes_model_update
         """
-        return self.delete_consistencygroup(context, group, volumes)
+        return self.delete_consistencygroup(ctxt, group, volumes)
 
-    def update_consistencygroup(self, context, group, add_volumes=None,
+    def update_consistencygroup(self, ctxt, group, add_volumes=None,
                                 remove_volumes=None):
         """Updates a consistency group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the dictionary of the consistency group to be updated.
         :param add_volumes: a list of volume dictionaries to be added.
         :param remove_volumes: a list of volume dictionaries to be removed.
@@ -899,23 +1264,23 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         remove_volumes_update = []
         return group_model_update, add_volumes_update, remove_volumes_update
 
-    def update_group(self, context, group,
+    def update_group(self, ctxt, group,
                      add_volumes=None, remove_volumes=None):
         """Updates a group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the group object.
         :param add_volumes: a list of volume objects to be added.
         :param remove_volumes: a list of volume objects to be removed.
         :returns: model_update, add_volumes_update, remove_volumes_update
         """
-        return self.update_consistencygroup(context, group, add_volumes,
+        return self.update_consistencygroup(ctxt, group, add_volumes,
                                             remove_volumes)
 
-    def create_cgsnapshot(self, context, cgsnapshot, snapshots):
+    def create_cgsnapshot(self, ctxt, cgsnapshot, snapshots):
         """Creates a consistency group snapshot.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param cgsnapshot: the dictionary of the cgsnapshot to be created.
         :param snapshots: a list of snapshot dictionaries in the cgsnapshot.
         :returns: group_model_update, snapshots_model_update
@@ -923,12 +1288,12 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         group_model_update = {}
         snapshots_model_update = []
         cgsnapshot_name = self.group_snapshot_template % cgsnapshot['id']
-        cgsnapshot_path = '%s@%s' % (self.root_path, cgsnapshot_name)
+        cgsnapshot_path = '%s@%s' % (self.san_path, cgsnapshot_name)
         create_payload = {'path': cgsnapshot_path, 'recursive': True}
         self.nef.snapshots.create(create_payload)
         for snapshot in snapshots:
             volume_name = snapshot['volume_name']
-            volume_path = posixpath.join(self.root_path, volume_name)
+            volume_path = posixpath.join(self.san_path, volume_name)
             snapshot_name = snapshot['name']
             snapshot_path = '%s@%s' % (volume_path, cgsnapshot_name)
             rename_payload = {'newName': snapshot_name}
@@ -937,20 +1302,20 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         self.nef.snapshots.delete(cgsnapshot_path, delete_payload)
         return group_model_update, snapshots_model_update
 
-    def create_group_snapshot(self, context, group_snapshot, snapshots):
+    def create_group_snapshot(self, ctxt, group_snapshot, snapshots):
         """Creates a group_snapshot.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group_snapshot: the GroupSnapshot object to be created.
         :param snapshots: a list of Snapshot objects in the group_snapshot.
         :returns: model_update, snapshots_model_update
         """
-        return self.create_cgsnapshot(context, group_snapshot, snapshots)
+        return self.create_cgsnapshot(ctxt, group_snapshot, snapshots)
 
-    def delete_cgsnapshot(self, context, cgsnapshot, snapshots):
+    def delete_cgsnapshot(self, ctxt, cgsnapshot, snapshots):
         """Deletes a consistency group snapshot.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param cgsnapshot: the dictionary of the cgsnapshot to be created.
         :param snapshots: a list of snapshot dictionaries in the cgsnapshot.
         :returns: group_model_update, snapshots_model_update
@@ -961,22 +1326,22 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             self.delete_snapshot(snapshot)
         return group_model_update, snapshots_model_update
 
-    def delete_group_snapshot(self, context, group_snapshot, snapshots):
+    def delete_group_snapshot(self, ctxt, group_snapshot, snapshots):
         """Deletes a group_snapshot.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group_snapshot: the GroupSnapshot object to be deleted.
         :param snapshots: a list of snapshot objects in the group_snapshot.
         :returns: model_update, snapshots_model_update
         """
-        return self.delete_cgsnapshot(context, group_snapshot, snapshots)
+        return self.delete_cgsnapshot(ctxt, group_snapshot, snapshots)
 
-    def create_consistencygroup_from_src(self, context, group, volumes,
+    def create_consistencygroup_from_src(self, ctxt, group, volumes,
                                          cgsnapshot=None, snapshots=None,
                                          source_cg=None, source_vols=None):
         """Creates a consistency group from source.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the dictionary of the consistency group to be created.
         :param volumes: a list of volume dictionaries in the group.
         :param cgsnapshot: the dictionary of the cgsnapshot as source.
@@ -992,7 +1357,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 self.create_volume_from_snapshot(volume, snapshot)
         elif source_cg and source_vols:
             snapshot_name = self.origin_snapshot_template % group['id']
-            snapshot_path = '%s@%s' % (self.root_path, snapshot_name)
+            snapshot_path = '%s@%s' % (self.san_path, snapshot_name)
             create_payload = {'path': snapshot_path, 'recursive': True}
             self.nef.snapshots.create(create_payload)
             for volume, source_vol in zip(volumes, source_vols):
@@ -1007,12 +1372,12 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             self.nef.snapshots.delete(snapshot_path, delete_payload)
         return group_model_update, volumes_model_update
 
-    def create_group_from_src(self, context, group, volumes,
+    def create_group_from_src(self, ctxt, group, volumes,
                               group_snapshot=None, snapshots=None,
                               source_group=None, source_vols=None):
         """Creates a group from source.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the Group object to be created.
         :param volumes: a list of Volume objects in the group.
         :param group_snapshot: the GroupSnapshot object as source.
@@ -1021,7 +1386,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param source_vols: a list of volume objects in the source_group.
         :returns: model_update, volumes_model_update
         """
-        return self.create_consistencygroup_from_src(context, group, volumes,
+        return self.create_consistencygroup_from_src(ctxt, group, volumes,
                                                      group_snapshot, snapshots,
                                                      source_group, source_vols)
 
@@ -1039,7 +1404,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                        % {'keys': keys})
             raise jsonrpc.NefException(code='EINVAL', message=message)
         payload = {
-            'parent': self.root_path,
+            'parent': self.san_path,
             'fields': 'name,path,volumeSize'
         }
         for key, value in types.items():
@@ -1187,6 +1552,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             volume_path = self._get_volume_path(volume)
             payload = {'newPath': volume_path}
             self.nef.volumes.rename(existing_volume_path, payload)
+        self._update_volume_properties(volume)
 
     def manage_existing_get_size(self, volume, existing_ref):
         """Return size of volume to be managed by manage_existing.
@@ -1237,7 +1603,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             value = cinder_volume['id']
             cinder_volume_names[key] = value
         payload = {
-            'parent': self.root_path,
+            'parent': self.san_path,
             'fields': 'name,guid,path,volumeSize',
             'recursive': False
         }
@@ -1251,6 +1617,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             guid = volume['guid']
             size = volume['volumeSize'] // units.Gi
             name = volume['name']
+            if nexenta_utils.match_template(self.cache_image_template, name):
+                LOG.debug('Skip image cache %(path)s',
+                          {'path': path})
+                continue
             if name in cinder_volume_names:
                 cinder_id = cinder_volume_names[name]
                 safe_to_manage = False
@@ -1264,7 +1634,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 members = []
                 for mapping in mappings:
                     hostgroup = mapping['hostGroup']
-                    if hostgroup == options.DEFAULT_HOST_GROUP:
+                    if hostgroup == DEFAULT_HOST_GROUP:
                         members.append(hostgroup)
                     else:
                         group = self.nef.hostgroups.get(hostgroup)
@@ -1405,7 +1775,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             }
             cinder_snapshot_names[key] = value
         payload = {
-            'parent': self.root_path,
+            'parent': self.san_path,
             'fields': 'name,guid,path,parent,hprService,snaplistId',
             'recursive': True
         }
@@ -1424,16 +1794,23 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                           'volume %(parent)s is unmanaged',
                           {'path': path, 'parent': parent})
                 continue
-            if name.startswith(self.origin_snapshot_template):
+            if nexenta_utils.match_template(self.cache_snapshot_template,
+                                            name):
+                LOG.debug('Skip image cache snapshot %(path)s',
+                          {'path': path})
+                continue
+            if nexenta_utils.match_template(self.origin_snapshot_template,
+                                            name):
                 LOG.debug('Skip temporary origin snapshot %(path)s',
                           {'path': path})
                 continue
-            if name.startswith(self.group_snapshot_template):
+            if nexenta_utils.match_template(self.group_snapshot_template,
+                                            name):
                 LOG.debug('Skip temporary group snapshot %(path)s',
                           {'path': path})
                 continue
             if snapshot['hprService'] or snapshot['snaplistId']:
-                LOG.debug('Skip HPR/snapping snapshot %(path)s',
+                LOG.debug('Skip Replication/Snapping snapshot %(path)s',
                           {'path': path})
                 continue
             if name in cinder_snapshot_names:
@@ -1494,87 +1871,33 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         """Return local path to existing local volume."""
         raise NotImplementedError()
 
-    def migrate_volume(self, context, volume, host):
-        """Migrate the volume to the specified host.
-
-        Returns a boolean indicating whether the migration occurred,
-        as well as model_update.
-
-        :param context: Security context
-        :param volume: A dictionary describing the volume to migrate
-        :param host: A dictionary describing the host to migrate to, where
-                     host['host'] is its name, and host['capabilities'] is a
-                     dictionary of its reported capabilities.
-        """
-        LOG.debug('Start storage assisted volume migration '
-                  'for volume %(volume)s to host %(host)s',
-                  {'volume': volume['name'],
-                   'host': host['host']})
-        false_ret = (False, None)
-        if 'capabilities' not in host:
-            LOG.debug('No host capabilities found for '
-                      'the destination host %(host)s',
-                      {'host': host['host']})
-            return false_ret
-        capabilities = host['capabilities']
-        required_capabilities = [
-            'vendor_name',
-            'location_info',
-            'storage_protocol',
-            'free_capacity_gb',
-            'nef_url',
-            'nef_port'
-        ]
-        for capability in required_capabilities:
-            if capability not in capabilities:
-                LOG.debug('Required host capability %(capability)s not '
-                          'found for the destination host %(host)s',
-                          {'capability': capability, 'host': host['host']})
-                return false_ret
-        vendor = capabilities['vendor_name']
-        if vendor != self.vendor_name:
-            LOG.debug('Unsupported vendor %(vendor)s found '
-                      'for the destination host %(host)s',
-                      {'vendor': vendor, 'host': host['host']})
-            return false_ret
-        location = capabilities['location_info']
+    def _migrate_volume(self, volume, scheme, hosts, port, path):
+        """Storage assisted volume migration."""
+        src_hosts = self._get_host_addresses()
+        src_path = self._get_volume_path(volume)
+        dst_path = posixpath.join(path, volume['name'])
+        for dst_host in hosts:
+            if dst_host in src_hosts and src_path == dst_path:
+                LOG.info('Skip local migration for host %(dst_host)s: '
+                         'source volume %(src_path)s and destination '
+                         'volume %(dst_path)s are the same volume',
+                         {'dst_host': dst_host, 'src_path': src_path,
+                          'dst_path': dst_path})
+                return True
+        payload = {'fields': 'name'}
         try:
-            driver, san_host, san_path = location.split(':')
-        except ValueError as error:
-            LOG.debug('Failed to split location info %(location)s '
-                      'for the destination host %(host)s: %(error)s',
-                      {'location': location, 'host': host['host'],
-                       'error': error})
-            return false_ret
-        if not (driver and san_path):
-            LOG.debug('Incomplete location info %(location)s '
-                      'found for the destination host %(host)s',
-                      {'location': location, 'host': host['host']})
-            return false_ret
-        if driver != self.driver_name:
-            LOG.debug('Unsupported storage driver %(driver)s '
-                      'found for the destination host %(host)s',
-                      {'driver': driver, 'host': host['host']})
-            return false_ret
-        try:
-            payload = {'fields': 'name'}
             self.nef.hpr.list(payload)
         except jsonrpc.NefException as error:
-            LOG.debug('Storage assisted volume migration is unavailable '
-                      'for the destination host %(host)s: %(error)s',
-                      {'host': host['host'], 'error': error})
-            return false_ret
-        src_path = self._get_volume_path(volume)
-        dst_path = posixpath.join(san_path, volume['name'])
-        dst_port = capabilities['nef_port']
-        src_hosts = self._get_host_addresses()
-        dst_hosts = capabilities['nef_url'].split(',')
-        service_name = 'cinder-migrate-%s' % volume['name']
-        service_created = service_running = service_success = False
-        while dst_hosts and not service_created:
-            dst_host = dst_hosts.pop()
-            if dst_host is not None:
-                dst_host = dst_host.strip()
+            LOG.error('Storage assisted volume migration '
+                      'is unavailable: %(error)s',
+                      {'error': error})
+            return False
+        service_name = '%(prefix)s-%(volume)s' % {
+            'prefix': self.migration_service_prefix,
+            'volume': volume['name']
+        }
+        service_created = False
+        for dst_host in hosts:
             payload = {
                 'name': service_name,
                 'sourceDataset': src_path,
@@ -1585,71 +1908,73 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 payload['isSource'] = True
                 payload['remoteNode'] = {
                     'host': dst_host,
-                    'port': dst_port
+                    'port': port,
+                    'proto': scheme
                 }
-            elif src_path == dst_path:
-                LOG.debug('Skip local to local replication: '
-                          'source volume %(src_path)s and '
-                          'destination volume %(dst_path)s '
-                          'are the same volume',
-                          {'src_path': src_path,
-                           'dst_path': dst_path})
-                return True, None
+                if self.migration_throttle:
+                    payload['transportOptions'] = {
+                        'throttle': self.migration_throttle * units.Mi
+                    }
             try:
                 self.nef.hpr.create(payload)
                 service_created = True
+                break
             except jsonrpc.NefException as error:
-                LOG.debug('Failed to create replication service '
+                LOG.error('Failed to create migration service '
                           'with payload %(payload)s: %(error)s',
                           {'payload': payload, 'error': error})
-                if error.code not in ('ENOENT', 'EINVAL'):
-                    return false_ret
+        service_running = False
         if service_created:
             try:
                 self.nef.hpr.start(service_name)
                 service_running = True
             except jsonrpc.NefException as error:
-                LOG.debug('Failed to start replication service '
+                LOG.error('Failed to start migration service '
                           '%(service_name)s: %(error)s',
                           {'service_name': service_name,
                            'error': error})
-        retry_count = 0
-        while service_running and not service_success:
+        service_success = False
+        service_retries = 0
+        while service_running:
+            service_retries += 1
+            self.nef.delay(service_retries)
+            payload = {'fields': 'state,progress,runNumber,lastError'}
             try:
-                service = self.nef.hpr.get(service_name)
+                service = self.nef.hpr.get(service_name, payload)
             except jsonrpc.NefException as error:
-                LOG.debug('Failed to stat replication service '
+                LOG.error('Failed to stat migration service '
                           '%(service_name)s: %(error)s',
                           {'service_name': service_name,
                            'error': error})
-                break
-            state = service['state']
-            if state == 'faulted':
+                if service_retries > self.nef.retries:
+                    break
+            service_state = service['state']
+            service_counter = service['runNumber']
+            service_progress = service['progress']
+            if service_state == 'faulted':
                 service_error = service['lastError']
-                LOG.debug('Replication service %(service_name)s '
+                LOG.error('Migration service %(service_name)s '
                           'failed with error: %(service_error)s',
                           {'service_name': service_name,
                            'service_error': service_error})
-                break
-            elif state == 'disabled':
-                LOG.debug('Replication service %(service_name)s '
-                          'successfully replicated %(src_path)s '
-                          'to %(dst_host)s:%(dst_path)s',
-                          {'service_name': service_name,
-                           'src_path': src_path,
-                           'dst_host': dst_host,
-                           'dst_path': dst_path})
+                service_running = False
+            elif service_state == 'disabled' and service_counter > 0:
+                LOG.info('Migration service %(service_name)s '
+                         'successfully replicated %(src_path)s '
+                         'to %(dst_host)s:%(dst_path)s',
+                         {'service_name': service_name,
+                          'src_path': src_path,
+                          'dst_host': dst_host,
+                          'dst_path': dst_path})
                 service_running = False
                 service_success = True
-                break
             else:
-                progress = service['progress']
-                LOG.debug('Replication service %(service_name)s '
-                          'is running, progress %(progress)s%%',
-                          {'service_name': service_name,
-                           'progress': progress})
-                self.nef.delay(retry_count)
-                retry_count += 1
+                LOG.info('Migration service %(service_name)s '
+                         'is %(service_state)s, progress '
+                         '%(service_progress)s%%',
+                         {'service_name': service_name,
+                          'service_state': service_state,
+                          'service_progress': service_progress})
         if service_created:
             payload = {
                 'destroySourceSnapshots': True,
@@ -1659,109 +1984,281 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             try:
                 self.nef.hpr.delete(service_name, payload)
             except jsonrpc.NefException as error:
-                LOG.debug('Failed to delete replication service '
+                LOG.error('Failed to delete migration service '
                           '%(service_name)s: %(error)s',
                           {'service_name': service_name,
                            'error': error})
         if not service_success:
-            return false_ret
+            return False
         try:
             self.delete_volume(volume)
         except jsonrpc.NefException as error:
-            LOG.debug('Failed to delete source '
+            LOG.error('Failed to delete source '
                       'volume %(volume)s: %(error)s',
                       {'volume': volume['name'],
                        'error': error})
-        return True, None
+        return True
 
-    def update_migrated_volume(self, context, volume, new_volume,
+    def migrate_volume(self, ctxt, volume, host):
+        """Migrate the volume to the specified host.
+
+        Returns a boolean indicating whether the migration occurred,
+        as well as model_update.
+
+        :param ctxt: Security context
+        :param volume: A dictionary describing the volume to migrate
+        :param host: A dictionary describing the host to migrate to, where
+                     host['host'] is its name, and host['capabilities'] is a
+                     dictionary of its reported capabilities.
+        """
+        LOG.info('Start storage assisted volume migration '
+                 'for volume %(volume)s to host %(host)s',
+                 {'volume': volume['name'],
+                  'host': host['host']})
+        false_ret = (False, None)
+        if 'capabilities' not in host:
+            LOG.error('No host capabilities found for '
+                      'the destination host %(host)s',
+                      {'host': host['host']})
+            return false_ret
+        capabilities = host['capabilities']
+        required_capabilities = [
+            'vendor_name',
+            'location_info',
+            'storage_protocol',
+            'free_capacity_gb'
+        ]
+        for capability in required_capabilities:
+            if not (capability in capabilities and capabilities[capability]):
+                LOG.error('Required host capability %(capability)s not '
+                          'found for the destination host %(host)s',
+                          {'capability': capability, 'host': host['host']})
+                return false_ret
+        vendor = capabilities['vendor_name']
+        if vendor != self.vendor_name:
+            LOG.error('Unsupported vendor %(vendor)s found '
+                      'for the destination host %(host)s',
+                      {'vendor': vendor, 'host': host['host']})
+            return false_ret
+        location = capabilities['location_info']
+        try:
+            san_driver, san_host, san_path = location.split(':')
+        except ValueError as error:
+            LOG.error('Failed to parse location info %(location)s '
+                      'for the destination host %(host)s: %(error)s',
+                      {'location': location, 'host': host['host'],
+                       'error': error})
+            return false_ret
+        if not (san_driver and san_host and san_path):
+            LOG.error('Incomplete location info %(location)s '
+                      'found for the destination host %(host)s',
+                      {'location': location, 'host': host['host']})
+            return false_ret
+        if san_driver != self.san_driver:
+            LOG.error('Unsupported storage driver %(san_driver)s '
+                      'found for the destination host %(host)s',
+                      {'san_driver': san_driver,
+                       'host': host['host']})
+            return false_ret
+        storage_protocol = capabilities['storage_protocol']
+        if storage_protocol != self.storage_protocol:
+            LOG.error('Unsupported storage protocol %(protocol)s '
+                      'found for the destination host %(host)s',
+                      {'protocol': storage_protocol,
+                       'host': host['host']})
+            return false_ret
+        free_capacity_gb = capabilities['free_capacity_gb']
+        if free_capacity_gb < volume['size']:
+            LOG.error('There is not enough space available on the '
+                      'destination host %(host)s to migrate volume '
+                      '%(volume)s, available space: %(free)sG, '
+                      'required space: %(required)sG',
+                      {'host': host['host'],
+                       'volume': volume['name'],
+                       'free': free_capacity_gb,
+                       'required': volume['size']})
+            return false_ret
+        nef_scheme = None
+        nef_hosts = []
+        nef_port = None
+        if 'nef_hosts' in capabilities and capabilities['nef_hosts']:
+            for nef_host in capabilities['nef_hosts'].split(','):
+                nef_host = nef_host.strip()
+                if nef_host:
+                    nef_hosts.append(nef_host)
+        elif 'nef_url' in capabilities and capabilities['nef_url']:
+            url = six.moves.urllib.parse.urlparse(capabilities['nef_url'])
+            if url.scheme and url.hostname and url.port:
+                nef_scheme = url.scheme
+                nef_hosts.append(url.hostname)
+                nef_port = url.port
+            else:
+                for nef_host in capabilities['nef_url'].split(','):
+                    nef_host = nef_host.strip()
+                    if nef_host:
+                        nef_hosts.append(nef_host)
+        if not nef_hosts:
+            LOG.error('NEF management address not found for the '
+                      'destination host %(host)s: %(capabilities)s',
+                      {'host': host['host'],
+                       'capabilities': capabilities})
+            return false_ret
+        if not nef_scheme:
+            if 'nef_scheme' in capabilities and capabilities['nef_scheme']:
+                nef_scheme = capabilities['nef_scheme']
+            else:
+                nef_scheme = self.nef.scheme
+        if not nef_port:
+            if 'nef_port' in capabilities and capabilities['nef_port']:
+                nef_port = capabilities['nef_port']
+            else:
+                nef_port = self.nef.port
+        if self._migrate_volume(volume, nef_scheme, nef_hosts, nef_port,
+                                san_path):
+            return (True, None)
+        return false_ret
+
+    def update_migrated_volume(self, ctxt, volume, new_volume,
                                original_volume_status):
         """Return model update for migrated volume.
 
         This method should rename the back-end volume name on the
         destination host back to its original name on the source host.
 
-        :param context: The context of the caller
+        :param ctxt: The context of the caller
         :param volume: The original volume that was migrated to this backend
         :param new_volume: The migration volume object that was created on
                            this backend as part of the migration process
         :param original_volume_status: The status of the original volume
         :returns: model_update to update DB with any needed changes
         """
-        name_id = None
-        path = self._get_volume_path(volume)
-        new_path = self._get_volume_path(new_volume)
-        payload = {'newPath': path}
         try:
             self.terminate_connection(new_volume, None)
         except jsonrpc.NefException as error:
-            LOG.debug('Failed to terminate all connections '
+            LOG.error('Failed to terminate all connections '
                       'to migrated volume %(volume)s before '
                       'renaming: %(error)s',
                       {'volume': new_volume['name'],
                        'error': error})
+            raise
+        volume_renamed = False
+        volume_path = self._get_volume_path(volume)
+        new_volume_path = self._get_volume_path(new_volume)
+        bak_volume_path = '%s-backup' % volume_path
+        if volume['host'] == new_volume['host']:
+            volume['_name_id'] = new_volume['id']
+            payload = {'newPath': bak_volume_path}
+            try:
+                self.nef.volumes.rename(volume_path, payload)
+            except jsonrpc.NefException as error:
+                LOG.error('Failed to create backup copy of original '
+                          'volume %(volume)s: %(error)s',
+                          {'volume': volume['name'],
+                           'error': error})
+                if error.code != 'ENOENT':
+                    raise error
+            else:
+                volume_renamed = True
+        payload = {'newPath': volume_path}
         try:
-            self.nef.volumes.rename(new_path, payload)
-        except jsonrpc.NefException as error:
-            LOG.debug('Failed to rename volume %(new_volume)s '
-                      'to %(volume)s after migration: %(error)s',
+            self.nef.volumes.rename(new_volume_path, payload)
+        except jsonrpc.NefException as rename_error:
+            LOG.error('Failed to rename temporary volume %(new_volume)s '
+                      'to original %(volume)s after migration: %(error)s',
                       {'new_volume': new_volume['name'],
                        'volume': volume['name'],
-                       'error': error})
-            name_id = new_volume._name_id or new_volume.id
-        model_update = {'_name_id': name_id}
-        return model_update
+                       'error': rename_error})
+            if volume_renamed:
+                payload = {'newPath': volume_path}
+                try:
+                    self.nef.volumes.rename(bak_volume_path, payload)
+                except jsonrpc.NefException as restore_error:
+                    LOG.error('Failed to restore backup copy of original '
+                              'volume %(volume)s: %(error)s',
+                              {'volume': volume['name'],
+                               'error': restore_error})
+            raise rename_error
+        if volume_renamed:
+            payload = {'newPath': new_volume_path}
+            try:
+                self.nef.volumes.rename(bak_volume_path, payload)
+            except jsonrpc.NefException as error:
+                LOG.error('Failed to rename backup copy of original '
+                          'volume %(volume)s to temporary volume '
+                          '%(new_volume)s: %(error)s',
+                          {'volume': volume['name'],
+                           'new_volume': new_volume['name'],
+                           'error': error})
+        return {'_name_id': None, 'provider_location': None}
 
-    def retype(self, context, volume, new_type, diff, host):
+    def retype(self, ctxt, volume, new_type, diff, host):
         """Retype from one volume type to another."""
         LOG.debug('Retype volume %(volume)s to host %(host)s '
                   'and volume type %(type)s with diff %(diff)s',
-                  {'volume': volume['name'], 'host': host['host'],
+                  {'volume': volume['name'], 'host': host,
                    'type': new_type['name'], 'diff': diff})
-        retyped = False
-        migrated, model_update = self.migrate_volume(context, volume, host)
         volume_path = self._get_volume_path(volume)
-        payload = {'source': True}
-        volume_specs = self.nef.volumes.get(volume_path, payload)
-        payload = {}
-        extra_specs = volume_types.get_volume_type_extra_specs(new_type['id'])
         vendor_specs = self.nef.volumes.properties
+        names = [_['api'] for _ in vendor_specs if 'api' in _]
+        names.append('source')
+        fields = ','.join(names)
+        payload = {'fields': fields, 'source': True}
+        volume_specs = self.nef.volumes.get(volume_path, payload)
+        volume_type_specs = self._get_vendor_properties(vendor_specs,
+                                                        volume,
+                                                        new_type)
+        sparse_volume = volume_type_specs['sparseVolume']
+        payload = {}
         for vendor_spec in vendor_specs:
-            property_name = vendor_spec['name']
             api = vendor_spec['api']
-            if 'retype' in vendor_spec:
-                LOG.debug('Skip retype vendor volume property '
-                          '%(property_name)s. %(reason)s',
-                          {'property_name': property_name,
-                           'reason': vendor_spec['retype']})
-                continue
-            if property_name in extra_specs:
-                extra_spec = extra_specs[property_name]
-                value = self._get_vendor_value(extra_spec, vendor_spec)
+            if api in volume_type_specs:
+                value = volume_type_specs[api]
+                if api in volume_specs:
+                    if volume_specs[api] == value:
+                        continue
+                if 'retype' in vendor_spec:
+                    code = 'EINVAL'
+                    message = (_('Failed to retype volume %(volume)s '
+                                 'to host %(host)s and volume type '
+                                 '%(type)s. %(reason)s')
+                               % {'volume': volume['name'],
+                                  'host': host,
+                                  'type': new_type['name'],
+                                  'reason': vendor_spec['retype']})
+                    raise jsonrpc.NefException(code=code, message=message)
                 payload[api] = value
             elif (api in volume_specs and 'source' in volume_specs and
-                    api in volume_specs['source'] and
-                    volume_specs['source'][api] in ['local', 'received']):
-                if 'cfg' in vendor_spec:
-                    cfg = vendor_spec['cfg']
-                    value = self.configuration.safe_get(cfg)
-                    if volume_specs[api] != value:
-                        payload[api] = value
-                else:
-                    if 'inherit' in vendor_spec:
-                        LOG.debug('Skip inherit vendor volume property '
-                                  '%(property_name)s. %(reason)s',
-                                  {'property_name': property_name,
-                                   'reason': vendor_spec['inherit']})
-                        continue
-                    payload[api] = None
+                  api in volume_specs['source'] and
+                  volume_specs['source'][api] in ['local', 'received']):
+                if volume_specs[api] == vendor_spec['default']:
+                    continue
+                if 'inherit' in vendor_spec:
+                    LOG.debug('Unable to inherit property %(name)s '
+                              'from volume type %(type)s for volume '
+                              '%(volume)s. %(reason)s',
+                              {'name': api,
+                               'type': new_type['name'],
+                               'volume': volume['name'],
+                               'reason': vendor_spec['inherit']})
+                    continue
+                payload[api] = None
+        if 'sparseVolume' in payload:
+            sparse_volume = payload.pop('sparseVolume')
         try:
             self.nef.volumes.set(volume_path, payload)
-            retyped = True
         except jsonrpc.NefException as error:
-            LOG.debug('Failed to retype volume %(volume)s: %(error)s',
-                      {'volume': volume['name'], 'error': error})
-        return retyped or migrated, model_update
+            LOG.error('Failed to retype volume %(volume)s to '
+                      'host %(host)s and volume type %(type)s '
+                      'with payload %(payload)s: %(error)s',
+                      {'volume': volume['name'],
+                       'host': host,
+                       'type': new_type['name'],
+                       'payload': payload,
+                       'error': error})
+            raise
+        reservation = 0 if sparse_volume else None
+        self._set_volume_reservation(volume, reservation)
+        return True, None
 
     def _init_vendor_properties(self):
         """Create a dictionary of vendor unique properties.
@@ -1795,14 +2292,24 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         properties = {}
         vendor_properties = []
         namespace = self.nef.volumes.namespace
-        keys = ('enum', 'default', 'minimum', 'maximum')
+        keys = ['enum', 'default', 'minimum', 'maximum']
         vendor_properties += self.nef.volumes.properties
         vendor_properties += self.nef.logicalunits.properties
         for vendor_spec in vendor_properties:
             property_spec = {}
             for key in keys:
                 if key in vendor_spec:
-                    property_spec[key] = vendor_spec[key]
+                    value = vendor_spec[key]
+                    property_spec[key] = value
+            api = vendor_spec['api']
+            if 'cfg' in vendor_spec:
+                key = vendor_spec['cfg']
+                value = self.configuration.safe_get(key)
+                if value not in [None, '']:
+                    property_spec['default'] = value
+            elif api in self.san_stat:
+                value = self.san_stat[api]
+                property_spec['default'] = value
             property_name = vendor_spec['name']
             property_title = vendor_spec['title']
             property_description = vendor_spec['description']
@@ -1825,29 +2332,36 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             )
         return properties, namespace
 
-    def _get_vendor_properties(self, volume, vendor_specs):
-        properties = extra_specs = {}
-        type_id = volume.get('volume_type_id', None)
-        if type_id:
-            extra_specs = volume_types.get_volume_type_extra_specs(type_id)
+    def _get_vendor_properties(self, vendor_specs, volume, volume_type=None):
+        properties = {}
+        extra_specs = {}
+        if volume_type:
+            volume_type_id = volume_type['id']
+        else:
+            volume_type_id = volume['volume_type_id']
+        if volume_type_id:
+            extra_specs = volume_types.get_volume_type_extra_specs(
+                volume_type_id)
         for vendor_spec in vendor_specs:
-            property_name = vendor_spec['name']
-            if property_name in extra_specs:
-                extra_spec = extra_specs[property_name]
+            api = vendor_spec['api']
+            name = vendor_spec['name']
+            if name in extra_specs:
+                extra_spec = extra_specs[name]
                 value = self._get_vendor_value(extra_spec, vendor_spec)
             elif 'cfg' in vendor_spec:
-                cfg = vendor_spec['cfg']
-                value = self.configuration.safe_get(cfg)
+                key = vendor_spec['cfg']
+                value = self.configuration.safe_get(key)
+                if value in [None, '']:
+                    continue
+            elif volume_type and api in self.san_stat:
+                value = self.san_stat[api]
             else:
                 continue
-            api = vendor_spec['api']
-            if api == 'volumeBlockSize' and value < 512:
-                value *= units.Ki
             properties[api] = value
-            LOG.debug('Get vendor property name %(property_name)s '
-                      'with API name %(api)s and %(type)s value '
+            LOG.debug('Get vendor property name %(name)s with '
+                      'API name %(api)s and %(type)s value '
                       '%(value)s for volume %(volume)s',
-                      {'property_name': property_name,
+                      {'name': name,
                        'api': api,
                        'type': type(value).__name__,
                        'value': value,
@@ -1910,3 +2424,13 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                            % {'value': value, 'enum': enum, 'name': name})
                 raise jsonrpc.NefException(code=code, message=message)
         return value
+
+    def _get_backend_name(self):
+        backend_name = self.configuration.safe_get('volume_backend_name')
+        if not backend_name:
+            LOG.error('Failed to get configured volume backend name')
+            backend_name = '%(product)s_%(protocol)s' % {
+                'product': self.product_name,
+                'protocol': self.storage_protocol
+            }
+        return backend_name

--- a/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -27,6 +26,14 @@ from cinder.i18n import _
 
 LOG = logging.getLogger(__name__)
 
+HTTPS_PORT = 8443
+HTTP_PORT = 8080
+HTTPS = 'https'
+HTTP = 'http'
+AUTO = 'auto'
+NFS = 'nfs'
+ISCSI = 'iscsi'
+
 
 class NefException(exception.VolumeDriverException):
     def __init__(self, data=None, **kwargs):
@@ -50,9 +57,8 @@ class NefException(exception.VolumeDriverException):
         for key in defaults:
             if key not in kwargs:
                 kwargs[key] = defaults[key]
-        message = (_('%(message)s (source: %(source)s, '
-                     'name: %(name)s, code: %(code)s)')
-                   % kwargs)
+        message = ('%(message)s (source: %(source)s, '
+                   'name: %(name)s, code: %(code)s)') % kwargs
         self.code = kwargs['code']
         del kwargs['message']
         super(NefException, self).__init__(message, **kwargs)
@@ -62,11 +68,12 @@ class NefRequest(object):
     def __init__(self, proxy, method):
         self.proxy = proxy
         self.method = method
+        self.attempts = proxy.retries + 1
+        self.payload = None
+        self.error = None
         self.path = None
-        self.lock = False
         self.time = 0
         self.data = []
-        self.payload = {}
         self.stat = {}
         self.hooks = {
             'response': self.hook
@@ -77,246 +84,234 @@ class NefRequest(object):
         }
 
     def __call__(self, path, payload=None):
-        LOG.debug('NEF request start: %(method)s %(path)s %(payload)s',
+        LOG.debug('Start NEF request: %(method)s %(path)s %(payload)s',
                   {'method': self.method, 'path': path, 'payload': payload})
+        self.path = path
+        self.payload = payload
+        for attempt in range(self.attempts):
+            self.data = []
+            if self.error:
+                self.proxy.delay(attempt)
+                if not self.find_host():
+                    continue
+                LOG.debug('Retry NEF request: %(method)s %(path)s %(payload)s '
+                          '[%(attempt)s/%(attempts)s], reason: %(error)s',
+                          {'method': self.method, 'path': path,
+                           'payload': payload, 'attempt': attempt,
+                           'attempts': self.attempts, 'error': self.error})
+            try:
+                response = self.request(self.method, self.path, self.payload)
+            except Exception as error:
+                if isinstance(error, NefException):
+                    self.error = error
+                else:
+                    message = six.text_type(error)
+                    self.error = NefException(message=message)
+                continue
+            LOG.debug('Finish NEF request: %(method)s %(path)s %(payload)s, '
+                      'total response time: %(time)s seconds, '
+                      'total requests count: %(count)s, '
+                      'requests statistics: %(stat)s, '
+                      'response content: %(content)s',
+                      {'method': self.method,
+                       'path': self.path,
+                       'payload': self.payload,
+                       'time': self.time,
+                       'count': sum(self.stat.values()),
+                       'stat': self.stat,
+                       'content': response.content})
+            if response.ok and not response.content:
+                return None
+            content = json.loads(response.content)
+            if not response.ok:
+                raise NefException(content)
+            if isinstance(content, dict) and 'data' in content:
+                return self.data
+            return content
+        LOG.error('Failed NEF request: %(method)s %(path)s '
+                  '%(payload)s, request reached maximum retry '
+                  'attempts: %(attempts)s, reason: %(error)s',
+                  {'method': self.method, 'path': path,
+                   'payload': payload, 'attempts': self.attempts,
+                   'error': self.error})
+        raise self.error
+
+    def request(self, method, path, payload):
         if self.method not in ['get', 'delete', 'put', 'post']:
-            message = (_('NEF API does not support %(method)s method')
+            message = (_('Request method %(method)s not supported')
                        % {'method': self.method})
             raise NefException(code='EINVAL', message=message)
         if not path:
-            message = _('NEF API call requires collection path')
+            message = _('Request path is required')
             raise NefException(code='EINVAL', message=message)
-        self.path = path
+        url = self.proxy.url(path)
+        kwargs = dict(self.kwargs)
         if payload:
             if not isinstance(payload, dict):
-                message = _('NEF API call payload must be a dictionary')
+                message = _('Request payload must be a dictionary')
                 raise NefException(code='EINVAL', message=message)
-            if self.method in ['get', 'delete']:
-                self.payload = {'params': payload}
-            elif self.method in ['put', 'post']:
-                self.payload = {'data': json.dumps(payload)}
-        try:
-            response = self.request(self.method, self.path, **self.payload)
-        except (requests.exceptions.ConnectionError,
-                requests.exceptions.Timeout) as error:
-            LOG.debug('Failed to %(method)s %(path)s %(payload)s: %(error)s',
-                      {'method': self.method, 'path': self.path,
-                       'payload': self.payload, 'error': error})
-            if not self.failover():
-                raise
-            LOG.debug('Retry initial request after failover: '
-                      '%(method)s %(path)s %(payload)s',
-                      {'method': self.method,
-                       'path': self.path,
-                       'payload': self.payload})
-            response = self.request(self.method, self.path, **self.payload)
-        LOG.debug('NEF request done: %(method)s %(path)s %(payload)s, '
-                  'total response time: %(time)s seconds, '
-                  'total requests count: %(count)s, '
-                  'requests statistics: %(stat)s',
-                  {'method': self.method,
-                   'path': self.path,
-                   'payload': self.payload,
-                   'time': self.time,
-                   'count': sum(self.stat.values()),
-                   'stat': self.stat})
-        if response.ok and not response.content:
-            return None
-        content = json.loads(response.content)
-        if not response.ok:
-            raise NefException(content)
-        if isinstance(content, dict) and 'data' in content:
-            return self.data
-        return content
-
-    def request(self, method, path, **kwargs):
-        url = self.proxy.url(path)
-        LOG.debug('Perform session request: %(method)s %(url)s %(body)s',
-                  {'method': method, 'url': url, 'body': kwargs})
-        kwargs.update(self.kwargs)
+            if method in ['get', 'delete']:
+                kwargs['params'] = payload
+            elif method in ['put', 'post']:
+                kwargs['data'] = json.dumps(payload)
+        LOG.debug('Session request: %(method)s %(url)s %(data)s',
+                  {'method': method, 'url': url, 'data': kwargs})
         return self.proxy.session.request(method, url, **kwargs)
 
     def hook(self, response, **kwargs):
-        initial_text = (_('initial request %(method)s %(path)s %(body)s')
-                        % {'method': self.method,
-                           'path': self.path,
-                           'body': self.payload})
-        request_text = (_('session request %(method)s %(url)s %(body)s')
-                        % {'method': response.request.method,
-                           'url': response.request.url,
-                           'body': response.request.body})
-        response_text = (_('session response %(code)s %(content)s')
-                         % {'code': response.status_code,
-                            'content': response.content})
-        text = (_('%(request_text)s and %(response_text)s')
-                % {'request_text': request_text,
-                   'response_text': response_text})
-        LOG.debug('Hook start on %(text)s', {'text': text})
-
+        text = (_('session request %(method)s %(url)s %(body)s '
+                  'and session response %(code)s %(content)s')
+                % {'method': response.request.method,
+                   'url': response.request.url,
+                   'body': response.request.body,
+                   'code': response.status_code,
+                   'content': response.content})
+        LOG.debug('Start request hook on %(text)s', {'text': text})
         if response.status_code not in self.stat:
             self.stat[response.status_code] = 0
         self.stat[response.status_code] += 1
         self.time += response.elapsed.total_seconds()
-
+        attempt = self.stat[response.status_code]
+        limit = len(self.proxy.hosts) * self.attempts
         if response.ok and not response.content:
-            LOG.debug('Hook done on %(text)s: '
-                      'empty response content',
-                      {'text': text})
             return response
-
-        if not response.content:
-            message = (_('There is no response content '
-                         'is available for %(text)s')
-                       % {'text': text})
-            raise NefException(code='ENODATA', message=message)
-
         try:
             content = json.loads(response.content)
         except (TypeError, ValueError) as error:
-            message = (_('Failed to decode JSON for %(text)s: %(error)s')
+            message = (_('Failed request hook on %(text)s: '
+                         'JSON parser error: %(error)s')
                        % {'text': text, 'error': error})
-            raise NefException(code='ENOMSG', message=message)
-
+            raise NefException(code='EINVAL', message=message)
+        if response.ok and content is None:
+            return response
+        if not isinstance(content, dict):
+            message = (_('Failed request hook on %(text)s: '
+                         'no valid content found')
+                       % {'text': text})
+            raise NefException(code='EINVAL', message=message)
+        if attempt > limit and not response.ok:
+            return response
         method = 'get'
         if response.status_code == requests.codes.unauthorized:
-            if self.stat[response.status_code] > self.proxy.retries:
+            if 'code' in content and content['code'] == 'ELICENSE':
                 raise NefException(content)
-            self.auth()
-            LOG.debug('Retry %(text)s after authentication',
-                      {'text': request_text})
+            if not self.auth():
+                raise NefException(content)
             request = response.request.copy()
             request.headers.update(self.proxy.session.headers)
             return self.proxy.session.send(request, **kwargs)
         elif response.status_code == requests.codes.not_found:
-            if self.lock:
-                LOG.debug('Hook done on %(text)s: '
-                          'nested failover is detected',
-                          {'text': text})
-                return response
-            if self.stat[response.status_code] > self.proxy.retries:
+            if not self.check_host():
                 raise NefException(content)
-            if not self.failover():
-                LOG.debug('Hook done on %(text)s: '
-                          'no valid hosts found',
-                          {'text': text})
-                return response
-            LOG.debug('Retry %(text)s after failover',
-                      {'text': initial_text})
-            self.data = []
-            return self.request(self.method, self.path, **self.payload)
+            return response
         elif response.status_code == requests.codes.server_error:
-            if not (isinstance(content, dict) and
-                    'code' in content and
-                    content['code'] == 'EBUSY'):
+            if 'code' in content and content['code'] == 'EBUSY':
                 raise NefException(content)
-            if self.stat[response.status_code] > self.proxy.retries:
-                raise NefException(content)
-            self.proxy.delay(self.stat[response.status_code])
-            LOG.debug('Retry %(text)s after delay',
-                      {'text': initial_text})
-            self.data = []
-            return self.request(self.method, self.path, **self.payload)
+            return response
         elif response.status_code == requests.codes.accepted:
-            path = self.getpath(content, 'monitor')
+            path, payload = self.parse(content, 'monitor')
             if not path:
-                message = (_('There is no monitor path '
-                             'available for %(text)s')
+                message = (_('Failed request hook on %(text)s: '
+                             'monitor path not found')
                            % {'text': text})
-                raise NefException(code='ENOMSG', message=message)
-            self.proxy.delay(self.stat[response.status_code])
-            return self.request(method, path)
+                raise NefException(code='ENODATA', message=message)
+            self.proxy.delay(attempt)
+            return self.request(method, path, payload)
         elif response.status_code == requests.codes.ok:
-            if not (isinstance(content, dict) and 'data' in content):
-                LOG.debug('Hook done on %(text)s: there '
-                          'is no JSON data available',
+            if 'data' not in content or not content['data']:
+                LOG.debug('Finish request hook on %(text)s: '
+                          'non-paginated content',
                           {'text': text})
                 return response
-            LOG.debug('Append %(count)s data items to response',
-                      {'count': len(content['data'])})
-            self.data += content['data']
-            path = self.getpath(content, 'next')
+            data = content['data']
+            LOG.debug('Continue request hook on %(text)s: '
+                      'add %(count)s data items to response',
+                      {'text': text, 'count': len(data)})
+            self.data += data
+            path, payload = self.parse(content, 'next')
             if not path:
-                LOG.debug('Hook done on %(text)s: there '
-                          'is no next path available',
+                LOG.debug('Finish request hook on %(text)s: '
+                          'no next page found',
                           {'text': text})
                 return response
-            LOG.debug('Perform next session request %(method)s %(path)s',
-                      {'method': method, 'path': path})
-            return self.request(method, path)
-        LOG.debug('Hook done on %(text)s and '
-                  'returned original response',
+            if self.payload:
+                payload.update(self.payload)
+            LOG.debug('Continue request hook with new request '
+                      '%(method)s %(path)s %(payload)s',
+                      {'method': method, 'path': path,
+                       'payload': payload})
+            return self.request(method, path, payload)
+        LOG.debug('Finish request hook on %(text)s',
                   {'text': text})
         return response
 
     def auth(self):
         method = 'post'
-        path = 'auth/login'
+        path = '/auth/login'
         payload = {
             'username': self.proxy.username,
             'password': self.proxy.password
         }
-        data = json.dumps(payload)
-        kwargs = {'data': data}
         self.proxy.delete_bearer()
-        response = self.request(method, path, **kwargs)
+        response = self.request(method, path, payload)
         content = json.loads(response.content)
-        if not (isinstance(content, dict) and 'token' in content):
-            message = (_('There is no authentication token available '
-                         'for authentication request %(method)s %(url)s '
-                         '%(body)s and response %(code)s %(content)s')
-                       % {'method': response.request.method,
-                          'url': response.request.url,
-                          'body': response.request.body,
-                          'code': response.status_code,
-                          'content': response.content})
-            raise NefException(code='ENODATA', message=message)
-        token = content['token']
-        self.proxy.update_token(token)
+        if 'token' in content:
+            token = content['token']
+            if token:
+                self.proxy.update_token(token)
+                return True
+        return False
 
-    def failover(self):
-        result = False
-        self.lock = True
+    def check_host(self):
         method = 'get'
-        root = self.proxy.root
+        payload = {
+            'path': self.proxy.pool,
+            'fields': 'path'
+        }
+        LOG.info('Attempt to find pool %(pool)s on host %(host)s',
+                 {'pool': self.proxy.pool,
+                  'host': self.proxy.host})
+        try:
+            response = self.request(method, self.proxy.root, payload)
+        except Exception as error:
+            LOG.error('Failed to find pool %(pool)s '
+                      'on host %(host)s: %(error)s',
+                      {'pool': self.proxy.pool,
+                       'host': self.proxy.host,
+                       'error': error})
+            return False
+        content = json.loads(response.content)
+        if 'data' not in content or not content['data']:
+            LOG.error('Pool %(pool)s not found on host %(host)s',
+                      {'pool': self.proxy.pool,
+                       'host': self.proxy.host})
+            return False
+        LOG.info('Found pool %(pool)s on host %(host)s',
+                 {'pool': self.proxy.pool,
+                  'host': self.proxy.host})
+        return True
+
+    def find_host(self):
         for host in self.proxy.hosts:
             self.proxy.update_host(host)
-            LOG.debug('Try to failover path '
-                      '%(root)s to host %(host)s',
-                      {'root': root, 'host': host})
-            try:
-                response = self.request(method, root)
-            except (requests.exceptions.ConnectionError,
-                    requests.exceptions.Timeout) as error:
-                LOG.debug('Skip unavailable host %(host)s '
-                          'due to error: %(error)s',
-                          {'host': host, 'error': error})
-                continue
-            LOG.debug('Failover result: %(code)s %(content)s',
-                      {'code': response.status_code,
-                       'content': response.content})
-            if response.status_code == requests.codes.ok:
-                LOG.debug('Successful failover path '
-                          '%(root)s to host %(host)s',
-                          {'root': root, 'host': host})
-                result = True
-                break
-            else:
-                LOG.debug('Skip unsuitable host %(host)s: '
-                          'there is no %(root)s path found',
-                          {'host': host, 'root': root})
-        self.lock = False
-        return result
+            if self.check_host():
+                return True
+        return False
 
     @staticmethod
-    def getpath(content, name):
-        if isinstance(content, dict) and 'links' in content:
-            for link in content['links']:
-                if not isinstance(link, dict):
-                    continue
-                if 'rel' in link and 'href' in link:
-                    if link['rel'] == name:
-                        return link['href']
-        return None
+    def parse(content, name):
+        if 'links' in content:
+            links = content['links']
+            if isinstance(links, list):
+                for link in links:
+                    if (isinstance(link, dict) and
+                            'href' in link and
+                            'rel' in link and
+                            link['rel'] == name):
+                        url = six.moves.urllib.parse.urlparse(link['href'])
+                        payload = six.moves.urllib.parse.parse_qs(url.query)
+                        return url.path, payload
+        return None, None
 
 
 class NefCollections(object):
@@ -440,7 +435,7 @@ class NefVolumes(NefVolumeGroups, NefDatasets, NefCollections):
             {
                 'name': self.key('blocksize'),
                 'api': 'volumeBlockSize',
-                'cfg': 'nexenta_ns5_blocksize',
+                'cfg': 'nexenta_blocksize',
                 'title': 'Block size',
                 'retype': _('Volume block size cannot be changed after '
                             'the volume has been created.'),
@@ -545,14 +540,13 @@ class NefVolumes(NefVolumeGroups, NefDatasets, NefCollections):
             {
                 'name': self.key('thin_provisioning'),
                 'api': 'sparseVolume',
-                'cfg': 'nexenta_sparse',
+                'cfg': 'nexenta_sparsed_volumes',
                 'title': 'Thin provisioning',
-                'retype': _('Volume provisioning type cannot be changed '
-                            'after the volume has been created.'),
+                'inherit': _('Provisioning type cannot be inherit.'),
                 'description': _('Controls if a volume is created sparse '
                                  '(with no space reservation).'),
                 'type': 'boolean',
-                'default': False
+                'default': True
             },
             {
                 'name': self.key('sync'),
@@ -601,16 +595,12 @@ class NefFilesystems(NefVolumes, NefVolumeGroups, NefDatasets, NefCollections):
         self.subj = 'filesystem'
         for prop in self.properties:
             if prop['name'] == self.key('blocksize'):
-                del prop['cfg']
+                del prop['retype']
                 prop['api'] = 'recordSize'
                 prop['description'] = _('Specifies a suggested block size '
                                         'for a volume.')
                 prop['enum'] = [512, 1024, 2048, 4096, 8192, 16384, 32768,
                                 65536, 131072, 262144, 524288, 1048576]
-                prop['default'] = 131072
-            elif prop['name'] == self.key('thin_provisioning'):
-                prop['cfg'] = 'nexenta_sparsed_volumes'
-                prop['default'] = True
         self.properties.append({
             'name': self.key('rate_limit'),
             'api': 'rateLimit',
@@ -621,6 +611,25 @@ class NefFilesystems(NefVolumes, NefVolumeGroups, NefDatasets, NefCollections):
             'default': 0
         })
         self.properties.append({
+            'name': self.key('nbmand'),
+            'api': 'nonBlockingMandatoryMode',
+            'title': 'Non-blocking mandatory locking',
+            'description': _('Allow or disallow non-blocking mandatory '
+                             'locking semantics for a volume.'),
+            'type': 'boolean',
+            'default': False
+        })
+        self.properties.append({
+            'name': self.key('smart_compression'),
+            'api': 'smartCompression',
+            'title': 'Smart compression',
+            'description': _('Allow or disallow dynamically tracks volume '
+                             'compression ratios to determine if a volume '
+                             'data is compressible or not.'),
+            'type': 'boolean',
+            'default': False
+        })
+        self.properties.append({
             'name': self.key('snapdir'),
             'api': 'snapshotDirectory',
             'title': '.zfs directory visibility',
@@ -629,6 +638,17 @@ class NefFilesystems(NefVolumes, NefVolumeGroups, NefDatasets, NefCollections):
                              'the volume file system.'),
             'type': 'boolean',
             'default': False
+        })
+        self.properties.append({
+            'name': self.key('format'),
+            'api': 'volumeFormat',
+            'cfg': 'nexenta_volume_format',
+            'title': 'Volume format',
+            'description': _('Controls volume format.'),
+            'enum': ['raw', 'qcow', 'qcow2', 'parallels',
+                     'vdi', 'vhdx', 'vmdk', 'vpc', 'qed'],
+            'type': 'string',
+            'default': 'raw'
         })
 
     def mount(self, name, payload=None):
@@ -675,7 +695,7 @@ class NefRsf(NefCollections):
 
     def __init__(self, proxy):
         super(NefRsf, self).__init__(proxy)
-        self.root = 'rsf/clusters'
+        self.root = '/rsf/clusters'
         self.subj = 'RSF Clusters'
 
 
@@ -766,8 +786,7 @@ class NefNetAddresses(NefCollections):
 
 
 class NefProxy(object):
-    def __init__(self, proto, path, conf):
-        self.session = requests.Session()
+    def __init__(self, proto, pool, path, conf):
         self.settings = NefSettings(self)
         self.filesystems = NefFilesystems(self)
         self.volumegroups = NefVolumeGroups(self)
@@ -784,54 +803,58 @@ class NefProxy(object):
         self.logicalunits = NefLogicalUnits(self)
         self.netaddrs = NefNetAddresses(self)
         self.lock = None
+        self.auto = False
         self.tokens = {}
         self.headers = {
             'Content-Type': 'application/json',
             'X-XSS-Protection': '1'
         }
-        if conf.nexenta_use_https:
-            self.scheme = 'https'
+        if conf.nexenta_use_https is None:
+            self.scheme = conf.nexenta_rest_protocol
+            if self.scheme == AUTO:
+                self.auto = True
+                self.scheme = HTTPS
         else:
-            self.scheme = 'http'
+            if conf.nexenta_use_https:
+                self.scheme = HTTPS
+            else:
+                self.scheme = HTTP
+        if conf.nexenta_rest_port:
+            self.port = conf.nexenta_rest_port
+        else:
+            if self.scheme == HTTPS:
+                self.port = HTTPS_PORT
+            else:
+                self.port = HTTP_PORT
         self.username = conf.nexenta_user
         self.password = conf.nexenta_password
         self.hosts = []
         if conf.nexenta_rest_address:
             for host in conf.nexenta_rest_address.split(','):
                 self.hosts.append(host.strip())
-        if proto == 'nfs':
-            self.root = self.filesystems.path(path)
-            if not self.hosts:
-                self.hosts.append(conf.nas_host)
-        elif proto == 'iscsi':
-            self.root = self.volumegroups.path(path)
-            if not self.hosts:
-                self.hosts.append(conf.nexenta_host)
+        elif proto == ISCSI and conf.nexenta_host:
+            self.hosts.append(conf.nexenta_host)
+        elif proto == NFS and conf.nas_host:
+            self.hosts.append(conf.nas_host)
         else:
-            message = (_('Storage protocol %(proto)s not supported')
-                       % {'proto': proto})
-            raise NefException(code='EPROTO', message=message)
+            message = (_('NexentaStor Rest API address is not defined, '
+                         'please check the Cinder configuration file for '
+                         'NexentaStor backend and nexenta_rest_address, '
+                         'nexenta_host or nas_host configuration options'))
+            raise NefException(code='EINVAL', message=message)
         self.host = self.hosts[0]
-        if conf.nexenta_rest_port:
-            self.port = conf.nexenta_rest_port
-        else:
-            if conf.nexenta_use_https:
-                self.port = 8443
-            else:
-                self.port = 8080
-        self.proto = proto
+        self.pool = pool
         self.path = path
+        self.root = self.filesystems.root
+        self.retries = conf.nexenta_rest_retry_count
         self.backoff_factor = conf.nexenta_rest_backoff_factor
-        self.retries = len(self.hosts) * conf.nexenta_rest_retry_count
         self.timeout = (conf.nexenta_rest_connect_timeout,
                         conf.nexenta_rest_read_timeout)
-        max_retries = requests.packages.urllib3.util.retry.Retry(
-            total=conf.nexenta_rest_retry_count,
-            backoff_factor=conf.nexenta_rest_backoff_factor)
-        adapter = requests.adapters.HTTPAdapter(max_retries=max_retries)
+        self.session = requests.Session()
         self.session.verify = conf.driver_ssl_cert_verify
+        if self.session.verify and conf.driver_ssl_cert_path:
+            self.session.verify = conf.driver_ssl_cert_path
         self.session.headers.update(self.headers)
-        self.session.mount('%s://' % self.scheme, adapter)
         if not conf.driver_ssl_cert_verify:
             requests.packages.urllib3.disable_warnings()
         self.update_lock()
@@ -893,23 +916,24 @@ class NefProxy(object):
         if not guid:
             guid = ':'.join(sorted(self.hosts))
         lock = '%s:%s' % (guid, self.path)
-        if six.PY3:
+        if isinstance(lock, six.text_type):
             lock = lock.encode('utf-8')
         self.lock = hashlib.md5(lock).hexdigest()
         LOG.debug('NEF coordination lock: %(lock)s',
                   {'lock': self.lock})
 
-    def url(self, path):
-        if not path:
-            message = _('NEF API url requires path')
-            raise NefException(code='EINVAL', message=message)
+    def url(self, path=''):
         netloc = '%s:%d' % (self.host, self.port)
         components = (self.scheme, netloc, path, None, None)
         url = six.moves.urllib.parse.urlunsplit(components)
         return url
 
     def delay(self, attempt):
-        interval = int(self.backoff_factor * (2 ** (attempt - 1)))
+        if self.retries > 0:
+            attempt %= self.retries
+            if attempt == 0:
+                attempt = self.retries
+        interval = float(self.backoff_factor * (2 ** (attempt - 1)))
         LOG.debug('Waiting for %(interval)s seconds',
                   {'interval': interval})
         greenthread.sleep(interval)

--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -14,12 +13,14 @@
 #    under the License.
 
 import errno
-import hashlib
 import ipaddress
 import os
 import posixpath
+import sys
 import uuid
 
+from os_brick.remotefs import remotefs
+from oslo_concurrency import processutils
 from oslo_log import log as logging
 from oslo_utils import strutils
 from oslo_utils import units
@@ -28,16 +29,30 @@ import six
 from cinder import context
 from cinder import coordination
 from cinder.i18n import _
+from cinder.image import image_utils
 from cinder import interface
 from cinder import objects
 from cinder.privsep import fs
+from cinder import utils as cinder_utils
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 from cinder.volume.drivers.nexenta import options
+from cinder.volume.drivers.nexenta import utils as nexenta_utils
 from cinder.volume.drivers import nfs
 from cinder.volume import volume_types
 from cinder.volume import volume_utils
 
 LOG = logging.getLogger(__name__)
+
+VOLUME_FILE_NAME = 'volume'
+VOLUME_FORMAT_RAW = 'raw'
+VOLUME_FORMAT_QCOW = 'qcow'
+VOLUME_FORMAT_QCOW2 = 'qcow2'
+VOLUME_FORMAT_PARALLELS = 'parallels'
+VOLUME_FORMAT_VDI = 'vdi'
+VOLUME_FORMAT_VHDX = 'vhdx'
+VOLUME_FORMAT_VMDK = 'vmdk'
+VOLUME_FORMAT_VPC = 'vpc'
+VOLUME_FORMAT_QED = 'qed'
 
 
 @interface.volumedriver
@@ -84,14 +99,27 @@ class NexentaNfsDriver(nfs.NfsDriver):
         1.8.2 - Added manage/unmanage/manageable-list volume/snapshot support.
         1.8.3 - Added consistency group capability to generic volume group.
         1.8.4 - Refactored storage assisted volume migration.
-                Added support for volume retype.
-                Added support for volume type extra specs.
-                Added vendor capabilities support.
+              - Added support for volume retype.
+              - Added support for volume type extra specs.
+              - Added vendor capabilities support.
         1.8.5 - Fixed NFS protocol version for generic volume migration.
         1.8.6 - Fixed post-migration volume mount.
+        1.8.7 - Added workaround for pagination.
+        1.8.8 - Improved error messages.
+              - Improved compatibility with initial driver versions.
+              - Added throttle for storage assisted volume migration.
+        1.8.9 - Added support for different volume formats.
+              - Added space reservation for thick provisioned volumes.
+              - Fixed renaming volume after generic migration.
+              - Fixed properties for volumes created from snapshot.
+              - Allow retype volume to another provisioning type.
+        1.9.0 - Added image caching using clone_image method.
+        1.9.1 - Added flag backend_state to report backend status.
+              - Added retry on driver initialization failure.
+              - Added QoS support in terms of I/O throttling rate.
     """
 
-    VERSION = '1.8.6'
+    VERSION = '1.9.1'
     CI_WIKI_NAME = "Nexenta_CI"
 
     vendor_name = 'Nexenta'
@@ -99,7 +127,8 @@ class NexentaNfsDriver(nfs.NfsDriver):
     storage_protocol = 'NFS'
     driver_volume_type = 'nfs'
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, execute=processutils.execute, *args, **kwargs):
+        self._remotefsclient = None
         super(NexentaNfsDriver, self).__init__(*args, **kwargs)
         if not self.configuration:
             message = (_('%(product_name)s %(storage_protocol)s '
@@ -107,64 +136,331 @@ class NexentaNfsDriver(nfs.NfsDriver):
                        % {'product_name': self.product_name,
                           'storage_protocol': self.storage_protocol})
             raise jsonrpc.NefException(code='ENODATA', message=message)
-        self.configuration.append_config_values(
-            options.NEXENTA_CONNECTION_OPTS)
-        self.configuration.append_config_values(
-            options.NEXENTA_NFS_OPTS)
-        self.configuration.append_config_values(
-            options.NEXENTA_DATASET_OPTS)
+        self.configuration.append_config_values(options.NEXENTASTOR5_NFS_OPTS)
+        root_helper = cinder_utils.get_root_helper()
+        mount_point_base = self.configuration.nexenta_mount_point_base
+        self.mount_point_base = os.path.realpath(mount_point_base)
+        nfs_options = self.configuration.safe_get('nfs_mount_options')
+        nas_options = self.configuration.safe_get('nas_mount_options')
+        if nfs_options and nas_options:
+            LOG.debug('Overriding NFS mount options: '
+                      'nfs_mount_options = "%(nfs_options)s" with '
+                      'nas_mount_options = "%(nas_options)s"',
+                      {'nfs_options': nfs_options,
+                       'nas_options': nas_options})
+        if nas_options:
+            self.mount_options = nas_options
+        elif nfs_options:
+            self.mount_options = nfs_options
+        else:
+            self.mount_options = None
+        self._remotefsclient = remotefs.RemoteFsClient(
+            self.driver_volume_type,
+            root_helper, execute=execute,
+            nfs_mount_point_base=self.mount_point_base,
+            nfs_mount_options=self.mount_options)
         self.nef = None
-        self.driver_name = self.__class__.__name__
+        self.nas_stat = None
+        self.backend_name = self._get_backend_name()
+        self.nas_driver = self.__class__.__name__
         self.nas_host = self.configuration.nas_host
-        self.root_path = self.configuration.nas_share_path
-        self.mount_point_base = self.configuration.nexenta_mount_point_base
+        self.nas_path = self.configuration.nas_share_path
+        self.nas_pool = self.nas_path.split(posixpath.sep)[0]
+        self.image_cache = self.configuration.nexenta_image_cache
+        self.nbmand = self.configuration.nexenta_nbmand
+        self.smart_compression = (
+            self.configuration.nexenta_smart_compression)
         self.group_snapshot_template = (
             self.configuration.nexenta_group_snapshot_template)
         self.origin_snapshot_template = (
             self.configuration.nexenta_origin_snapshot_template)
+        self.cache_image_template = (
+            self.configuration.nexenta_cache_image_template)
+        self.cache_snapshot_template = (
+            self.configuration.nexenta_cache_snapshot_template)
+        self.migration_service_prefix = (
+            self.configuration.nexenta_migration_service_prefix)
+        self.migration_throttle = (
+            self.configuration.nexenta_migration_throttle)
 
     @staticmethod
     def get_driver_options():
-        return (
-            options.NEXENTA_CONNECTION_OPTS +
-            options.NEXENTA_NFS_OPTS +
-            options.NEXENTA_DATASET_OPTS
-        )
+        return options.NEXENTASTOR5_NFS_OPTS
 
-    def do_setup(self, context):
-        self.nef = jsonrpc.NefProxy(self.driver_volume_type,
-                                    self.root_path,
-                                    self.configuration)
+    def do_setup(self, ctxt):
+        retries = 0
+        while not self._do_setup():
+            retries += 1
+            self.nef.delay(retries)
+
+    def _do_setup(self):
+        try:
+            self.nef = jsonrpc.NefProxy(self.driver_volume_type,
+                                        self.nas_pool, self.nas_path,
+                                        self.configuration)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to initialize RESTful API for backend '
+                      '%(backend_name)s on host %(host)s: %(error)s',
+                      {'backend_name': self.backend_name,
+                       'host': self.host,
+                       'error': error})
+            return False
+        return True
 
     def check_for_setup_error(self):
+        retries = 0
+        while not self._check_for_setup_error():
+            retries += 1
+            self.nef.delay(retries)
+
+    def _check_for_setup_error(self):
         """Check root filesystem, NFS service and NFS share."""
-        filesystem = self.nef.filesystems.get(self.root_path)
-        if filesystem['mountPoint'] == 'none':
-            message = (_('NFS root filesystem %(path)s is not writable')
-                       % {'path': filesystem['mountPoint']})
-            raise jsonrpc.NefException(code='ENOENT', message=message)
-        if not filesystem['isMounted']:
-            message = (_('NFS root filesystem %(path)s is not mounted')
-                       % {'path': filesystem['mountPoint']})
-            raise jsonrpc.NefException(code='ENOTDIR', message=message)
-        payload = {}
-        if filesystem['nonBlockingMandatoryMode']:
-            payload['nonBlockingMandatoryMode'] = False
-        if filesystem['smartCompression']:
-            payload['smartCompression'] = False
-        if payload:
-            self.nef.filesystems.set(self.root_path, payload)
-        service = self.nef.services.get('nfs')
+        payload = {'fields': 'path'}
+        try:
+            self.nef.filesystems.get(self.nas_pool, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to get stat of NAS pool %(nas_pool)s: %(error)s',
+                      {'nas_pool': self.nas_pool, 'error': error})
+            return False
+        specs = self.nef.filesystems.properties
+        names = [spec['api'] for spec in specs if 'api' in spec]
+        names.remove('sparseVolume')
+        names.remove('volumeFormat')
+        names.append('mountPoint')
+        names.append('isMounted')
+        fields = ','.join(names)
+        payload = {'fields': fields}
+        try:
+            self.nas_stat = self.nef.filesystems.get(self.nas_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to get stat of NAS path %(nas_path)s: %(error)s',
+                      {'nas_path': self.nas_path, 'error': error})
+            return False
+        if self.nas_stat['mountPoint'] == 'none':
+            LOG.error('NAS path %(nas_path)s is not writable',
+                      {'nas_path': self.nas_path})
+            return False
+        if not self.nas_stat['isMounted']:
+            LOG.error('NAS path %(nas_path)s is not mounted',
+                      {'nas_path': self.nas_path})
+            return False
+        try:
+            service = self.nef.services.get('nfs')
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to get state of NFS service: %(error)s',
+                      {'error': error})
+            return False
         if service['state'] != 'online':
-            message = (_('NFS server service is not online: %(state)s')
-                       % {'state': service['state']})
-            raise jsonrpc.NefException(code='ESRCH', message=message)
-        share = self.nef.nfs.get(self.root_path)
+            LOG.error('NFS service is not online: %(state)s',
+                      {'state': service['state']})
+            return False
+        try:
+            share = self.nef.nfs.get(self.nas_path)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to get state of NFS share %(share)s: %(error)s',
+                      {'share': self.nas_path, 'error': error})
+            return False
         if share['shareState'] != 'online':
-            message = (_('NFS share %(share)s is not online: %(state)s')
-                       % {'share': self.root_path,
-                          'state': share['shareState']})
-            raise jsonrpc.NefException(code='ESRCH', message=message)
+            LOG.error('NFS share %(share)s is not online: %(state)s',
+                      {'share': self.nas_path,
+                       'state': share['shareState']})
+            return False
+        payload = {}
+        if self.nas_stat['nonBlockingMandatoryMode'] != self.nbmand:
+            payload['nonBlockingMandatoryMode'] = self.nbmand
+        if self.nas_stat['smartCompression'] != self.smart_compression:
+            payload['smartCompression'] = self.smart_compression
+        if not payload:
+            return True
+        try:
+            self.nef.filesystems.set(self.nas_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to set NAS path %(nas_path)s '
+                      'properties %{payload}s: %(error)s',
+                      {'nas_path': self.nas_path,
+                       'payload': payload, 'error': error})
+            return False
+        self.nas_stat.update(payload)
+        return True
+
+    def _update_volume_properties(self, volume):
+        """Updates the existing volume properties.
+
+        :param volume: volume reference
+        """
+        if not volume['volume_type_id']:
+            return
+        ctxt = context.get_admin_context()
+        volume_type_id = volume['volume_type_id']
+        volume_type = volume_types.get_volume_type(ctxt, volume_type_id)
+        diff = {}
+        host = volume['host']
+        self.retype(ctxt, volume, volume_type, diff, host)
+
+    def _get_volume_reservation(self, volume, volume_size, volume_format):
+        """Calculates the correct reservation size for given volume size.
+
+        Its purpose is to reserve additional space for volume metadata
+        so volume don't unexpectedly run out of room. This function is
+        a copy of the volsize_to_reservation function in libzfs_dataset.c
+        and qcow2_calc_prealloc_size function in qcow2.c
+
+        :param volume: volume reference
+        :param volume_size: volume size in bytes
+        :param volume_format: volume backend file format
+        :returns: reservation size
+        """
+        volume_path = self._get_volume_path(volume)
+        payload = {'fields': 'recordSize,dataCopies'}
+        filesystem = self.nef.filesystems.get(volume_path, payload)
+        block_size = filesystem['recordSize']
+        data_copies = filesystem['dataCopies']
+        reservation = volume_size
+        numdb = 7
+        dn_max_indblkshift = 17
+        spa_blkptrshift = 7
+        spa_dvas_per_bp = 3
+        dnodes_per_level_shift = dn_max_indblkshift - spa_blkptrshift
+        dnodes_per_level = 1 << dnodes_per_level_shift
+        nblocks = reservation // block_size
+        while nblocks > 1:
+            nblocks += dnodes_per_level - 1
+            nblocks //= dnodes_per_level
+            numdb += nblocks
+        numdb *= min(spa_dvas_per_bp, data_copies + 1)
+        reservation *= data_copies
+        numdb *= 1 << dn_max_indblkshift
+        reservation += numdb
+        if volume_format == VOLUME_FORMAT_RAW:
+            meta_size = 0
+        elif volume_format == VOLUME_FORMAT_QCOW:
+            meta_size = 48 + 4 * volume_size // units.Mi
+        elif volume_format == VOLUME_FORMAT_QCOW2:
+            cluster_size = 64 * units.Ki
+            refcount_size = 4
+            int_size = (sys.maxsize.bit_length() + 1) // 8
+            meta_size = 0
+            aligned_volume_size = nexenta_utils.roundup(volume_size,
+                                                        cluster_size)
+            meta_size += cluster_size
+            blocks_per_table = cluster_size // int_size
+            clusters = aligned_volume_size // cluster_size
+            nl2e = nexenta_utils.roundup(clusters, blocks_per_table)
+            meta_size += nl2e * int_size
+            clusters = nl2e * int_size // cluster_size
+            nl1e = nexenta_utils.roundup(clusters, blocks_per_table)
+            meta_size += nl1e * int_size
+            clusters = (aligned_volume_size + meta_size) // cluster_size
+            refcounts_per_block = 8 * cluster_size // (1 << refcount_size)
+            table = blocks = first = 0
+            last = 1
+            while first != last:
+                last = first
+                first = clusters + blocks + table
+                blocks = nexenta_utils.divup(first, refcounts_per_block)
+                table = nexenta_utils.divup(blocks, blocks_per_table)
+                first = clusters + blocks + table
+            meta_size += (blocks + table) * cluster_size
+        elif volume_format == VOLUME_FORMAT_PARALLELS:
+            meta_size = (1 + volume_size // units.Gi // 256) * units.Mi
+        elif volume_format == VOLUME_FORMAT_VDI:
+            meta_size = 512 + 4 * volume_size // units.Mi
+        elif volume_format == VOLUME_FORMAT_VHDX:
+            meta_size = 8 * units.Mi
+        elif volume_format == VOLUME_FORMAT_VMDK:
+            meta_size = 192 * (units.Ki + volume_size // units.Mi)
+        elif volume_format == VOLUME_FORMAT_VPC:
+            meta_size = 512 + 2 * (units.Ki + volume_size // units.Mi)
+        elif volume_format == VOLUME_FORMAT_QED:
+            meta_size = 320 * units.Ki
+        else:
+            message = (_('Volume format %(volume_format)s is not supported')
+                       % {'volume_format': volume_format})
+            raise jsonrpc.NefException(code='EINVAL', message=message)
+        reservation += meta_size
+        volume_meta = reservation - volume_size
+        LOG.debug('Reservation size for %(format)s volume %(volume)s: '
+                  '%(reservation)s, volume data size: %(volume_size)s, '
+                  'volume metadata size: %(volume_meta)s and volume '
+                  'file metadata size: %(meta_size)s',
+                  {'format': volume_format, 'volume': volume['name'],
+                   'reservation': reservation, 'volume_size': volume_size,
+                   'volume_meta': volume_meta, 'meta_size': meta_size})
+        return reservation
+
+    def _set_volume_reservation(self, volume, volume_size, volume_format):
+        volume_reservation = 0
+        if volume_size:
+            volume_reservation = self._get_volume_reservation(volume,
+                                                              volume_size,
+                                                              volume_format)
+        volume_path = self._get_volume_path(volume)
+        payload = {'referencedReservationSize': volume_reservation}
+        try:
+            self.nef.filesystems.set(volume_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to set %(format)s volume %(volume)s '
+                      'reservation size to %(reservation)s: %(error)s',
+                      {'format': volume_format,
+                       'volume': volume['name'],
+                       'reservation': volume_reservation,
+                       'error': error})
+            raise
+
+    def _change_volume_format(self, volume, volume_file, src_format,
+                              dst_format):
+        backup_file = '%(path)s.%(format)s' % {
+            'path': volume_file,
+            'format': src_format
+        }
+        try:
+            self._execute('mv', volume_file, backup_file, run_as_root=True)
+        except OSError as error:
+            code = errno.errorcode[error.errno]
+            message = (_('Failed to rename backend file %(volume_file)s '
+                         'to %(backup_file)s before converting volume '
+                         '%(volume)s: %(error)s')
+                       % {'volume_file': volume_file,
+                          'backup_file': backup_file,
+                          'volume': volume['name'],
+                          'error': error.strerror})
+            raise jsonrpc.NefException(code=code, message=message)
+        try:
+            self._execute('qemu-img', 'convert',
+                          '-f', src_format,
+                          '-O', dst_format,
+                          backup_file,
+                          volume_file,
+                          run_as_root=True)
+        except OSError as error:
+            code = errno.errorcode[error.errno]
+            message = (_('Failed to convert %(src_format)s file '
+                         '%(backup_file)s to %(dst_format)s file '
+                         '%(volume_file)s for volume %(volume)s: %(error)s')
+                       % {'src_format': src_format,
+                          'backup_file': backup_file,
+                          'dst_format': dst_format,
+                          'volume_file': volume_file,
+                          'volume': volume['name'],
+                          'error': error.strerror})
+            raise jsonrpc.NefException(code=code, message=message)
+        try:
+            self._execute('rm', '-f', backup_file, run_as_root=True)
+        except OSError as error:
+            code = errno.errorcode[error.errno]
+            message = (_('Failed to delete %(src_format)s backup '
+                         'file %(backup_file)s after converting '
+                         'volume %(volume)s: %(error)s')
+                       % {'src_format': src_format,
+                          'backup_file': backup_file,
+                          'volume': volume['name'],
+                          'error': error.strerror})
+            raise jsonrpc.NefException(code=code, message=message)
+        LOG.debug('Successfully converted volume %(volume)s from '
+                  '%(src_format)s to %(dst_format)s format',
+                  {'volume': volume['name'],
+                   'src_format': src_format,
+                   'dst_format': dst_format})
 
     @coordination.synchronized('{self.nef.lock}')
     def create_volume(self, volume):
@@ -173,93 +469,221 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: volume reference
         """
         volume_path = self._get_volume_path(volume)
+        volume_size = volume['size'] * units.Gi
         properties = self.nef.filesystems.properties
-        payload = self._get_vendor_properties(volume, properties)
-        sparsed_volume = payload.pop('sparseVolume', True)
-        payload.update({'path': volume_path})
+        payload = self._get_vendor_properties(properties, volume)
+        sparse_volume = payload.pop('sparseVolume')
+        volume_format = payload.pop('volumeFormat')
+        specs = {'size': volume_size}
+        if volume_format == VOLUME_FORMAT_QCOW2:
+            specs['preallocation'] = 'metadata'
+        volume_options = ','.join(['%s=%s' % _ for _ in specs.items()])
+        payload['path'] = volume_path
         self.nef.filesystems.create(payload)
+        if not sparse_volume:
+            self._set_volume_reservation(volume, volume_size, volume_format)
+        self._set_volume_acl(volume)
+        nfs_share, mount_point, volume_file = self._mount_volume(volume)
+        self._execute('qemu-img', 'create',
+                      '-f', volume_format,
+                      '-o', volume_options,
+                      volume_file,
+                      run_as_root=True)
+        self._unmount_volume(volume, nfs_share, mount_point)
+
+    @coordination.synchronized('{self.nef.lock}-{volume[id]}')
+    def copy_image_to_volume(self, ctxt, volume, image_service, image_id):
+        nfs_share, mount_point, volume_file = self._mount_volume(volume)
+        volume_info = image_utils.qemu_img_info(volume_file,
+                                                force_share=True,
+                                                run_as_root=True)
+        volume_format = volume_info.file_format
+        volume_blocksize = self.configuration.volume_dd_blocksize
+        LOG.debug('Copy image %(image)s to %(format)s volume %(volume)s',
+                  {'image': image_id,
+                   'format': volume_format,
+                   'volume': volume['name']})
+        if volume_format not in [VOLUME_FORMAT_RAW, VOLUME_FORMAT_QCOW2]:
+            volume_format = VOLUME_FORMAT_RAW
+        image_utils.fetch_to_volume_format(ctxt, image_service, image_id,
+                                           volume_file, volume_format,
+                                           volume_blocksize,
+                                           run_as_root=True)
+        image_utils.resize_image(volume_file, volume['size'],
+                                 run_as_root=True)
+        if volume_format not in [VOLUME_FORMAT_RAW, VOLUME_FORMAT_QCOW2]:
+            volume_new_format = volume_info.file_format
+            self._change_volume_format(volume, volume_file, volume_format,
+                                       volume_new_format)
+        self._unmount_volume(volume, nfs_share, mount_point)
+
+    def _verify_cache_image(self, ctxt, volume, image_meta, image_service):
+        properties = self.nef.filesystems.properties
+        volume_type_specs = self._get_vendor_properties(properties, volume)
+        volume_format = volume_type_specs['volumeFormat']
+        image_id = image_meta['id']
+        image_checksum = image_meta['checksum']
+        namespace = uuid.UUID(image_id, version=4)
+        name = '%s:%s' % (image_checksum, volume_format)
+        name = nexenta_utils.native_string(name)
+        cache_uuid = uuid.uuid5(namespace, name)
+        cache_id = six.text_type(cache_uuid)
+        cache = {
+            'id': cache_id,
+            'name': self.cache_image_template % cache_id,
+            'volume_type_id': volume['volume_type_id']
+        }
+        cache_path = self._get_volume_path(cache)
+        payload = {'fields': 'readOnly'}
+        cache_exist = False
         try:
-            self._set_volume_acl(volume)
-            self._mount_volume(volume)
-            volume_file = self.local_path(volume)
-            if sparsed_volume:
-                self._create_sparsed_file(volume_file, volume['size'])
+            cache_specs = self.nef.filesystems.get(cache_path, payload)
+            if not cache_specs['readOnly']:
+                self.delete_volume(cache)
             else:
-                payload = {'source': True}
-                filesystem = self.nef.filesystems.get(volume_path, payload)
-                compression = filesystem['compressionMode']
-                source = filesystem['source']['compressionMode']
-                if compression != 'off':
-                    payload = {'compressionMode': 'off'}
-                    self.nef.filesystems.set(volume_path, payload)
-                self._create_regular_file(volume_file, volume['size'])
-                if compression != 'off':
-                    if source in ['local', 'received']:
-                        payload = {'compressionMode': compression}
-                    else:
-                        payload = {'compressionMode': None}
-                    self.nef.filesystems.set(volume_path, payload)
-        except jsonrpc.NefException as create_error:
-            try:
-                payload = {'force': True}
-                self.nef.filesystems.delete(volume_path, payload)
-            except jsonrpc.NefException as delete_error:
-                LOG.debug('Failed to delete volume %(path)s: %(error)s',
-                          {'path': volume_path, 'error': delete_error})
-            raise create_error
-        finally:
-            self._unmount_volume(volume)
+                cache_exist = True
+        except jsonrpc.NefException as error:
+            if error.code != 'ENOENT':
+                raise
+        if not cache_exist:
+            with image_utils.TemporaryImages.fetch(image_service, ctxt,
+                                                   image_id) as image_file:
+                image_info = image_utils.qemu_img_info(image_file,
+                                                       force_share=True,
+                                                       run_as_root=True)
+        else:
+            nfs_share, mount_point, cache_file = self._mount_volume(cache)
+            image_info = image_utils.qemu_img_info(cache_file,
+                                                   force_share=True,
+                                                   run_as_root=True)
+            self._unmount_volume(cache, nfs_share, mount_point)
+        image_size = nexenta_utils.roundup(image_info.virtual_size, units.Gi)
+        cache['size'] = image_size // units.Gi
+        if cache['size'] > volume['size']:
+            code = 'ENOSPC'
+            message = (_('Unable to clone cache %(cache)s '
+                         'to volume %(volume)s: cache size '
+                         '%(cache_size)sGB is larger than '
+                         'volume size %(volume_size)sGB')
+                       % {'cache': cache['name'],
+                          'volume': volume['name'],
+                          'cache_size': cache['size'],
+                          'volume_size': volume['size']})
+            raise jsonrpc.NefException(code=code, message=message)
+        if not cache_exist:
+            self.create_volume(cache)
+            self.copy_image_to_volume(ctxt, cache, image_service, image_id)
+            payload = {'readOnly': True}
+            self.nef.filesystems.set(cache_path, payload)
+        return cache
 
-    def copy_image_to_volume(self, context, volume, image_service, image_id):
-        LOG.debug('Copy image %(image)s to volume %(volume)s',
-                  {'image': image_id, 'volume': volume['name']})
-        self._mount_volume(volume)
-        super(NexentaNfsDriver, self).copy_image_to_volume(
-            context, volume, image_service, image_id)
-        self._unmount_volume(volume)
+    def _verify_cache_snapshot(self, cache):
+        snapshot = {
+            'id': cache['id'],
+            'name': self.cache_snapshot_template % cache['id'],
+            'volume_id': cache['id'],
+            'volume_name': cache['name'],
+            'volume_size': cache['size']
+        }
+        snapshot_path = self._get_snapshot_path(snapshot)
+        payload = {'fields': 'path'}
+        try:
+            self.nef.snapshots.get(snapshot_path, payload)
+        except jsonrpc.NefException as error:
+            if error.code != 'ENOENT':
+                raise
+            self.create_snapshot(snapshot)
+        return snapshot
 
-    def copy_volume_to_image(self, context, volume, image_service, image_meta):
-        LOG.debug('Copy volume %(volume)s to image %(image)s',
-                  {'volume': volume['name'], 'image': image_meta['id']})
-        self._mount_volume(volume)
-        super(NexentaNfsDriver, self).copy_volume_to_image(
-            context, volume, image_service, image_meta)
-        self._unmount_volume(volume)
+    @coordination.synchronized('{self.nef.lock}-{image_meta[id]}')
+    def clone_image(self, ctxt, volume, image_location, image_meta,
+                    image_service):
+        """Create a volume efficiently from an existing image.
 
-    def _ensure_share_unmounted(self, share):
-        """Ensure that NFS share is unmounted on the host.
+        image_location is a string whose format depends on the
+        image service backend in use. The driver should use it
+        to determine whether cloning is possible.
 
-        :param share: share path
+        image_meta is a dictionary that includes 'disk_format' (e.g.
+        raw, qcow2) and other image attributes that allow drivers to
+        decide whether they can clone the image without first requiring
+        conversion.
+
+        image_service is the reference of the image_service to use.
+        Note that this is needed to be passed here for drivers that
+        will want to fetch images from the image service directly.
+
+        Returns a dict of volume properties eg. provider_location,
+        boolean indicating whether cloning occurred.
         """
-        attempts = max(1, self.configuration.nfs_mount_attempts)
-        path = self._get_mount_point_for_share(share)
-        if path not in self._remotefsclient._read_mounts():
-            LOG.debug('NFS share %(share)s is not mounted at %(path)s',
-                      {'share': share, 'path': path})
-            return
-        for attempt in range(attempts):
-            try:
-                fs.umount(path)
-                LOG.debug('NFS share %(share)s has been unmounted at %(path)s',
-                          {'share': share, 'path': path})
-                break
-            except Exception as error:
-                if attempt == (attempts - 1):
-                    LOG.error('Failed to unmount NFS share %(share)s '
-                              'after %(attempts)s attempts',
-                              {'share': share, 'attempts': attempts})
-                    raise
-                LOG.debug('Unmount attempt %(attempt)s failed: %(error)s, '
-                          'retrying unmount %(share)s from %(path)s',
-                          {'attempt': attempt, 'error': error,
-                           'share': share, 'path': path})
-                self.nef.delay(attempt)
-        self._delete(path)
+        if not self.image_cache:
+            return None, False
+        try:
+            cache = self._verify_cache_image(ctxt, volume,
+                                             image_meta,
+                                             image_service)
+            snapshot = self._verify_cache_snapshot(cache)
+            self.create_volume_from_snapshot(volume, snapshot)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to clone image %(image)s '
+                      'to volume %(volume)s: %(error)s',
+                      {'image': image_meta['id'],
+                       'volume': volume['name'],
+                       'error': error})
+            return None, False
+        return None, True
+
+    @coordination.synchronized('{self.nef.lock}-{image_meta[id]}')
+    def copy_volume_to_image(self, ctxt, volume, image_service, image_meta):
+        nfs_share, mount_point, volume_file = self._mount_volume(volume)
+        volume_info = image_utils.qemu_img_info(volume_file,
+                                                force_share=True,
+                                                run_as_root=True)
+        volume_format = volume_info.file_format
+        LOG.debug('Copy %(format)s volume %(volume)s to image %(image)s',
+                  {'format': volume_format,
+                   'volume': volume['name'],
+                   'image': image_meta['id']})
+        image_utils.upload_volume(
+            ctxt, image_service,
+            image_meta, volume_file,
+            volume_format=volume_format,
+            run_as_root=True)
+        self._unmount_volume(volume, nfs_share, mount_point)
 
     def _mount_volume(self, volume):
-        """Ensure that volume is activated and mounted on the host."""
-        share = self._get_volume_share(volume)
-        self._ensure_share_mounted(share)
+        """Ensure that volume is mounted on the host.
+
+        :param volume: volume reference
+        :returns: NFS share, mount point and local volume file path
+        """
+        nfs_share = self._get_volume_share(volume)
+        attempts = max(1, self.configuration.nfs_mount_attempts)
+        for attempt in range(1, attempts + 1):
+            try:
+                self._remotefsclient.mount(nfs_share)
+            except OSError as error:
+                if attempt == attempts:
+                    LOG.error('Failed to mount NFS share %(nfs_share)s '
+                              'after %(attempts)s attempts: %(error)s',
+                              {'nfs_share': nfs_share,
+                               'attempts': attempts,
+                               'error': error})
+                    raise
+                LOG.debug('Mount attempt %(attempt)s failed: %(error)s, '
+                          'retrying mount NFS share %(nfs_share)s',
+                          {'attempt': attempt,
+                           'error': error,
+                           'nfs_share': nfs_share})
+                self.nef.delay(attempt)
+            else:
+                LOG.debug('NFS share %(nfs_share)s has '
+                          'been successfully mounted',
+                          {'nfs_share': nfs_share})
+                break
+        mount_point = self._get_mount_point_for_share(nfs_share)
+        volume_file = os.path.join(mount_point, VOLUME_FILE_NAME)
+        return nfs_share, mount_point, volume_file
 
     def _remount_volume(self, volume):
         """Workaround for NEX-16457."""
@@ -267,120 +691,89 @@ class NexentaNfsDriver(nfs.NfsDriver):
         self.nef.filesystems.unmount(volume_path)
         self.nef.filesystems.mount(volume_path)
 
-    def _unmount_volume(self, volume):
-        """Ensure that volume is unmounted on the host."""
-        try:
-            share = self._get_volume_share(volume)
-        except jsonrpc.NefException as error:
-            if error.code == 'ENOENT':
-                return
-        self._ensure_share_unmounted(share)
+    def _unmount_volume(self, volume, nfs_share=None, mount_point=None):
+        """Ensure that NFS share is unmounted on the host.
 
-    def _create_sparsed_file(self, path, size):
-        """Creates file with 0 disk usage."""
-        if self.configuration.nexenta_qcow2_volumes:
-            self._create_qcow2_file(path, size)
-        else:
-            super(NexentaNfsDriver, self)._create_sparsed_file(path, size)
-
-    def migrate_volume(self, context, volume, host):
-        """Migrate the volume to the specified host.
-
-        Returns a boolean indicating whether the migration occurred,
-        as well as model_update.
-
-        :param context: Security context
-        :param volume: A dictionary describing the volume to migrate
-        :param host: A dictionary describing the host to migrate to, where
-                     host['host'] is its name, and host['capabilities'] is a
-                     dictionary of its reported capabilities.
+        :param volume: volume reference
+        :param nfs_share: NFS share
+        :param mount_point: mount point
         """
-        LOG.debug('Start storage assisted volume migration '
-                  'for volume %(volume)s to host %(host)s',
-                  {'volume': volume['name'],
-                   'host': host['host']})
-        false_ret = (False, None)
-        if 'capabilities' not in host:
-            LOG.debug('No host capabilities found for '
-                      'the destination host %(host)s',
-                      {'host': host['host']})
-            return false_ret
-        capabilities = host['capabilities']
-        required_capabilities = [
-            'vendor_name',
-            'location_info',
-            'storage_protocol',
-            'free_capacity_gb',
-            'nef_url',
-            'nef_port'
-        ]
-        for capability in required_capabilities:
-            if capability not in capabilities:
-                LOG.debug('Required host capability %(capability)s not '
-                          'found for the destination host %(host)s',
-                          {'capability': capability, 'host': host['host']})
-                return false_ret
-        vendor = capabilities['vendor_name']
-        if vendor != self.vendor_name:
-            LOG.debug('Unsupported vendor %(vendor)s found '
-                      'for the destination host %(host)s',
-                      {'vendor': vendor, 'host': host['host']})
-            return false_ret
-        location = capabilities['location_info']
+        if nfs_share is None:
+            try:
+                nfs_share = self._get_volume_share(volume)
+            except jsonrpc.NefException:
+                nas_path = posixpath.join(
+                    self.nas_stat['mountPoint'],
+                    volume['name'])
+                nfs_share = '%(host)s:%(path)s' % {
+                    'host': self.nas_host,
+                    'path': nas_path
+                }
+        if mount_point is None:
+            mount_point = self._get_mount_point_for_share(nfs_share)
+        if mount_point not in self._remotefsclient._read_mounts():
+            LOG.debug('NFS share %(nfs_share)s is not mounted '
+                      'at mount point %(mount_point)s',
+                      {'nfs_share': nfs_share,
+                       'mount_point': mount_point})
+            return
+        attempts = max(1, self.configuration.nfs_mount_attempts)
+        for attempt in range(1, attempts + 1):
+            try:
+                fs.umount(mount_point)
+            except OSError as error:
+                if attempt == attempts:
+                    LOG.error('Failed to unmount NFS share %(nfs_share)s '
+                              'from mount point %(mount_point)s after '
+                              '%(attempts)s attempts: %(error)s',
+                              {'nfs_share': nfs_share,
+                               'mount_point': mount_point,
+                               'attempts': attempts,
+                               'error': error})
+                    raise
+                LOG.debug('Unmount attempt %(attempt)s failed: %(error)s, '
+                          'retrying unmount NFS share %(nfs_share)s from '
+                          'mount point %(mount_point)s',
+                          {'attempt': attempt,
+                           'error': error,
+                           'nfs_share': nfs_share,
+                           'mount_point': mount_point})
+                self.nef.delay(attempt)
+            else:
+                LOG.debug('NFS share %(nfs_share)s has been successfully '
+                          'unmounted from mount point %(mount_point)s',
+                          {'nfs_share': nfs_share,
+                           'mount_point': mount_point})
+                break
+        self._delete(mount_point)
+
+    def _migrate_volume(self, volume, scheme, hosts, port, path):
+        """Storage assisted volume migration."""
+        src_hosts = self._get_host_addresses()
+        src_path = self._get_volume_path(volume)
+        dst_path = posixpath.join(path, volume['name'])
+        for dst_host in hosts:
+            if dst_host in src_hosts and src_path == dst_path:
+                LOG.info('Skip local migration for host %(dst_host)s: '
+                         'source volume %(src_path)s and destination '
+                         'volume %(dst_path)s are the same volume',
+                         {'dst_host': dst_host, 'src_path': src_path,
+                          'dst_path': dst_path})
+                return True
+        payload = {'fields': 'name'}
         try:
-            driver, nas_host, nas_path = location.split(':')
-        except ValueError as error:
-            LOG.debug('Failed to split location info %(location)s '
-                      'for the destination host %(host)s: %(error)s',
-                      {'location': location, 'host': host['host'],
-                       'error': error})
-            return false_ret
-        if not (driver and nas_host and nas_path):
-            LOG.debug('Incomplete location info %(location)s '
-                      'found for the destination host %(host)s',
-                      {'location': location, 'host': host['host']})
-            return false_ret
-        if driver != self.driver_name:
-            LOG.debug('Unsupported storage driver %(driver)s '
-                      'found for the destination host %(host)s',
-                      {'driver': driver, 'host': host['host']})
-            return false_ret
-        storage_protocol = capabilities['storage_protocol']
-        if storage_protocol != self.storage_protocol:
-            LOG.debug('Unsupported storage protocol %(protocol)s '
-                      'found for the destination host %(host)s',
-                      {'protocol': storage_protocol,
-                       'host': host['host']})
-            return false_ret
-        free_capacity_gb = capabilities['free_capacity_gb']
-        if free_capacity_gb < volume['size']:
-            LOG.debug('There is not enough space available on the '
-                      'destination host %(host)s to migrate volume '
-                      '%(volume)s, available space: %(free)sG, '
-                      'required space: %(required)sG',
-                      {'host': host['host'], 'volume': volume['name'],
-                       'free': free_capacity_gb,
-                       'required': volume['size']})
-            return false_ret
-        try:
-            payload = {'fields': 'name'}
             self.nef.hpr.list(payload)
         except jsonrpc.NefException as error:
-            LOG.debug('Storage assisted volume migration is unavailable '
-                      'for the destination host %(host)s: %(error)s',
-                      {'host': host['host'], 'error': error})
-            return false_ret
-        src_path = self._get_volume_path(volume)
-        dst_path = posixpath.join(nas_path, volume['name'])
-        dst_port = capabilities['nef_port']
-        src_hosts = self._get_host_addresses()
-        dst_hosts = capabilities['nef_url'].split(',')
-        service_name = 'cinder-migrate-%s' % volume['name']
-        service_created = service_running = service_success = False
-        while dst_hosts and not service_created:
-            dst_host = dst_hosts.pop()
-            if dst_host is not None:
-                dst_host = dst_host.strip()
+            LOG.error('Storage assisted volume migration '
+                      'is unavailable: %(error)s',
+                      {'error': error})
+            return False
+        service_name = '%(prefix)s-%(volume)s' % {
+            'prefix': self.migration_service_prefix,
+            'volume': volume['name']
+        }
+        service_created = False
+        for dst_host in hosts:
             payload = {
                 'name': service_name,
                 'sourceDataset': src_path,
@@ -391,71 +784,73 @@ class NexentaNfsDriver(nfs.NfsDriver):
                 payload['isSource'] = True
                 payload['remoteNode'] = {
                     'host': dst_host,
-                    'port': dst_port
+                    'port': port,
+                    'proto': scheme
                 }
-            elif src_path == dst_path:
-                LOG.debug('Skip local to local replication: '
-                          'source volume %(src_path)s and '
-                          'destination volume %(dst_path)s '
-                          'are the same volume',
-                          {'src_path': src_path,
-                           'dst_path': dst_path})
-                return True, None
+                if self.migration_throttle:
+                    payload['transportOptions'] = {
+                        'throttle': self.migration_throttle * units.Mi
+                    }
             try:
                 self.nef.hpr.create(payload)
                 service_created = True
+                break
             except jsonrpc.NefException as error:
-                LOG.debug('Failed to create replication service '
+                LOG.error('Failed to create migration service '
                           'with payload %(payload)s: %(error)s',
                           {'payload': payload, 'error': error})
-                if error.code not in ('ENOENT', 'EINVAL'):
-                    return false_ret
+        service_running = False
         if service_created:
             try:
                 self.nef.hpr.start(service_name)
                 service_running = True
             except jsonrpc.NefException as error:
-                LOG.debug('Failed to start replication service '
+                LOG.error('Failed to start migration service '
                           '%(service_name)s: %(error)s',
                           {'service_name': service_name,
                            'error': error})
-        retry_count = 0
-        while service_running and not service_success:
+        service_success = False
+        service_retries = 0
+        while service_running:
+            service_retries += 1
+            self.nef.delay(service_retries)
+            payload = {'fields': 'state,progress,runNumber,lastError'}
             try:
-                service = self.nef.hpr.get(service_name)
+                service = self.nef.hpr.get(service_name, payload)
             except jsonrpc.NefException as error:
-                LOG.debug('Failed to stat replication service '
+                LOG.error('Failed to stat migration service '
                           '%(service_name)s: %(error)s',
                           {'service_name': service_name,
                            'error': error})
-                break
-            state = service['state']
-            if state == 'faulted':
+                if service_retries > self.nef.retries:
+                    break
+            service_state = service['state']
+            service_counter = service['runNumber']
+            service_progress = service['progress']
+            if service_state == 'faulted':
                 service_error = service['lastError']
-                LOG.debug('Replication service %(service_name)s '
+                LOG.error('Migration service %(service_name)s '
                           'failed with error: %(service_error)s',
                           {'service_name': service_name,
                            'service_error': service_error})
-                break
-            elif state == 'disabled':
-                LOG.debug('Replication service %(service_name)s '
-                          'successfully replicated %(src_path)s '
-                          'to %(dst_host)s:%(dst_path)s',
-                          {'service_name': service_name,
-                           'src_path': src_path,
-                           'dst_host': dst_host,
-                           'dst_path': dst_path})
+                service_running = False
+            elif service_state == 'disabled' and service_counter > 0:
+                LOG.info('Migration service %(service_name)s '
+                         'successfully replicated %(src_path)s '
+                         'to %(dst_host)s:%(dst_path)s',
+                         {'service_name': service_name,
+                          'src_path': src_path,
+                          'dst_host': dst_host,
+                          'dst_path': dst_path})
                 service_running = False
                 service_success = True
-                break
             else:
-                progress = service['progress']
-                LOG.debug('Replication service %(service_name)s '
-                          'is running, progress %(progress)s%%',
-                          {'service_name': service_name,
-                           'progress': progress})
-                self.nef.delay(retry_count)
-                retry_count += 1
+                LOG.info('Migration service %(service_name)s '
+                         'is %(service_state)s, progress '
+                         '%(service_progress)s%%',
+                         {'service_name': service_name,
+                          'service_state': service_state,
+                          'service_progress': service_progress})
         if service_created:
             payload = {
                 'destroySourceSnapshots': True,
@@ -465,30 +860,149 @@ class NexentaNfsDriver(nfs.NfsDriver):
             try:
                 self.nef.hpr.delete(service_name, payload)
             except jsonrpc.NefException as error:
-                LOG.debug('Failed to delete replication service '
+                LOG.error('Failed to delete migration service '
                           '%(service_name)s: %(error)s',
                           {'service_name': service_name,
                            'error': error})
         if not service_success:
-            return false_ret
+            return False
         try:
             self.delete_volume(volume)
         except jsonrpc.NefException as error:
-            LOG.debug('Failed to delete source '
+            LOG.error('Failed to delete source '
                       'volume %(volume)s: %(error)s',
                       {'volume': volume['name'],
                        'error': error})
-        return True, None
+        return True
 
-    def create_export(self, context, volume, connector):
+    def migrate_volume(self, ctxt, volume, host):
+        """Migrate the volume to the specified host.
+
+        Returns a boolean indicating whether the migration occurred,
+        as well as model_update.
+
+        :param ctxt: Security context of the caller.
+        :param volume: A dictionary describing the volume to migrate
+        :param host: A dictionary describing the host to migrate to, where
+                     host['host'] is its name, and host['capabilities'] is a
+                     dictionary of its reported capabilities.
+        """
+        LOG.info('Start storage assisted volume migration '
+                 'for volume %(volume)s to host %(host)s',
+                 {'volume': volume['name'],
+                  'host': host['host']})
+        false_ret = (False, None)
+        if 'capabilities' not in host:
+            LOG.error('No host capabilities found for '
+                      'the destination host %(host)s',
+                      {'host': host['host']})
+            return false_ret
+        capabilities = host['capabilities']
+        required_capabilities = [
+            'vendor_name',
+            'location_info',
+            'storage_protocol',
+            'free_capacity_gb'
+        ]
+        for capability in required_capabilities:
+            if not (capability in capabilities and capabilities[capability]):
+                LOG.error('Required host capability %(capability)s not '
+                          'found for the destination host %(host)s',
+                          {'capability': capability, 'host': host['host']})
+                return false_ret
+        vendor = capabilities['vendor_name']
+        if vendor != self.vendor_name:
+            LOG.error('Unsupported vendor %(vendor)s found '
+                      'for the destination host %(host)s',
+                      {'vendor': vendor, 'host': host['host']})
+            return false_ret
+        location = capabilities['location_info']
+        try:
+            nas_driver, nas_host, nas_path = location.split(':')
+        except ValueError as error:
+            LOG.error('Failed to parse location info %(location)s '
+                      'for the destination host %(host)s: %(error)s',
+                      {'location': location, 'host': host['host'],
+                       'error': error})
+            return false_ret
+        if not (nas_driver and nas_host and nas_path):
+            LOG.error('Incomplete location info %(location)s '
+                      'found for the destination host %(host)s',
+                      {'location': location, 'host': host['host']})
+            return false_ret
+        if nas_driver != self.nas_driver:
+            LOG.error('Unsupported storage driver %(nas_driver)s '
+                      'found for the destination host %(host)s',
+                      {'nas_driver': nas_driver,
+                       'host': host['host']})
+            return false_ret
+        storage_protocol = capabilities['storage_protocol']
+        if storage_protocol != self.storage_protocol:
+            LOG.error('Unsupported storage protocol %(protocol)s '
+                      'found for the destination host %(host)s',
+                      {'protocol': storage_protocol,
+                       'host': host['host']})
+            return false_ret
+        free_capacity_gb = capabilities['free_capacity_gb']
+        if free_capacity_gb < volume['size']:
+            LOG.error('There is not enough space available on the '
+                      'destination host %(host)s to migrate volume '
+                      '%(volume)s, available space: %(free)sG, '
+                      'required space: %(required)sG',
+                      {'host': host['host'],
+                       'volume': volume['name'],
+                       'free': free_capacity_gb,
+                       'required': volume['size']})
+            return false_ret
+        nef_scheme = None
+        nef_hosts = []
+        nef_port = None
+        if 'nef_hosts' in capabilities and capabilities['nef_hosts']:
+            for nef_host in capabilities['nef_hosts'].split(','):
+                nef_host = nef_host.strip()
+                if nef_host:
+                    nef_hosts.append(nef_host)
+        elif 'nef_url' in capabilities and capabilities['nef_url']:
+            url = six.moves.urllib.parse.urlparse(capabilities['nef_url'])
+            if url.scheme and url.hostname and url.port:
+                nef_scheme = url.scheme
+                nef_hosts.append(url.hostname)
+                nef_port = url.port
+            else:
+                for nef_host in capabilities['nef_url'].split(','):
+                    nef_host = nef_host.strip()
+                    if nef_host:
+                        nef_hosts.append(nef_host)
+        if not nef_hosts:
+            LOG.error('NEF management address not found for the '
+                      'destination host %(host)s: %(capabilities)s',
+                      {'host': host['host'],
+                       'capabilities': capabilities})
+            return false_ret
+        if not nef_scheme:
+            if 'nef_scheme' in capabilities and capabilities['nef_scheme']:
+                nef_scheme = capabilities['nef_scheme']
+            else:
+                nef_scheme = self.nef.scheme
+        if not nef_port:
+            if 'nef_port' in capabilities and capabilities['nef_port']:
+                nef_port = capabilities['nef_port']
+            else:
+                nef_port = self.nef.port
+        if self._migrate_volume(volume, nef_scheme, nef_hosts, nef_port,
+                                nas_path):
+            return (True, None)
+        return false_ret
+
+    def create_export(self, ctxt, volume, connector):
         """Driver entry point to get the export info for a new volume."""
         pass
 
-    def ensure_export(self, context, volume):
+    def ensure_export(self, ctxt, volume):
         """Driver entry point to get the export info for an existing volume."""
         pass
 
-    def remove_export(self, context, volume):
+    def remove_export(self, ctxt, volume):
         """Driver entry point to remove an export for a volume."""
         pass
 
@@ -510,32 +1024,46 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param connector: a connector object
         :returns: dictionary of connection information
         """
-        LOG.debug('Initialize volume connection for %(volume)s',
-                  {'volume': volume['name']})
-        share = self._get_volume_share(volume)
-        data = {
-            'export': share,
-            'name': 'volume'
+        LOG.debug('Initialize volume connection for %(volume)s '
+                  'and connector %(connector)s',
+                  {'volume': volume['name'],
+                   'connector': connector})
+        volume_path = self._get_volume_path(volume)
+        payload = {
+            'fields': 'nonBlockingMandatoryMode,source',
+            'source': True
         }
-        nfs_options = self.configuration.safe_get('nfs_mount_options')
-        nas_options = self.configuration.safe_get('nas_mount_options')
-        if nfs_options and nas_options:
-            LOG.debug('Overriding NFS mount options for volume %(volume)s: '
-                      'nfs_mount_options = "%(nfs_options)s" with '
-                      'nas_mount_options = "%(nas_options)s"',
-                      {'volume': volume['name'],
-                       'nfs_options': nfs_options,
-                       'nas_options': nas_options})
-        if nas_options:
-            data['options'] = '-o %s' % nas_options
-        elif nfs_options:
-            data['options'] = '-o %s' % nfs_options
-        info = {
+        volume_specs = self.nef.filesystems.get(volume_path, payload)
+        if volume_specs['nonBlockingMandatoryMode'] != self.nbmand:
+            payload = {'nonBlockingMandatoryMode': self.nbmand}
+            if 'source' in volume_specs:
+                source = volume_specs['source']
+                value = source['nonBlockingMandatoryMode']
+                if value == 'inherited':
+                    self.nef.filesystems.set(self.nas_path, payload)
+                elif value in ['local', 'received']:
+                    self.nef.filesystems.set(volume_path, payload)
+            else:
+                self.nef.filesystems.set(volume_path, payload)
+            self._remount_volume(volume)
+        nfs_share, mount_point, volume_file = self._mount_volume(volume)
+        volume_info = image_utils.qemu_img_info(volume_file,
+                                                force_share=True,
+                                                run_as_root=True)
+        self._unmount_volume(volume, nfs_share, mount_point)
+        data = {
+            'export': nfs_share,
+            'format': volume_info.file_format,
+            'name': VOLUME_FILE_NAME
+        }
+        if self.mount_options:
+            data['options'] = '-o %s' % self.mount_options
+        connection_info = {
             'driver_volume_type': self.driver_volume_type,
             'mount_point_base': self.mount_point_base,
             'data': data
         }
-        return info
+        return connection_info
 
     @coordination.synchronized('{self.nef.lock}')
     def delete_volume(self, volume):
@@ -543,35 +1071,69 @@ class NexentaNfsDriver(nfs.NfsDriver):
 
         :param volume: volume reference
         """
-        volume_path = self._get_volume_path(volume)
         self._unmount_volume(volume)
-        delete_payload = {'force': True, 'snapshots': True}
+        volume_path = self._get_volume_path(volume)
+        payload = {'fields': 'originalSnapshot'}
         try:
-            self.nef.filesystems.delete(volume_path, delete_payload)
+            volume_spec = self.nef.filesystems.get(volume_path, payload)
+        except jsonrpc.NefException as error:
+            if error.code == 'ENOENT':
+                return
+            raise
+        volume_origin = volume_spec['originalSnapshot']
+        payload = {'force': True, 'snapshots': True}
+        try:
+            self.nef.filesystems.delete(volume_path, payload)
         except jsonrpc.NefException as error:
             if error.code != 'EEXIST':
                 raise
-            snapshots_tree = {}
-            snapshots_payload = {'parent': volume_path, 'fields': 'path'}
-            snapshots = self.nef.snapshots.list(snapshots_payload)
+            snapshot_tree = {}
+            payload = {'parent': volume_path, 'fields': 'path'}
+            snapshots = self.nef.snapshots.list(payload)
             for snapshot in snapshots:
-                clones_payload = {'fields': 'clones,creationTxg'}
-                data = self.nef.snapshots.get(snapshot['path'], clones_payload)
-                if data['clones']:
-                    snapshots_tree[data['creationTxg']] = data['clones'][0]
-            if snapshots_tree:
-                clone_path = snapshots_tree[max(snapshots_tree)]
+                snapshot_path = snapshot['path']
+                payload = {'fields': 'clones,creationTxg'}
+                snapshot_spec = self.nef.snapshots.get(snapshot_path, payload)
+                if snapshot_spec['clones']:
+                    snapshot_txg = snapshot_spec['creationTxg']
+                    snapshot_clones = snapshot_spec['clones']
+                    first_clone = snapshot_clones[0]
+                    snapshot_tree[snapshot_txg] = first_clone
+            if snapshot_tree:
+                latest_txg = max(snapshot_tree)
+                clone_path = snapshot_tree[latest_txg]
                 self.nef.filesystems.promote(clone_path)
-            self.nef.filesystems.delete(volume_path, delete_payload)
+            payload = {'force': True, 'snapshots': True}
+            self.nef.filesystems.delete(volume_path, payload)
+        if not volume_origin:
+            return
+        origin_path, snapshot_name = volume_origin.split('@')
+        origin_name = posixpath.basename(origin_path)
+        if nexenta_utils.match_template(self.origin_snapshot_template,
+                                        snapshot_name):
+            payload = {'defer': True}
+            try:
+                self.nef.snapshots.delete(volume_origin, payload)
+            except Exception:
+                pass
+        elif (nexenta_utils.match_template(self.cache_snapshot_template,
+                                           snapshot_name) and
+              nexenta_utils.match_template(self.cache_image_template,
+                                           origin_name)):
+            payload = {'force': True, 'snapshots': True}
+            try:
+                self.nef.filesystems.delete(origin_path, payload)
+            except Exception:
+                pass
 
     def _delete(self, path):
         """Override parent method for safe remove mountpoint."""
         try:
-            os.rmdir(path)
+            self._execute('rm', '-d', path, run_as_root=True)
             LOG.debug('The mountpoint %(path)s has been successfully removed',
                       {'path': path})
         except OSError as error:
-            LOG.debug('Failed to remove mountpoint %(path)s: %(error)s',
+            LOG.error('Failed to remove mountpoint %(path)s: %(error)s',
                       {'path': path, 'error': error.strerror})
 
     def extend_volume(self, volume, new_size):
@@ -582,27 +1144,19 @@ class NexentaNfsDriver(nfs.NfsDriver):
         """
         LOG.info('Extend volume %(volume)s, new size: %(size)sGB',
                  {'volume': volume['name'], 'size': new_size})
-        self._mount_volume(volume)
-        volume_file = self.local_path(volume)
         properties = self.nef.filesystems.properties
-        payload = self._get_vendor_properties(volume, properties)
-        sparsed_volume = payload.pop('sparseVolume', True)
-        if sparsed_volume:
-            self._execute('truncate', '-s',
-                          '%dG' % new_size,
-                          volume_file,
-                          run_as_root=True)
-        else:
-            seek = volume['size'] * units.Ki
-            count = (new_size - volume['size']) * units.Ki
-            self._execute('dd',
-                          'if=/dev/zero',
-                          'of=%s' % volume_file,
-                          'bs=%d' % units.Mi,
-                          'seek=%d' % seek,
-                          'count=%d' % count,
-                          run_as_root=True)
-        self._unmount_volume(volume)
+        payload = self._get_vendor_properties(properties, volume)
+        sparse_volume = payload.pop('sparseVolume')
+        nfs_share, mount_point, volume_file = self._mount_volume(volume)
+        if not sparse_volume:
+            volume_info = image_utils.qemu_img_info(volume_file,
+                                                    force_share=True,
+                                                    run_as_root=True)
+            volume_size = new_size * units.Gi
+            volume_format = volume_info.file_format
+            self._set_volume_reservation(volume, volume_size, volume_format)
+        image_utils.resize_image(volume_file, new_size, run_as_root=True)
+        self._unmount_volume(volume, nfs_share, mount_point)
 
     @coordination.synchronized('{self.nef.lock}')
     def create_snapshot(self, snapshot):
@@ -631,7 +1185,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         # actually helpful.
         return False
 
-    def revert_to_snapshot(self, context, volume, snapshot):
+    def revert_to_snapshot(self, ctxt, volume, snapshot):
         """Revert volume to snapshot."""
         volume_path = self._get_volume_path(volume)
         payload = {'snapshot': snapshot['name']}
@@ -646,17 +1200,15 @@ class NexentaNfsDriver(nfs.NfsDriver):
         """
         LOG.debug('Create volume %(volume)s from snapshot %(snapshot)s',
                   {'volume': volume['name'], 'snapshot': snapshot['name']})
+        volume_path = self._get_volume_path(volume)
         snapshot_path = self._get_snapshot_path(snapshot)
-        clone_path = self._get_volume_path(volume)
-        payload = {'targetPath': clone_path}
+        payload = {'targetPath': volume_path}
         self.nef.snapshots.clone(snapshot_path, payload)
         self._remount_volume(volume)
         self._set_volume_acl(volume)
         if volume['size'] > snapshot['volume_size']:
-            new_size = volume['size']
-            volume['size'] = snapshot['volume_size']
-            self.extend_volume(volume, new_size)
-            volume['size'] = new_size
+            self.extend_volume(volume, volume['size'])
+        self._update_volume_properties(volume)
 
     def create_cloned_volume(self, volume, src_vref):
         """Creates a clone of the specified volume.
@@ -674,7 +1226,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         try:
             self.create_volume_from_snapshot(volume, snapshot)
         except jsonrpc.NefException as error:
-            LOG.debug('Failed to create clone %(clone)s '
+            LOG.error('Failed to create clone %(clone)s '
                       'from volume %(volume)s: %(error)s',
                       {'clone': volume['name'],
                        'volume': src_vref['name'],
@@ -684,35 +1236,35 @@ class NexentaNfsDriver(nfs.NfsDriver):
             try:
                 self.delete_snapshot(snapshot)
             except jsonrpc.NefException as error:
-                LOG.debug('Failed to delete temporary snapshot '
+                LOG.error('Failed to delete temporary snapshot '
                           '%(volume)s@%(snapshot)s: %(error)s',
                           {'volume': src_vref['name'],
                            'snapshot': snapshot['name'],
                            'error': error})
 
-    def create_consistencygroup(self, context, group):
+    def create_consistencygroup(self, ctxt, group):
         """Creates a consistency group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the dictionary of the consistency group to be created.
         :returns: group_model_update
         """
         group_model_update = {}
         return group_model_update
 
-    def create_group(self, context, group):
+    def create_group(self, ctxt, group):
         """Creates a group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the group object.
         :returns: model_update
         """
-        return self.create_consistencygroup(context, group)
+        return self.create_consistencygroup(ctxt, group)
 
-    def delete_consistencygroup(self, context, group, volumes):
+    def delete_consistencygroup(self, ctxt, group, volumes):
         """Deletes a consistency group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the dictionary of the consistency group to be deleted.
         :param volumes: a list of volume dictionaries in the group.
         :returns: group_model_update, volumes_model_update
@@ -723,21 +1275,21 @@ class NexentaNfsDriver(nfs.NfsDriver):
             self.delete_volume(volume)
         return group_model_update, volumes_model_update
 
-    def delete_group(self, context, group, volumes):
+    def delete_group(self, ctxt, group, volumes):
         """Deletes a group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the group object.
         :param volumes: a list of volume objects in the group.
         :returns: model_update, volumes_model_update
         """
-        return self.delete_consistencygroup(context, group, volumes)
+        return self.delete_consistencygroup(ctxt, group, volumes)
 
-    def update_consistencygroup(self, context, group, add_volumes=None,
+    def update_consistencygroup(self, ctxt, group, add_volumes=None,
                                 remove_volumes=None):
         """Updates a consistency group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the dictionary of the consistency group to be updated.
         :param add_volumes: a list of volume dictionaries to be added.
         :param remove_volumes: a list of volume dictionaries to be removed.
@@ -748,23 +1300,23 @@ class NexentaNfsDriver(nfs.NfsDriver):
         remove_volumes_update = []
         return group_model_update, add_volumes_update, remove_volumes_update
 
-    def update_group(self, context, group, add_volumes=None,
+    def update_group(self, ctxt, group, add_volumes=None,
                      remove_volumes=None):
         """Updates a group.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the group object.
         :param add_volumes: a list of volume objects to be added.
         :param remove_volumes: a list of volume objects to be removed.
         :returns: model_update, add_volumes_update, remove_volumes_update
         """
-        return self.update_consistencygroup(context, group, add_volumes,
+        return self.update_consistencygroup(ctxt, group, add_volumes,
                                             remove_volumes)
 
-    def create_cgsnapshot(self, context, cgsnapshot, snapshots):
+    def create_cgsnapshot(self, ctxt, cgsnapshot, snapshots):
         """Creates a consistency group snapshot.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param cgsnapshot: the dictionary of the cgsnapshot to be created.
         :param snapshots: a list of snapshot dictionaries in the cgsnapshot.
         :returns: group_model_update, snapshots_model_update
@@ -772,12 +1324,12 @@ class NexentaNfsDriver(nfs.NfsDriver):
         group_model_update = {}
         snapshots_model_update = []
         cgsnapshot_name = self.group_snapshot_template % cgsnapshot['id']
-        cgsnapshot_path = '%s@%s' % (self.root_path, cgsnapshot_name)
+        cgsnapshot_path = '%s@%s' % (self.nas_path, cgsnapshot_name)
         create_payload = {'path': cgsnapshot_path, 'recursive': True}
         self.nef.snapshots.create(create_payload)
         for snapshot in snapshots:
             volume_name = snapshot['volume_name']
-            volume_path = posixpath.join(self.root_path, volume_name)
+            volume_path = posixpath.join(self.nas_path, volume_name)
             snapshot_name = snapshot['name']
             snapshot_path = '%s@%s' % (volume_path, cgsnapshot_name)
             rename_payload = {'newName': snapshot_name}
@@ -786,20 +1338,20 @@ class NexentaNfsDriver(nfs.NfsDriver):
         self.nef.snapshots.delete(cgsnapshot_path, delete_payload)
         return group_model_update, snapshots_model_update
 
-    def create_group_snapshot(self, context, group_snapshot, snapshots):
+    def create_group_snapshot(self, ctxt, group_snapshot, snapshots):
         """Creates a group_snapshot.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group_snapshot: the GroupSnapshot object to be created.
         :param snapshots: a list of Snapshot objects in the group_snapshot.
         :returns: model_update, snapshots_model_update
         """
-        return self.create_cgsnapshot(context, group_snapshot, snapshots)
+        return self.create_cgsnapshot(ctxt, group_snapshot, snapshots)
 
-    def delete_cgsnapshot(self, context, cgsnapshot, snapshots):
+    def delete_cgsnapshot(self, ctxt, cgsnapshot, snapshots):
         """Deletes a consistency group snapshot.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param cgsnapshot: the dictionary of the cgsnapshot to be created.
         :param snapshots: a list of snapshot dictionaries in the cgsnapshot.
         :returns: group_model_update, snapshots_model_update
@@ -810,22 +1362,22 @@ class NexentaNfsDriver(nfs.NfsDriver):
             self.delete_snapshot(snapshot)
         return group_model_update, snapshots_model_update
 
-    def delete_group_snapshot(self, context, group_snapshot, snapshots):
+    def delete_group_snapshot(self, ctxt, group_snapshot, snapshots):
         """Deletes a group_snapshot.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group_snapshot: the GroupSnapshot object to be deleted.
         :param snapshots: a list of snapshot objects in the group_snapshot.
         :returns: model_update, snapshots_model_update
         """
-        return self.delete_cgsnapshot(context, group_snapshot, snapshots)
+        return self.delete_cgsnapshot(ctxt, group_snapshot, snapshots)
 
-    def create_consistencygroup_from_src(self, context, group, volumes,
+    def create_consistencygroup_from_src(self, ctxt, group, volumes,
                                          cgsnapshot=None, snapshots=None,
                                          source_cg=None, source_vols=None):
         """Creates a consistency group from source.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the dictionary of the consistency group to be created.
         :param volumes: a list of volume dictionaries in the group.
         :param cgsnapshot: the dictionary of the cgsnapshot as source.
@@ -841,7 +1393,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
                 self.create_volume_from_snapshot(volume, snapshot)
         elif source_cg and source_vols:
             snapshot_name = self.origin_snapshot_template % group['id']
-            snapshot_path = '%s@%s' % (self.root_path, snapshot_name)
+            snapshot_path = '%s@%s' % (self.nas_path, snapshot_name)
             create_payload = {'path': snapshot_path, 'recursive': True}
             self.nef.snapshots.create(create_payload)
             for volume, source_vol in zip(volumes, source_vols):
@@ -856,12 +1408,12 @@ class NexentaNfsDriver(nfs.NfsDriver):
             self.nef.snapshots.delete(snapshot_path, delete_payload)
         return group_model_update, volumes_model_update
 
-    def create_group_from_src(self, context, group, volumes,
+    def create_group_from_src(self, ctxt, group, volumes,
                               group_snapshot=None, snapshots=None,
                               source_group=None, source_vols=None):
         """Creates a group from source.
 
-        :param context: the context of the caller.
+        :param ctxt: the context of the caller.
         :param group: the Group object to be created.
         :param volumes: a list of Volume objects in the group.
         :param group_snapshot: the GroupSnapshot object as source.
@@ -870,28 +1422,19 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param source_vols: a list of volume objects in the source_group.
         :returns: model_update, volumes_model_update
         """
-        return self.create_consistencygroup_from_src(context, group, volumes,
+        return self.create_consistencygroup_from_src(ctxt, group, volumes,
                                                      group_snapshot, snapshots,
                                                      source_group, source_vols)
-
-    def _local_volume_dir(self, volume):
-        """Get volume dir (mounted locally fs path) for given volume.
-
-        :param volume: volume reference
-        """
-        share = self._get_volume_share(volume)
-        if six.PY3:
-            share = share.encode('utf-8')
-        path = hashlib.md5(share).hexdigest()
-        return os.path.join(self.mount_point_base, path)
 
     def local_path(self, volume):
         """Get volume path (mounted locally fs path) for given volume.
 
         :param volume: volume reference
         """
-        volume_dir = self._local_volume_dir(volume)
-        return os.path.join(volume_dir, 'volume')
+        nfs_share = self._get_volume_share(volume)
+        mount_point = self._get_mount_point_for_share(nfs_share)
+        volume_file = os.path.join(mount_point, VOLUME_FILE_NAME)
+        return volume_file
 
     def _set_volume_acl(self, volume):
         """Sets access permissions for given volume.
@@ -923,19 +1466,22 @@ class NexentaNfsDriver(nfs.NfsDriver):
             filesystem = self.nef.filesystems.get(volume_path, get_payload)
         if not filesystem['isMounted']:
             self.nef.filesystems.mount(volume_path)
-        share = '%s:%s' % (self.nas_host, filesystem['mountPoint'])
-        return share
+        nfs_share = '%s:%s' % (self.nas_host, filesystem['mountPoint'])
+        return nfs_share
 
     def _get_volume_path(self, volume):
         """Return ZFS dataset path for the volume."""
-        return posixpath.join(self.root_path, volume['name'])
+        volume_name = volume['name']
+        volume_path = posixpath.join(self.nas_path, volume_name)
+        return volume_path
 
     def _get_snapshot_path(self, snapshot):
         """Return ZFS snapshot path for the snapshot."""
         volume_name = snapshot['volume_name']
         snapshot_name = snapshot['name']
-        volume_path = posixpath.join(self.root_path, volume_name)
-        return '%s@%s' % (volume_path, snapshot_name)
+        volume_path = posixpath.join(self.nas_path, volume_name)
+        snapshot_path = '%s@%s' % (volume_path, snapshot_name)
+        return snapshot_path
 
     def get_volume_stats(self, refresh=False):
         """Get volume stats.
@@ -944,38 +1490,27 @@ class NexentaNfsDriver(nfs.NfsDriver):
         """
         if refresh or not self._stats:
             self._update_volume_stats()
-
         return self._stats
 
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor Appliance."""
-        payload = {'fields': 'bytesAvailable,bytesUsed,pool'}
-        dataset = self.nef.filesystems.get(self.root_path, payload)
-        pool_name = dataset['pool']
-        free_capacity_gb = dataset['bytesAvailable'] // units.Gi
-        allocated_capacity_gb = dataset['bytesUsed'] // units.Gi
-        total_capacity_gb = free_capacity_gb + allocated_capacity_gb
-        provisioned_capacity_gb = total_volumes = 0
+        provisioned_capacity_gb = total_volumes = total_snapshots = 0
         ctxt = context.get_admin_context()
         volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
         for volume in volumes:
             provisioned_capacity_gb += volume['size']
             total_volumes += 1
-        volume_backend_name = (
-            self.configuration.safe_get('volume_backend_name'))
-        if not volume_backend_name:
-            LOG.debug('Failed to get configured volume backend name')
-            volume_backend_name = '%(product)s_%(protocol)s' % {
-                'product': self.product_name,
-                'protocol': self.storage_protocol
-            }
+        snapshots = objects.SnapshotList.get_by_host(ctxt, self.host)
+        for snapshot in snapshots:
+            provisioned_capacity_gb += snapshot['volume_size']
+            total_snapshots += 1
         description = (
             self.configuration.safe_get('nexenta_dataset_description'))
         if not description:
             description = '%(product)s %(host)s:%(path)s' % {
                 'product': self.product_name,
-                'host': self.configuration.nas_host,
-                'path': self.configuration.nas_share_path
+                'host': self.nas_host,
+                'path': self.nas_path
             }
         max_over_subscription_ratio = (
             self.configuration.safe_get('max_over_subscription_ratio'))
@@ -984,47 +1519,66 @@ class NexentaNfsDriver(nfs.NfsDriver):
         if reserved_percentage is None:
             reserved_percentage = 0
         location_info = '%(driver)s:%(host)s:%(path)s' % {
-            'driver': self.driver_name,
-            'host': self.configuration.nas_host,
-            'path': self.configuration.nas_share_path
+            'driver': self.nas_driver,
+            'host': self.nas_host,
+            'path': self.nas_path
         }
         display_name = 'Capabilities of %(product)s %(protocol)s driver' % {
             'product': self.product_name,
             'protocol': self.storage_protocol
         }
-        visibility = 'public'
-        self._stats = {
+        stats = {
+            'backend_state': 'down',
             'driver_version': self.VERSION,
             'vendor_name': self.vendor_name,
             'storage_protocol': self.storage_protocol,
-            'volume_backend_name': volume_backend_name,
+            'volume_backend_name': self.backend_name,
             'location_info': location_info,
             'description': description,
             'display_name': display_name,
-            'pool_name': pool_name,
+            'pool_name': self.nas_pool,
             'multiattach': True,
-            'QoS_support': False,
+            'QoS_support': True,
             'consistencygroup_support': True,
             'consistent_group_snapshot_enabled': True,
             'online_extend_support': True,
             'sparse_copy_volume': True,
             'thin_provisioning_support': True,
             'thick_provisioning_support': True,
-            'total_capacity_gb': total_capacity_gb,
-            'allocated_capacity_gb': allocated_capacity_gb,
-            'free_capacity_gb': free_capacity_gb,
+            'total_capacity_gb': 'unknown',
+            'allocated_capacity_gb': 'unknown',
+            'free_capacity_gb': 'unknown',
             'provisioned_capacity_gb': provisioned_capacity_gb,
             'total_volumes': total_volumes,
+            'total_snapshots': total_snapshots,
             'max_over_subscription_ratio': max_over_subscription_ratio,
             'reserved_percentage': reserved_percentage,
-            'visibility': visibility,
+            'nef_scheme': self.nef.scheme,
+            'nef_hosts': ','.join(self.nef.hosts),
             'nef_port': self.nef.port,
-            'nef_url': self.nef.host
+            'nef_url': self.nef.url()
         }
+        payload = {'fields': 'bytesAvailable,bytesUsed'}
+        try:
+            nas_stat = self.nef.filesystems.get(self.nas_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to get backend statistics for host %(host)s '
+                      'and volume backend %(backend_name)s: %(error)s',
+                      {'host': self.host,
+                       'backend_name': self.backend_name,
+                       'error': error})
+        else:
+            available = nas_stat['bytesAvailable'] // units.Gi
+            used = nas_stat['bytesUsed'] // units.Gi
+            stats['free_capacity_gb'] = available
+            stats['allocated_capacity_gb'] = used
+            stats['total_capacity_gb'] = available + used
+            stats['backend_state'] = 'up'
+        self._stats = stats
         LOG.debug('Updated volume backend statistics for host %(host)s '
-                  'and volume backend %(volume_backend_name)s: %(stats)s',
+                  'and volume backend %(backend_name)s: %(stats)s',
                   {'host': self.host,
-                   'volume_backend_name': volume_backend_name,
+                   'backend_name': self.backend_name,
                    'stats': self._stats})
 
     def _get_existing_volume(self, existing_ref):
@@ -1041,14 +1595,14 @@ class NexentaNfsDriver(nfs.NfsDriver):
                        % {'keys': keys})
             raise jsonrpc.NefException(code='EINVAL', message=message)
         payload = {
-            'parent': self.root_path,
+            'parent': self.nas_path,
             'fields': 'path',
             'recursive': False
         }
         for key, value in types.items():
             if key in existing_ref:
                 if value == 'path':
-                    path = posixpath.join(self.root_path,
+                    path = posixpath.join(self.nas_path,
                                           existing_ref[key])
                 else:
                     path = existing_ref[key]
@@ -1185,6 +1739,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
             volume_path = self._get_volume_path(volume)
             payload = {'newPath': volume_path}
             self.nef.filesystems.rename(existing_volume_path, payload)
+        self._update_volume_properties(volume)
 
     def manage_existing_get_size(self, volume, existing_ref):
         """Return size of volume to be managed by manage_existing.
@@ -1198,22 +1753,29 @@ class NexentaNfsDriver(nfs.NfsDriver):
         """
         existing_volume = self._get_existing_volume(existing_ref)
         self._set_volume_acl(existing_volume)
-        self._mount_volume(existing_volume)
-        local_path = self.local_path(existing_volume)
+        nfs_share, mount_point, existing_volume_file = (
+            self._mount_volume(existing_volume))
         try:
-            volume_size = os.path.getsize(local_path)
+            existing_volume_info = image_utils.qemu_img_info(
+                existing_volume_file,
+                force_share=True,
+                run_as_root=True)
         except OSError as error:
             code = errno.errorcode[error.errno]
-            message = (_('Manage existing volume %(name)s failed: '
-                         'unable to get size of volume data file '
-                         '%(file)s: %(error)s')
-                       % {'name': existing_volume['name'],
-                          'file': local_path,
+            message = (_('Manage existing volume %(volume)s failed, '
+                         'unable to get size of volume backend file '
+                         '%(volume_file)s: %(error)s')
+                       % {'volume': existing_volume['name'],
+                          'volume_file': existing_volume_file,
                           'error': error.strerror})
             raise jsonrpc.NefException(code=code, message=message)
         finally:
-            self._unmount_volume(existing_volume)
-        return volume_size // units.Gi
+            self._unmount_volume(existing_volume, nfs_share, mount_point)
+        existing_volume_size = existing_volume_info.virtual_size // units.Gi
+        LOG.debug('Manage existing volume: %(volume)s size is %(size)sG',
+                  {'volume': existing_volume['name'],
+                   'size': existing_volume_size})
+        return existing_volume_size
 
     def get_manageable_volumes(self, cinder_volumes, marker, limit, offset,
                                sort_keys, sort_dirs):
@@ -1251,7 +1813,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
             value = cinder_volume['id']
             cinder_volume_names[key] = value
         payload = {
-            'parent': self.root_path,
+            'parent': self.nas_path,
             'fields': 'guid,parent,path,bytesUsed',
             'recursive': False
         }
@@ -1266,9 +1828,13 @@ class NexentaNfsDriver(nfs.NfsDriver):
             parent = volume['parent']
             size = volume['bytesUsed'] // units.Gi
             name = posixpath.basename(path)
-            if path == self.root_path:
+            if path == self.nas_path:
                 continue
-            if parent != self.root_path:
+            if parent != self.nas_path:
+                continue
+            if nexenta_utils.match_template(self.cache_image_template, name):
+                LOG.debug('Skip image cache %(path)s',
+                          {'path': path})
                 continue
             if name in cinder_volume_names:
                 cinder_id = cinder_volume_names[name]
@@ -1404,7 +1970,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
             }
             cinder_snapshot_names[key] = value
         payload = {
-            'parent': self.root_path,
+            'parent': self.nas_path,
             'fields': 'name,guid,path,parent,hprService,snaplistId',
             'recursive': True
         }
@@ -1423,16 +1989,23 @@ class NexentaNfsDriver(nfs.NfsDriver):
                           'volume %(parent)s is unmanaged',
                           {'path': path, 'parent': parent})
                 continue
-            if name.startswith(self.origin_snapshot_template):
+            if nexenta_utils.match_template(self.cache_snapshot_template,
+                                            name):
+                LOG.debug('Skip image cache snapshot %(path)s',
+                          {'path': path})
+                continue
+            if nexenta_utils.match_template(self.origin_snapshot_template,
+                                            name):
                 LOG.debug('Skip temporary origin snapshot %(path)s',
                           {'path': path})
                 continue
-            if name.startswith(self.group_snapshot_template):
+            if nexenta_utils.match_template(self.group_snapshot_template,
+                                            name):
                 LOG.debug('Skip temporary group snapshot %(path)s',
                           {'path': path})
                 continue
             if snapshot['hprService'] or snapshot['snaplistId']:
-                LOG.debug('Skip HPR/snapping snapshot %(path)s',
+                LOG.debug('Skip Replication/Snapping snapshot %(path)s',
                           {'path': path})
                 continue
             if name in cinder_snapshot_names:
@@ -1489,86 +2062,181 @@ class NexentaNfsDriver(nfs.NfsDriver):
         """
         pass
 
-    def update_migrated_volume(self, context, volume, new_volume,
+    def update_migrated_volume(self, ctxt, volume, new_volume,
                                original_volume_status):
         """Return model update for migrated volume.
 
         This method should rename the back-end volume name on the
         destination host back to its original name on the source host.
 
-        :param context: The context of the caller
+        :param ctxt: The context of the caller
         :param volume: The original volume that was migrated to this backend
         :param new_volume: The migration volume object that was created on
                            this backend as part of the migration process
         :param original_volume_status: The status of the original volume
         :returns: model_update to update DB with any needed changes
         """
-        name_id = None
-        path = self._get_volume_path(volume)
-        new_path = self._get_volume_path(new_volume)
-        payload = {'newPath': path}
+        volume_renamed = False
+        volume_path = self._get_volume_path(volume)
+        new_volume_path = self._get_volume_path(new_volume)
+        bak_volume_path = '%s-backup' % volume_path
+        if volume['host'] == new_volume['host']:
+            volume['_name_id'] = new_volume['id']
+            payload = {'newPath': bak_volume_path}
+            try:
+                self.nef.filesystems.rename(volume_path, payload)
+            except jsonrpc.NefException as error:
+                LOG.error('Failed to create backup copy of original '
+                          'volume %(volume)s: %(error)s',
+                          {'volume': volume['name'],
+                           'error': error})
+                if error.code != 'ENOENT':
+                    raise
+            else:
+                volume_renamed = True
+        payload = {'newPath': volume_path}
         try:
-            self.nef.filesystems.rename(new_path, payload)
-        except jsonrpc.NefException as error:
-            LOG.debug('Failed to rename volume %(new_volume)s '
-                      'to %(volume)s after migration: %(error)s',
+            self.nef.filesystems.rename(new_volume_path, payload)
+        except jsonrpc.NefException as rename_error:
+            LOG.error('Failed to rename temporary volume %(new_volume)s '
+                      'to original %(volume)s after migration: %(error)s',
                       {'new_volume': new_volume['name'],
                        'volume': volume['name'],
-                       'error': error})
-            name_id = new_volume._name_id or new_volume.id
-        model_update = {'_name_id': name_id}
-        return model_update
+                       'error': rename_error})
+            if volume_renamed:
+                payload = {'newPath': volume_path}
+                try:
+                    self.nef.filesystems.rename(bak_volume_path, payload)
+                except jsonrpc.NefException as restore_error:
+                    LOG.error('Failed to restore backup copy of original '
+                              'volume %(volume)s: %(error)s',
+                              {'volume': volume['name'],
+                               'error': restore_error})
+            raise rename_error
+        if volume_renamed:
+            payload = {'newPath': new_volume_path}
+            try:
+                self.nef.filesystems.rename(bak_volume_path, payload)
+            except jsonrpc.NefException as error:
+                LOG.error('Failed to rename backup copy of original '
+                          'volume %(volume)s to temporary volume '
+                          '%(new_volume)s: %(error)s',
+                          {'volume': volume['name'],
+                           'new_volume': new_volume['name'],
+                           'error': error})
+        return {'_name_id': None, 'provider_location': None}
 
-    def retype(self, context, volume, new_type, diff, host):
+    def before_volume_copy(self, ctxt, src_volume, dst_volume, remote=None):
+        """Driver-specific actions before copy volume data.
+
+        This method will be called before _copy_volume_data during volume
+        migration
+        """
+        connector_properties = cinder_utils.brick_get_connector_properties()
+        attach_info, dst_volume = self._attach_volume(ctxt, dst_volume,
+                                                      connector_properties,
+                                                      remote=True)
+        dst_volume_file = attach_info['device']['path']
+        dst_volume_info = image_utils.qemu_img_info(dst_volume_file,
+                                                    force_share=True,
+                                                    run_as_root=True)
+        self._detach_volume(ctxt, attach_info, dst_volume,
+                            connector_properties, force=True)
+        src_nfs_share, src_mount_point, src_volume_file = (
+            self._mount_volume(src_volume))
+        src_volume_info = image_utils.qemu_img_info(src_volume_file,
+                                                    force_share=True,
+                                                    run_as_root=True)
+        if src_volume_info.file_format != dst_volume_info.file_format:
+            self._change_volume_format(src_volume, src_volume_file,
+                                       src_volume_info.file_format,
+                                       dst_volume_info.file_format)
+        self._unmount_volume(src_volume, src_nfs_share, src_mount_point)
+
+    def retype(self, ctxt, volume, new_type, diff, host):
         """Retype from one volume type to another."""
         LOG.debug('Retype volume %(volume)s to host %(host)s '
                   'and volume type %(type)s with diff %(diff)s',
-                  {'volume': volume['name'], 'host': host['host'],
+                  {'volume': volume['name'], 'host': host,
                    'type': new_type['name'], 'diff': diff})
-        retyped = False
-        migrated, model_update = self.migrate_volume(context, volume, host)
         volume_path = self._get_volume_path(volume)
-        payload = {'source': True}
-        volume_specs = self.nef.filesystems.get(volume_path, payload)
-        payload = {}
-        extra_specs = volume_types.get_volume_type_extra_specs(new_type['id'])
         vendor_specs = self.nef.filesystems.properties
+        names = [_['api'] for _ in vendor_specs if 'api' in _]
+        names.remove('sparseVolume')
+        names.remove('volumeFormat')
+        names.append('source')
+        fields = ','.join(names)
+        payload = {'fields': fields, 'source': True}
+        volume_specs = self.nef.filesystems.get(volume_path, payload)
+        volume_type_specs = self._get_vendor_properties(vendor_specs,
+                                                        volume,
+                                                        new_type)
+        sparse_volume = volume_type_specs['sparseVolume']
+        volume_new_format = volume_type_specs['volumeFormat']
+        payload = {}
         for vendor_spec in vendor_specs:
-            property_name = vendor_spec['name']
             api = vendor_spec['api']
-            if 'retype' in vendor_spec:
-                LOG.debug('Skip retype vendor volume property '
-                          '%(property_name)s. %(reason)s',
-                          {'property_name': property_name,
-                           'reason': vendor_spec['retype']})
-                continue
-            if property_name in extra_specs:
-                extra_spec = extra_specs[property_name]
-                value = self._get_vendor_value(extra_spec, vendor_spec)
+            if api in volume_type_specs:
+                value = volume_type_specs[api]
+                if api in volume_specs:
+                    if volume_specs[api] == value:
+                        continue
+                if 'retype' in vendor_spec:
+                    code = 'EINVAL'
+                    message = (_('Failed to retype volume %(volume)s '
+                                 'to host %(host)s and volume type '
+                                 '%(type)s. %(reason)s')
+                               % {'volume': volume['name'],
+                                  'host': host,
+                                  'type': new_type['name'],
+                                  'reason': vendor_spec['retype']})
+                    raise jsonrpc.NefException(code=code, message=message)
                 payload[api] = value
             elif (api in volume_specs and 'source' in volume_specs and
                   api in volume_specs['source'] and
                   volume_specs['source'][api] in ['local', 'received']):
-                if 'cfg' in vendor_spec:
-                    cfg = vendor_spec['cfg']
-                    value = self.configuration.safe_get(cfg)
-                    if volume_specs[api] != value:
-                        payload[api] = value
-                else:
-                    if 'inherit' in vendor_spec:
-                        LOG.debug('Skip inherit vendor volume property '
-                                  '%(property_name)s. %(reason)s',
-                                  {'property_name': property_name,
-                                   'reason': vendor_spec['inherit']})
-                        continue
-                    payload[api] = None
+                if volume_specs[api] == vendor_spec['default']:
+                    continue
+                if 'inherit' in vendor_spec:
+                    LOG.debug('Unable to inherit property %(name)s '
+                              'from volume type %(type)s for volume '
+                              '%(volume)s. %(reason)s',
+                              {'name': api,
+                               'type': new_type['name'],
+                               'volume': volume['name'],
+                               'reason': vendor_spec['inherit']})
+                    continue
+                payload[api] = None
+        if 'sparseVolume' in payload:
+            sparse_volume = payload.pop('sparseVolume')
+        if 'volumeFormat' in payload:
+            volume_new_format = payload.pop('volumeFormat')
         try:
             self.nef.filesystems.set(volume_path, payload)
-            retyped = True
         except jsonrpc.NefException as error:
-            LOG.debug('Failed to retype volume %(volume)s: %(error)s',
-                      {'volume': volume['name'], 'error': error})
-        return retyped or migrated, model_update
+            LOG.error('Failed to retype volume %(volume)s to '
+                      'host %(host)s and volume type %(type)s '
+                      'with payload %(payload)s: %(error)s',
+                      {'volume': volume['name'],
+                       'host': host,
+                       'type': new_type['name'],
+                       'payload': payload,
+                       'error': error})
+            raise
+        nfs_share, mount_point, volume_file = self._mount_volume(volume)
+        volume_info = image_utils.qemu_img_info(volume_file,
+                                                force_share=True,
+                                                run_as_root=True)
+        volume_size = volume_info.virtual_size
+        volume_format = volume_info.file_format
+        if volume_format != volume_new_format:
+            self._change_volume_format(volume, volume_file, volume_format,
+                                       volume_new_format)
+        self._unmount_volume(volume, nfs_share, mount_point)
+        if sparse_volume:
+            volume_size = 0
+        self._set_volume_reservation(volume, volume_size, volume_new_format)
+        return True, None
 
     def _init_vendor_properties(self):
         """Create a dictionary of vendor unique properties.
@@ -1600,15 +2268,24 @@ class NexentaNfsDriver(nfs.NfsDriver):
         : return vendor name
         """
         properties = {}
-        vendor_properties = []
         namespace = self.nef.filesystems.namespace
-        keys = ('enum', 'default', 'minimum', 'maximum')
-        vendor_properties += self.nef.filesystems.properties
+        vendor_properties = self.nef.filesystems.properties
+        keys = ['enum', 'default', 'minimum', 'maximum']
         for vendor_spec in vendor_properties:
             property_spec = {}
             for key in keys:
                 if key in vendor_spec:
-                    property_spec[key] = vendor_spec[key]
+                    value = vendor_spec[key]
+                    property_spec[key] = value
+            api = vendor_spec['api']
+            if 'cfg' in vendor_spec:
+                key = vendor_spec['cfg']
+                value = self.configuration.safe_get(key)
+                if value not in [None, '']:
+                    property_spec['default'] = value
+            elif api in self.nas_stat:
+                value = self.nas_stat[api]
+                property_spec['default'] = value
             property_name = vendor_spec['name']
             property_title = vendor_spec['title']
             property_description = vendor_spec['description']
@@ -1631,27 +2308,36 @@ class NexentaNfsDriver(nfs.NfsDriver):
             )
         return properties, namespace
 
-    def _get_vendor_properties(self, volume, vendor_specs):
-        properties = extra_specs = {}
-        type_id = volume.get('volume_type_id', None)
-        if type_id:
-            extra_specs = volume_types.get_volume_type_extra_specs(type_id)
+    def _get_vendor_properties(self, vendor_specs, volume, volume_type=None):
+        properties = {}
+        extra_specs = {}
+        if volume_type:
+            volume_type_id = volume_type['id']
+        else:
+            volume_type_id = volume['volume_type_id']
+        if volume_type_id:
+            extra_specs = volume_types.get_volume_type_extra_specs(
+                volume_type_id)
         for vendor_spec in vendor_specs:
-            property_name = vendor_spec['name']
-            if property_name in extra_specs:
-                extra_spec = extra_specs[property_name]
+            api = vendor_spec['api']
+            name = vendor_spec['name']
+            if name in extra_specs:
+                extra_spec = extra_specs[name]
                 value = self._get_vendor_value(extra_spec, vendor_spec)
             elif 'cfg' in vendor_spec:
-                cfg = vendor_spec['cfg']
-                value = self.configuration.safe_get(cfg)
+                key = vendor_spec['cfg']
+                value = self.configuration.safe_get(key)
+                if value in [None, '']:
+                    continue
+            elif volume_type and api in self.nas_stat:
+                value = self.nas_stat[api]
             else:
                 continue
-            api = vendor_spec['api']
             properties[api] = value
-            LOG.debug('Get vendor property name %(property_name)s '
-                      'with API name %(api)s and %(type)s value '
+            LOG.debug('Get vendor property name %(name)s with '
+                      'API name %(api)s and %(type)s value '
                       '%(value)s for volume %(volume)s',
-                      {'property_name': property_name,
+                      {'name': name,
                        'api': api,
                        'type': type(value).__name__,
                        'value': value,
@@ -1716,15 +2402,25 @@ class NexentaNfsDriver(nfs.NfsDriver):
         return value
 
     def _get_host_addresses(self):
-        """Return NexentaStor IP addresses list."""
+        """Returns NexentaStor IP addresses list."""
         addresses = []
-        items = self.nef.netaddrs.list()
-        for item in items:
-            cidr = six.text_type(item['address'])
-            addr, mask = cidr.split('/')
-            obj = ipaddress.ip_address(addr)
-            if not obj.is_loopback:
-                addresses.append(obj.exploded)
+        netaddrs = self.nef.netaddrs.list()
+        for netaddr in netaddrs:
+            cidr = six.text_type(netaddr['address'])
+            ip = cidr.split('/')[0]
+            instance = ipaddress.ip_address(ip)
+            if not instance.is_loopback:
+                addresses.append(instance.exploded)
         LOG.debug('Configured IP addresses: %(addresses)s',
                   {'addresses': addresses})
         return addresses
+
+    def _get_backend_name(self):
+        backend_name = self.configuration.safe_get('volume_backend_name')
+        if not backend_name:
+            LOG.error('Failed to get configured volume backend name')
+            backend_name = '%(product)s_%(protocol)s' % {
+                'product': self.product_name,
+                'protocol': self.storage_protocol
+            }
+        return backend_name

--- a/cinder/volume/drivers/nexenta/options.py
+++ b/cinder/volume/drivers/nexenta/options.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -17,15 +16,120 @@ from oslo_config import cfg
 
 from cinder.volume import configuration as conf
 
-DEFAULT_ISCSI_PORT = 3260
-DEFAULT_HOST_GROUP = 'all'
-DEFAULT_TARGET_GROUP = 'all'
+NEXENTASTOR_CONNECTION_OPTS = [
+    cfg.BoolOpt('nexenta_use_https',
+                deprecated_for_removal=True,
+                deprecated_reason='NexentaStor RESTful API interface '
+                                  'protocol should now be set using the '
+                                  'common parameter nexenta_rest_protocol.',
+                help='Use HTTP secure protocol for NexentaStor '
+                     'management REST API connections.'),
+    cfg.StrOpt('nexenta_rest_protocol',
+               default='auto',
+               choices=['http', 'https', 'auto'],
+               help='NexentaStor RESTful API interface protocol.'),
+    cfg.IntOpt('nexenta_rest_port',
+               deprecated_for_removal=True,
+               deprecated_reason='Rest address should now be set using '
+                                 'the common param san_api_port.',
+               default=0,
+               help='NexentaStor RESTful API interface port. If it is '
+                    'equal zero, 8443 for HTTPS and 8080 for HTTP will '
+                    'be used for NexentaStor5 and 8457 for NexentaStor4.'),
+    cfg.StrOpt('nexenta_user',
+               deprecated_for_removal=True,
+               deprecated_reason='Common user parameters should be used '
+                                 'depending on the driver type: '
+                                 'san_login or nas_login',
+               default='admin',
+               help='User name to connect to NexentaStor RESTful API '
+                    'interface.'),
+    cfg.StrOpt('nexenta_password',
+               deprecated_for_removal=True,
+               deprecated_reason='Common password parameters should be '
+                                 'used depending on the driver type: '
+                                 'san_password or nas_password.',
+               default='nexenta',
+               help='User password to connect to NexentaStor RESTful API '
+                    'interface.',
+               secret=True),
+    cfg.StrOpt('nexenta_rest_address',
+               deprecated_for_removal=True,
+               deprecated_reason='Rest address should now be set using '
+                                 'the common param depending on driver '
+                                 'type, san_ip or nas_host.',
+               default='',
+               help='IP address of NexentaStor RESTful API interface.'),
+    cfg.FloatOpt('nexenta_rest_connect_timeout',
+                 default=30,
+                 help='Specifies the time limit (in seconds), within '
+                      'which the connection to NexentaStor RESTful '
+                      'API interface must be established.'),
+    cfg.FloatOpt('nexenta_rest_read_timeout',
+                 default=300,
+                 help='Specifies the time limit (in seconds), '
+                      'within which NexentaStor RESTful API '
+                      'interface must send a response.'),
+    cfg.FloatOpt('nexenta_rest_backoff_factor',
+                 default=1,
+                 help='Specifies the backoff factor to apply between '
+                      'connection attempts to NexentaStor RESTful '
+                      'API interface.'),
+    cfg.IntOpt('nexenta_rest_retry_count',
+               default=5,
+               help='Specifies the number of times to repeat NexentaStor '
+                    'RESTful API calls in case of connection errors '
+                    'or NexentaStor appliance retryable errors.')
+]
 
-NEXENTA_EDGE_OPTS = [
+NEXENTASTOR_ISCSI_OPTS = [
+    cfg.StrOpt('nexenta_host',
+               default='',
+               help='IP address of NexentaStor iSCSI target.'),
+    cfg.StrOpt('nexenta_volume',
+               default='cinder',
+               help='NexentaStor pool name that holds all volumes.'),
+    cfg.IntOpt('nexenta_iscsi_target_portal_port',
+               default=3260,
+               help='NexentaStor default iSCSI target portal port.'),
+    cfg.StrOpt('nexenta_target_prefix',
+               default='iqn.2005-07.com.nexenta:01:cinder',
+               help='Prefix for NexentaStor iSCSI targets.'),
+    cfg.StrOpt('nexenta_target_group_prefix',
+               default='cinder',
+               help='Prefix for iSCSI target groups on NexentaStor.'),
+    cfg.StrOpt('nexenta_host_group_prefix',
+               default='cinder',
+               help='Prefix for iSCSI host groups on NexentaStor.'),
+    cfg.BoolOpt('nexenta_lu_writebackcache_disabled',
+                default=False,
+                help='iSCSI LUNs write-back cache disable behavior: '
+                     'postponed write to backing store is disabled or no.'),
+    cfg.IntOpt('nexenta_luns_per_target',
+               default=100,
+               help='Limit of LUNs per iSCSI target.'),
+    cfg.StrOpt('nexenta_iscsi_target_host_group',
+               deprecated_for_removal=True,
+               deprecated_reason='NexentaStor cinder driver has been '
+                                 'refactored and host groups are created '
+                                 'dynamically. So the configuration '
+                                 'parameter nexenta_iscsi_target_host_group '
+                                 'is no longer used.',
+               default='all',
+               help='Group of hosts which are allowed to access volumes.'),
+    cfg.BoolOpt('nexenta_sparse',
+                deprecated_for_removal=True,
+                deprecated_reason='Common provisioning parameter should '
+                                  'be used: nexenta_sparsed_volumes.',
+                default=False,
+                help='Enables or disables the creation of sparse datasets.')
+]
+
+NEXENTAEDGE_ISCSI_OPTS = [
     cfg.StrOpt('nexenta_nbd_symlinks_dir',
                default='/dev/disk/by-path',
                help='NexentaEdge logical path of directory to store symbolic '
-                    'links to NBDs'),
+                    'links to NBDs.'),
     cfg.StrOpt('nexenta_rest_user',
                default='admin',
                help='User name to connect to NexentaEdge.'),
@@ -35,10 +139,10 @@ NEXENTA_EDGE_OPTS = [
                secret=True),
     cfg.StrOpt('nexenta_lun_container',
                default='',
-               help='NexentaEdge logical path of bucket for LUNs'),
+               help='NexentaEdge logical path of bucket for LUNs.'),
     cfg.StrOpt('nexenta_iscsi_service',
                default='',
-               help='NexentaEdge iSCSI service name'),
+               help='NexentaEdge iSCSI service name.'),
     cfg.StrOpt('nexenta_client_address',
                deprecated_for_removal=True,
                deprecated_reason='iSCSI target address should now be set using'
@@ -48,10 +152,10 @@ NEXENTA_EDGE_OPTS = [
                'address for non-VIP service'),
     cfg.IntOpt('nexenta_iops_limit',
                default=0,
-               help='NexentaEdge iSCSI LUN object IOPS limit'),
+               help='NexentaEdge iSCSI LUN object IOPS limit.'),
     cfg.IntOpt('nexenta_chunksize',
                default=32768,
-               help='NexentaEdge iSCSI LUN object chunk size'),
+               help='NexentaEdge iSCSI LUN object chunk size.'),
     cfg.IntOpt('nexenta_replication_count',
                default=3,
                help='NexentaEdge iSCSI LUN object replication count.'),
@@ -61,201 +165,198 @@ NEXENTA_EDGE_OPTS = [
                      'has encryption enabled.')
 ]
 
-NEXENTA_CONNECTION_OPTS = [
-    cfg.StrOpt('nexenta_host',
+NEXENTASTOR4_ISCSI_OPTS = [
+    cfg.StrOpt('nexenta_folder',
                default='',
-               help='IP address of NexentaStor Appliance'),
-    cfg.StrOpt('nexenta_rest_address',
-               deprecated_for_removal=True,
-               deprecated_reason='Rest address should now be set using '
-                                 'the common param depending on driver type, '
-                                 'san_ip or nas_host',
-               default='',
-               help='IP address of NexentaStor management REST API endpoint'),
-    cfg.IntOpt('nexenta_rest_port',
-               deprecated_for_removal=True,
-               deprecated_reason='Rest address should now be set using '
-                                 'the common param san_api_port.',
-               default=0,
-               help='HTTP(S) port to connect to NexentaStor management '
-                    'REST API server. If it is equal zero, 8443 for '
-                    'HTTPS and 8080 for HTTP is used'),
-    cfg.StrOpt('nexenta_rest_protocol',
-               default='auto',
-               choices=['http', 'https', 'auto'],
-               help='Use http or https for NexentaStor management '
-                    'REST API connection (default auto)'),
-    cfg.FloatOpt('nexenta_rest_connect_timeout',
-                 default=30,
-                 help='Specifies the time limit (in seconds), within '
-                      'which the connection to NexentaStor management '
-                      'REST API server must be established'),
-    cfg.FloatOpt('nexenta_rest_read_timeout',
-                 default=300,
-                 help='Specifies the time limit (in seconds), '
-                      'within which NexentaStor management '
-                      'REST API server must send a response'),
-    cfg.FloatOpt('nexenta_rest_backoff_factor',
-                 default=0.5,
-                 help='Specifies the backoff factor to apply '
-                      'between connection attempts to NexentaStor '
-                      'management REST API server'),
-    cfg.IntOpt('nexenta_rest_retry_count',
-               default=3,
-               help='Specifies the number of times to repeat NexentaStor '
-                    'management REST API call in case of connection errors '
-                    'and NexentaStor appliance EBUSY or ENOENT errors'),
-    cfg.BoolOpt('nexenta_use_https',
-                default=True,
-                help='Use HTTP secure protocol for NexentaStor '
-                     'management REST API connections'),
-    cfg.BoolOpt('nexenta_lu_writebackcache_disabled',
-                default=False,
-                help='Postponed write to backing store or not'),
-    cfg.StrOpt('nexenta_user',
-               deprecated_for_removal=True,
-               deprecated_reason='Common user parameters should be used '
-                                 'depending on the driver type: '
-                                 'san_login or nas_login',
-               default='admin',
-               help='User name to connect to NexentaStor '
-                    'management REST API server'),
-    cfg.StrOpt('nexenta_password',
-               deprecated_for_removal=True,
-               deprecated_reason='Common password parameters should be used '
-                                 'depending on the driver type: '
-                                 'san_password or nas_password',
-               default='nexenta',
-               help='Password to connect to NexentaStor '
-                    'management REST API server',
-               secret=True)
-]
-
-NEXENTA_ISCSI_OPTS = [
+               help='NexentaStor folder name that holds all volumes.'),
     cfg.ListOpt('nexenta_iscsi_target_portal_groups',
                 default=[],
                 help='List of comma-separated NexentaStor4 iSCSI target '
-                     'portal groups'),
-    cfg.StrOpt('nexenta_iscsi_target_portals',
-               default='',
-               help='Comma separated list of portals for NexentaStor5, in'
-                    'format of IP1:port1,IP2:port2. Port is optional, '
-                    'default=3260. Example: 10.10.10.1:3267,10.10.1.2'),
-    cfg.StrOpt('nexenta_iscsi_target_host_group',
-               deprecated_for_removal=True,
-               deprecated_reason='NexentaStor cinder driver has been '
-                                 'refactored and host groups are created '
-                                 'dynamically. So the configuration '
-                                 'parameter nexenta_iscsi_target_host_group '
-                                 'is no longer used.',
-               default='all',
-               help='Group of hosts which are allowed to access volumes'),
-    cfg.IntOpt('nexenta_iscsi_target_portal_port',
-               default=3260,
-               help='NexentaStor iSCSI target portal port'),
-    cfg.IntOpt('nexenta_luns_per_target',
-               default=100,
-               help='Limit of LUNs per iSCSI target'),
-    cfg.StrOpt('nexenta_volume',
-               default='cinder',
-               help='NexentaStor pool name that holds all volumes'),
-    cfg.StrOpt('nexenta_target_prefix',
-               default='iqn.2005-07.com.nexenta:01:cinder',
-               help='iqn prefix for NexentaStor iSCSI targets'),
-    cfg.StrOpt('nexenta_target_group_prefix',
-               default='cinder',
-               help='Prefix for iSCSI target groups on NexentaStor'),
-    cfg.StrOpt('nexenta_host_group_prefix',
-               default='cinder',
-               help='Prefix for iSCSI host groups on NexentaStor'),
+                     'portal groups.')
+]
+
+NEXENTASTOR5_ISCSI_OPTS = [
     cfg.StrOpt('nexenta_volume_group',
                default='iscsi',
-               help='Volume group for NexentaStor5 iSCSI'),
+               help='NexentaStor volume group name that holds all volumes.'),
+    cfg.ListOpt('nexenta_iscsi_target_portals',
+                default='',
+                help='Comma separated list of portals for NexentaStor, in '
+                     'format of IP:port,IP:port. Port number is optional, '
+                     'default value is 3260.'),
+    cfg.IntOpt('nexenta_ns5_blocksize',
+               deprecated_for_removal=True,
+               deprecated_reason='Common block size parameter should be '
+                                 'used: nexenta_blocksize.',
+               default=32,
+               help='Block size for datasets.')
 ]
 
 NEXENTA_NFS_OPTS = [
+    cfg.StrOpt('nexenta_volume_format',
+               default='raw',
+               choices=['raw', 'qcow', 'qcow2', 'parallels',
+                        'vdi', 'vhdx', 'vmdk', 'vpc', 'qed'],
+               help='Volume image file format.'),
+    cfg.BoolOpt('nexenta_nbmand',
+                default=False,
+                help='Allow or disallow non-blocking mandatory locking '
+                     'semantics for a volume.'),
+    cfg.BoolOpt('nexenta_smart_compression',
+                default=False,
+                help='Allow or disallow dynamically tracks per-volume '
+                     'compression ratios to determine if a volume data '
+                     'is compressible or not.'),
+    cfg.BoolOpt('nexenta_qcow2_volumes',
+                deprecated_for_removal=True,
+                deprecated_reason='Volume format parameter should '
+                                  'be used: nexenta_volume_format.',
+                default=False,
+                help='Create volumes as QCOW2 files rather than raw files.'),
     cfg.StrOpt('nexenta_shares_config',
+               deprecated_for_removal=True,
+               deprecated_reason='NexentaStor cinder driver has been '
+                                 'refactored and the configuration '
+                                 'parameter nexenta_shares_config '
+                                 'is no longer used.',
                default='/etc/cinder/nfs_shares',
-               help='File with the list of available nfs shares'),
+               help='File with the list of available nfs shares.'),
     cfg.StrOpt('nexenta_mount_point_base',
                default='$state_path/mnt',
-               help='Base directory that contains NFS share mount points'),
-    cfg.BoolOpt('nexenta_sparsed_volumes',
-                default=True,
-                help='Enables or disables the creation of volumes as '
-                     'sparsed files that take no space. If disabled '
-                     '(False), volume is created as a regular file, '
-                     'which takes a long time.'),
-    cfg.BoolOpt('nexenta_qcow2_volumes',
-                default=False,
-                help='Create volumes as QCOW2 files rather than raw files'),
+               help='Base directory that contains NFS share mount points.'),
     cfg.BoolOpt('nexenta_nms_cache_volroot',
+                deprecated_for_removal=True,
+                deprecated_reason='NexentaStor cinder driver has been '
+                                  'refactored and the configuration '
+                                  'parameter nexenta_nms_cache_volroot '
+                                  'is no longer used.',
                 default=True,
-                help='If set True cache NexentaStor appliance volroot option '
-                     'value.')
+                help='If set True cache NexentaStor appliance volroot '
+                     'option value.')
 ]
 
-NEXENTA_DATASET_OPTS = [
+NEXENTASTOR_DATASET_OPTS = [
     cfg.StrOpt('nexenta_dataset_compression',
-               default='lz4',
-               choices=['on', 'off', 'gzip', 'gzip-1', 'gzip-2', 'gzip-3',
+               choices=['off', 'on', 'gzip', 'gzip-1', 'gzip-2', 'gzip-3',
                         'gzip-4', 'gzip-5', 'gzip-6', 'gzip-7', 'gzip-8',
                         'gzip-9', 'lzjb', 'zle', 'lz4'],
-               help='Compression value for new ZFS folders.'),
+               help='Compression algorithm used to compress volume data.'),
     cfg.StrOpt('nexenta_dataset_dedup',
-               default='off',
-               choices=['on', 'off', 'sha256', 'verify', 'sha256, verify'],
-               help='Deduplication value for new ZFS folders.'),
-    cfg.StrOpt('nexenta_folder',
-               default='',
-               help='A folder where cinder created datasets will reside.'),
-    cfg.StrOpt('nexenta_dataset_description',
-               default='',
-               help='Human-readable description for the folder.'),
+               choices=['off', 'on', 'sha256', 'verify', 'sha256,verify'],
+               help='Deduplication algorithm used to verify volume data '
+                    'integrity.'),
+    cfg.BoolOpt('nexenta_sparsed_volumes',
+                default=True,
+                help='Volumes space allocation behavior. Whether volume '
+                     'is created as sparse and grown as needed or fully '
+                     'allocated up front. The default and recommended '
+                     'value is true, which ensures volumes are initially '
+                     'created as sparse devices. Setting value to false '
+                     'will result in volumes being fully allocated at the '
+                     'time of creation.'),
+    cfg.BoolOpt('nexenta_image_cache',
+                default=True,
+                help='Enables an internal cache of images to efficiently '
+                     'create a new volume by cloning an existing cached '
+                     'image.'),
     cfg.IntOpt('nexenta_blocksize',
                default=32768,
-               help='Block size for datasets'),
-    cfg.IntOpt('nexenta_ns5_blocksize',
-               default=32,
-               help='Block size for datasets'),
-    cfg.BoolOpt('nexenta_sparse',
-                default=False,
-                help='Enables or disables the creation of sparse datasets'),
+               help='Specifies a suggested block size for a volume. '
+                    'The size specified must be a power of two greater '
+                    'than or equal to 512 and less than or equal to 131072 '
+                    'bytes. For an NFS backend, the block size may be up '
+                    'to 1048576 bytes. For an iSCSI backend, the block size '
+                    'cannot be changed after the volume is created.'),
     cfg.IntOpt('nexenta_migration_throttle',
                min=1,
                max=2047,
-               help='Throttle migration throughput in MegaBytes per second'),
+               help='Throttle migration throughput in MegaBytes per second.'),
     cfg.StrOpt('nexenta_migration_service_prefix',
                default='cinder-migration',
-               help='Prefix for migration service name'),
+               help='Prefix for migration service name.'),
     cfg.StrOpt('nexenta_migration_snapshot_prefix',
                default='migration-snapshot',
-               help='Prefix for migration snapshot name'),
+               help='Prefix for migration snapshot name.'),
     cfg.StrOpt('nexenta_origin_snapshot_template',
                default='origin-snapshot-%s',
-               help='Template string to generate origin name of clone'),
+               help='Template string to generate origin name of clone.'),
     cfg.StrOpt('nexenta_group_snapshot_template',
                default='group-snapshot-%s',
-               help='Template string to generate group snapshot name')
+               help='Template string to generate group snapshot name.'),
+    cfg.StrOpt('nexenta_cache_image_template',
+               default='cache-image-%s',
+               help='Template string to generate cache image name.'),
+    cfg.StrOpt('nexenta_cache_snapshot_template',
+               default='cache-snapshot-%s',
+               help='Template string to generate cache snapshot name.'),
+    cfg.StrOpt('nexenta_dataset_description',
+               default='',
+               help='Human-readable description for the backend.')
 ]
 
-NEXENTA_RRMGR_OPTS = [
+NEXENTASTOR4_RRMGR_OPTS = [
     cfg.IntOpt('nexenta_rrmgr_compression',
+               deprecated_for_removal=True,
+               deprecated_reason='NexentaStor cinder driver has been '
+                                 'refactored and the configuration '
+                                 'parameter nexenta_rrmgr_compression '
+                                 'is no longer used.',
                default=0,
-               help=('Enable stream compression, level 1..9. 1 - gives best '
-                     'speed; 9 - gives best compression.')),
+               help='Enable stream compression, level 1..9. 1 - gives best '
+                    'speed; 9 - gives best compression.'),
     cfg.IntOpt('nexenta_rrmgr_tcp_buf_size',
+               deprecated_for_removal=True,
+               deprecated_reason='NexentaStor cinder driver has been '
+                                 'refactored and the configuration '
+                                 'parameter nexenta_rrmgr_tcp_buf_size '
+                                 'is no longer used.',
                default=4096,
                help='TCP Buffer size in KiloBytes.'),
     cfg.IntOpt('nexenta_rrmgr_connections',
+               deprecated_for_removal=True,
+               deprecated_reason='NexentaStor cinder driver has been '
+                                 'refactored and the configuration '
+                                 'parameter nexenta_rrmgr_connections '
+                                 'is no longer used.',
                default=2,
-               help='Number of TCP connections.'),
+               help='Number of TCP connections.')
 ]
 
+NEXENTAEDGE_ISCSI_OPTS += (
+    NEXENTASTOR_CONNECTION_OPTS +
+    NEXENTASTOR_DATASET_OPTS +
+    NEXENTASTOR_ISCSI_OPTS
+)
+
+NEXENTASTOR4_ISCSI_OPTS += (
+    NEXENTASTOR_CONNECTION_OPTS +
+    NEXENTASTOR_DATASET_OPTS +
+    NEXENTASTOR_ISCSI_OPTS +
+    NEXENTASTOR4_RRMGR_OPTS
+)
+
+NEXENTASTOR5_ISCSI_OPTS += (
+    NEXENTASTOR_CONNECTION_OPTS +
+    NEXENTASTOR_DATASET_OPTS +
+    NEXENTASTOR_ISCSI_OPTS
+)
+
+NEXENTASTOR4_NFS_OPTS = (
+    NEXENTASTOR_CONNECTION_OPTS +
+    NEXENTASTOR_DATASET_OPTS +
+    NEXENTA_NFS_OPTS +
+    NEXENTASTOR4_RRMGR_OPTS
+)
+
+NEXENTASTOR5_NFS_OPTS = (
+    NEXENTASTOR_CONNECTION_OPTS +
+    NEXENTASTOR_DATASET_OPTS +
+    NEXENTA_NFS_OPTS
+)
+
 CONF = cfg.CONF
-CONF.register_opts(NEXENTA_CONNECTION_OPTS, group=conf.SHARED_CONF_GROUP)
-CONF.register_opts(NEXENTA_ISCSI_OPTS, group=conf.SHARED_CONF_GROUP)
-CONF.register_opts(NEXENTA_DATASET_OPTS, group=conf.SHARED_CONF_GROUP)
-CONF.register_opts(NEXENTA_NFS_OPTS, group=conf.SHARED_CONF_GROUP)
-CONF.register_opts(NEXENTA_RRMGR_OPTS, group=conf.SHARED_CONF_GROUP)
-CONF.register_opts(NEXENTA_EDGE_OPTS, group=conf.SHARED_CONF_GROUP)
+CONF.register_opts(NEXENTAEDGE_ISCSI_OPTS, group=conf.SHARED_CONF_GROUP)
+CONF.register_opts(NEXENTASTOR4_ISCSI_OPTS, group=conf.SHARED_CONF_GROUP)
+CONF.register_opts(NEXENTASTOR5_ISCSI_OPTS, group=conf.SHARED_CONF_GROUP)
+CONF.register_opts(NEXENTASTOR4_NFS_OPTS, group=conf.SHARED_CONF_GROUP)
+CONF.register_opts(NEXENTASTOR5_NFS_OPTS, group=conf.SHARED_CONF_GROUP)

--- a/cinder/volume/drivers/nexenta/utils.py
+++ b/cinder/volume/drivers/nexenta/utils.py
@@ -1,5 +1,4 @@
-# Copyright 2018 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -14,12 +13,13 @@
 #    under the License.
 
 import re
-import six
+import uuid
 
 from oslo_utils import units
-import six.moves.urllib.parse as urlparse
+import six
 
 from cinder.i18n import _
+from cinder import utils as cinder_utils
 
 
 def str2size(s, scale=1024):
@@ -57,71 +57,42 @@ def str2gib_size(s):
     return size_in_bytes // units.Gi
 
 
-def get_rrmgr_cmd(src, dst, compression=None, tcp_buf_size=None,
-                  connections=None):
-    """Returns rrmgr command for source and destination."""
-    cmd = ['rrmgr', '-s', 'zfs']
-    if compression:
-        cmd.extend(['-c', six.text_type(compression)])
-    cmd.append('-q')
-    cmd.append('-e')
-    if tcp_buf_size:
-        cmd.extend(['-w', six.text_type(tcp_buf_size)])
-    if connections:
-        cmd.extend(['-n', six.text_type(connections)])
-    cmd.extend([src, dst])
-    return ' '.join(cmd)
+def native_string(text):
+    """Convert to native string.
 
+    Convert bytes and Unicode strings to native strings:
 
-def parse_nms_url(url):
-    """Parse NMS url into normalized parts like scheme, user, host and others.
-
-    Example NMS URL:
-        auto://admin:nexenta@192.168.1.1:2000/
-
-    NMS URL parts:
-
-    .. code-block:: none
-
-        auto                True if url starts with auto://, protocol
-                            will be automatically switched to https
-                            if http not supported;
-        scheme (auto)       connection protocol (http or https);
-        user (admin)        NMS user;
-        password (nexenta)  NMS password;
-        host (192.168.1.1)  NMS host;
-        port (2000)         NMS port.
-
-    :param url: url string
-    :return: tuple (auto, scheme, user, password, host, port, path)
+    * convert to bytes on Python 2:
+      encode Unicode using encodeutils.safe_encode()
+    * convert to Unicode on Python 3: decode bytes from UTF-8
     """
-    pr = urlparse.urlparse(url)
-    scheme = pr.scheme
-    auto = scheme == 'auto'
-    if auto:
-        scheme = 'http'
-    user = 'admin'
-    password = 'nexenta'
-    if '@' not in pr.netloc:
-        host_and_port = pr.netloc
-    else:
-        user_and_password, host_and_port = pr.netloc.split('@', 1)
-        if ':' in user_and_password:
-            user, password = user_and_password.split(':')
-        else:
-            user = user_and_password
-    if ':' in host_and_port:
-        host, port = host_and_port.split(':', 1)
-    else:
-        host, port = host_and_port, '2000'
-    return auto, scheme, user, password, host, port, '/rest/nms/'
+    return cinder_utils.convert_str(text)
 
 
-def get_migrate_snapshot_name(volume):
-    """Return name for snapshot that will be used to migrate the volume."""
-    return 'cinder-migrate-snapshot-%(id)s' % volume
+def divup(numerator, denominator):
+    return (numerator + denominator - 1) // denominator
 
 
-def ex2err(ex):
-    """Convert a Cinder Exception to a Nexenta Error."""
-    return ex.msg
+def roundup(numerator, denominator):
+    return divup(numerator, denominator) * denominator
+
+
+def match_template(template, name):
+    if not (name and isinstance(name, six.string_types) and
+            template and isinstance(template, six.string_types)):
+        return False
+    pattern = template.replace('%s', r'(?P<uuid>.+)')
+    if pattern == template:
+        return False
+    regex = re.compile(pattern)
+    match = regex.match(name)
+    if match is None:
+        return False
+    result = match.group('uuid')
+    if not (result and isinstance(result, six.string_types)):
+        return False
+    try:
+        uuid.UUID(result, version=4)
+    except ValueError:
+        return False
+    return True


### PR DESCRIPTION
**NEX-22069 Sync NexentaStor Cinder NFS/iSCSI drivers: Master => Train**

**Pep8**
```
+ tox -e pep8
...
pep8 run-test-pre: PYTHONHASHSEED='3528551545'
pep8 run-test: commands[0] | flake8 .
pep8 run-test: commands[1] | doc8
Scanning...
Validating...
========
Total files scanned = 210
Total files ignored = 1829
Total accumulated errors = 0
Detailed error counts:
    - CheckCarriageReturn = 0
    - CheckIndentationNoTab = 0
    - CheckMaxLineLength = 0
    - CheckNewlineEndOfFile = 0
    - CheckTrailingWhitespace = 0
    - CheckValidity = 0
pep8 run-test: commands[2] | /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 run-test: commands[3] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder /opt/stack/cinder/doc/source/ /opt/stack/cinder/releasenotes/notes
_____________________________________________________________________________________ summary ______________________________________________________________________________________
  pep8: commands succeeded
  congratulations :)
```

**NexentaStor4 NFS**
```
======
Totals
======
Ran: 263 tests in 3873.0000 sec.
 - Passed: 257
 - Skipped: 6
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2925.9523 sec.
```

**NexentaStor5 NFS**
```
======
Totals
======
Ran: 263 tests in 3799.0000 sec.
 - Passed: 259
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2868.8434 sec.
```

**NexentaStor4 iSCSI**
```
======
Totals
======
Ran: 263 tests in 4611.0000 sec.
 - Passed: 258
 - Skipped: 5
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3713.7200 sec.
```

**NexentaStor5 iSCSI**
```
======
Totals
======
Ran: 263 tests in 3669.0000 sec.
 - Passed: 260
 - Skipped: 3
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 2797.2807 sec.
```