### PR TITLE
NEX-22450 Failed to get list of manageable volumes: Invalid query parameters (source: rest, name: NefValidateError, code: EBADARG)

### DIFF
--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -94,9 +94,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         1.5.0 - Added flag backend_state to report backend status.
               - Added retry on driver initialization failure.
         1.5.1 - Support for location header.
+        1.5.2 - Fixed list manageable volumes.
     """
 
-    VERSION = '1.5.0'
+    VERSION = '1.5.2'
     CI_WIKI_NAME = "Nexenta_CI"
 
     vendor_name = 'Nexenta'
@@ -1602,8 +1603,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             cinder_volume_names[key] = value
         payload = {
             'parent': self.san_path,
-            'fields': 'name,guid,path,volumeSize',
-            'recursive': False
+            'fields': 'name,guid,path,volumeSize'
         }
         volumes = self.nef.volumes.list(payload)
         for volume in volumes:


### PR DESCRIPTION
**NEX-22450 Failed to get list of manageable volumes: Invalid query parameters (source: rest, name: NefValidateError, code: EBADARG)**

**Tempest**
```
======
Totals
======
Ran: 263 tests in 4177.7876 sec.
 - Passed: 260
 - Skipped: 3
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3198.2603 sec.
```

**pep8**
```
+ tox -e pep8
pep8 develop-inst-noop: /opt/stack/cinder
pep8 installed: alembic==1.3.3,amqp==2.5.2,appdirs==1.4.3,attrs==19.3.0,automaton==2.0.0,Babel==2.8.0,bandit==1.6.0,bcrypt==3.1.7,cachetools==4.0.0,castellan==2.0.0,certifi==2019.11.28,cffi==1.14.0,chardet==3.0.4,-e git+https://opendev.org/openstack/cinder.git@a154a1360be62eed0e2bf20937503b55659f4701#egg=cinder,cliff==3.0.0,cmd2==0.8.9,coverage==5.0.3,cryptography==2.8,cursive==0.2.2,ddt==1.2.2,debtcollector==2.0.0,decorator==4.4.1,defusedxml==0.6.0,dnspython==1.15.0,doc8==0.8.0,docutils==0.15.2,dogpile.cache==0.9.0,dulwich==0.19.15,entrypoints==0.3,eventlet==0.25.1,extras==1.0.0,fasteners==0.14.1,fixtures==3.0.0,flake8==3.7.9,flake8-import-order==0.18.1,flake8-logging-format==0.6.0,future==0.18.2,futurist==2.0.0,gitdb==4.0.2,GitPython==3.1.0,google-api-python-client==1.7.11,google-auth==1.11.2,google-auth-httplib2==0.0.3,greenlet==0.4.15,hacking==2.0.0,httplib2==0.17.0,idna==2.9,importlib-metadata==1.5.0,iso8601==0.1.12,Jinja2==2.11.1,jmespath==0.9.5,jsonpatch==1.25,jsonpointer==2.0,jsonschema==3.2.0,keystoneauth1==3.18.0,keystonemiddleware==8.0.0,kombu==4.6.7,linecache2==1.0.0,lxml==4.5.0,Mako==1.1.1,MarkupSafe==1.1.1,mccabe==0.6.1,mock==3.0.5,monotonic==1.5,mox3==1.0.0,msgpack==0.6.2,munch==2.5.0,netaddr==0.7.19,netifaces==0.10.9,networkx==2.4,oauth2client==4.1.3,openstacksdk==0.41.0,os-brick==3.0.0,os-client-config==2.0.0,os-service-types==1.7.0,os-win==5.0.0,oslo.cache==2.0.0,oslo.concurrency==4.0.1,oslo.config==8.0.1,oslo.context==3.0.0,oslo.db==7.0.0,oslo.i18n==4.0.0,oslo.log==4.0.1,oslo.messaging==11.0.0,oslo.middleware==4.0.1,oslo.policy==2.4.1,oslo.privsep==2.0.0,oslo.reports==2.0.0,oslo.rootwrap==6.0.1,oslo.serialization==3.0.0,oslo.service==2.0.0,oslo.upgradecheck==1.0.0,oslo.utils==4.0.0,oslo.versionedobjects==2.0.0,oslo.vmware==3.1.0,oslotest==3.9.0,osprofiler==3.0.0,paramiko==2.7.1,Paste==3.4.0,PasteDeploy==2.1.0,pbr==5.4.4,prettytable==0.7.2,psutil==5.7.0,psycopg2==2.8.4,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycadf==3.0.0,pycodestyle==2.5.0,pycparser==2.19,pydot==1.4.1,pyflakes==2.1.1,Pygments==2.5.2,pyinotify==0.9.6,PyMySQL==0.9.3,PyNaCl==1.3.0,pyOpenSSL==19.1.0,pyparsing==2.4.6,pyperclip==1.7.0,pyrsistent==0.15.7,python-barbicanclient==4.10.0,python-dateutil==2.8.1,python-editor==1.0.4,python-glanceclient==2.17.0,python-keystoneclient==3.22.0,python-mimeparse==1.6.0,python-novaclient==16.0.0,python-subunit==1.3.0,python-swiftclient==3.9.0,pytz==2019.3,pyudev==0.22.0,PyYAML==5.3,reno==3.0.0,repoze.lru==0.7,requests==2.23.0,requestsexceptions==1.4.0,restructuredtext-lint==1.3.0,retrying==1.3.3,rfc3986==1.3.2,Routes==2.4.1,rsa==4.0,rtslib-fb==2.1.71,simplejson==3.17.0,six==1.14.0,smmap==3.0.1,SQLAlchemy==1.3.13,sqlalchemy-migrate==0.13.0,SQLAlchemy-Utils==0.36.1,sqlparse==0.3.0,statsd==3.3.0,stestr==2.6.0,stevedore==1.32.0,suds-jurko==0.6,tabulate==0.8.6,taskflow==4.0.0,Tempita==0.5.2,tenacity==6.1.0,testresources==2.0.1,testscenarios==0.5.0,testtools==2.3.0,tooz==2.0.0,traceback2==1.4.0,unittest2==1.1.0,uritemplate==3.0.1,urllib3==1.25.8,vine==1.3.0,voluptuous==0.11.7,warlock==1.3.3,wcwidth==0.1.8,WebOb==1.8.6,wrapt==1.12.0,yappi==1.2.3,zipp==3.0.0
pep8 run-test-pre: PYTHONHASHSEED='2332510799'
pep8 run-test: commands[0] | flake8 .
pep8 run-test: commands[1] | doc8
Scanning...
Validating...
========
Total files scanned = 202
Total files ignored = 430
Total accumulated errors = 0
Detailed error counts:
    - CheckCarriageReturn = 0
    - CheckIndentationNoTab = 0
    - CheckMaxLineLength = 0
    - CheckNewlineEndOfFile = 0
    - CheckTrailingWhitespace = 0
    - CheckValidity = 0
pep8 run-test: commands[2] | /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 run-test: commands[3] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder /opt/stack/cinder/doc/source/ /opt/stack/cinder/releasenotes/notes
___________________________________ summary ____________________________________
  pep8: commands succeeded
  congratulations :)
```