### PR TITLE
NFS driver fixes

### DIFF
--- a/cinder/tests/unit/volume/drivers/nexenta/test_nexenta.py
+++ b/cinder/tests/unit/volume/drivers/nexenta/test_nexenta.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2020 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -13,17 +12,18 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-Unit tests for OpenStack Cinder volume driver
+Unit tests for NexentaStor4 Cinder volume driver
 """
 
-import mock
-from mock import patch
+from unittest import mock
+from unittest.mock import patch
+
 from oslo_utils import units
 
 from cinder import context
 from cinder import db
 from cinder import exception
-from cinder import test
+from cinder.tests.unit import test
 from cinder.volume import configuration as conf
 from cinder.volume.drivers.nexenta import iscsi
 from cinder.volume.drivers.nexenta import jsonrpc

--- a/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_iscsi.py
+++ b/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_iscsi.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2020 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -13,16 +12,16 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-Unit tests for OpenStack Cinder volume driver
+Unit tests for NexentaStor5 iSCSI Cinder volume driver
 """
+
+from unittest import mock
 import uuid
 
-import mock
 from oslo_utils import units
 
 from cinder import context
 from cinder import db
-from cinder import test
 from cinder.tests.unit.consistencygroup.fake_cgsnapshot import (
     fake_cgsnapshot_obj as fake_cgsnapshot)
 from cinder.tests.unit.consistencygroup.fake_consistencygroup import (
@@ -30,6 +29,7 @@ from cinder.tests.unit.consistencygroup.fake_consistencygroup import (
 from cinder.tests.unit import fake_constants as fake
 from cinder.tests.unit.fake_snapshot import fake_snapshot_obj as fake_snapshot
 from cinder.tests.unit.fake_volume import fake_volume_obj as fake_volume
+from cinder.tests.unit import test
 from cinder.volume import configuration as conf
 from cinder.volume.drivers.nexenta.ns5 import iscsi
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
@@ -47,6 +47,8 @@ class TestNexentaISCSIDriver(test.TestCase):
         self.cfg.volume_backend_name = 'nexenta_iscsi'
         self.cfg.nexenta_group_snapshot_template = 'group-snapshot-%s'
         self.cfg.nexenta_origin_snapshot_template = 'origin-snapshot-%s'
+        self.cfg.nexenta_cache_image_template = 'cache-image-%s'
+        self.cfg.nexenta_cache_snapshot_template = 'cache-snapshot-%s'
         self.cfg.nexenta_migration_service_prefix = 'cinder-migration'
         self.cfg.nexenta_migration_throttle = 100
         self.cfg.nexenta_dataset_description = ''
@@ -59,8 +61,9 @@ class TestNexentaISCSIDriver(test.TestCase):
         self.cfg.nexenta_iscsi_target_portal_port = 3260
         self.cfg.nexenta_target_prefix = 'iqn:cinder'
         self.cfg.nexenta_target_group_prefix = 'cinder'
-        self.cfg.nexenta_ns5_blocksize = 32
+        # self.cfg.nexenta_ns5_blocksize = 32
         self.cfg.nexenta_sparse = True
+        self.cfg.nexenta_image_cache = True
         self.cfg.nexenta_lu_writebackcache_disabled = True
         self.cfg.nexenta_dataset_compression = 'on'
         self.cfg.nexenta_dataset_dedup = 'off'
@@ -69,7 +72,7 @@ class TestNexentaISCSIDriver(test.TestCase):
         self.cfg.nexenta_volume = 'pool'
         self.cfg.driver_ssl_cert_verify = False
         self.cfg.nexenta_luns_per_target = 20
-        self.cfg.driver_ssl_cert_verify = False
+        self.cfg.nexenta_blocksize = 8192
         self.cfg.nexenta_iscsi_target_portals = '1.1.1.1:3260,2.2.2.2:3260'
         self.cfg.nexenta_iscsi_target_host_group = 'all'
         self.cfg.nexenta_rest_address = '1.1.1.1'

--- a/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_jsonrpc.py
+++ b/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_jsonrpc.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2020 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -13,20 +12,20 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-Unit tests for NexentaStor 5 REST API helper
+Unit tests for NexentaStor5 REST API helper
 """
 
 import copy
 import hashlib
 import json
 import posixpath
+from unittest import mock
 import uuid
 
-import mock
 import requests
 import six
 
-from cinder import test
+from cinder.tests.unit import test
 from cinder.volume import configuration as conf
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 

--- a/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_nfs.py
+++ b/cinder/tests/unit/volume/drivers/nexenta/test_nexenta5_nfs.py
@@ -1,5 +1,4 @@
-# Copyright 2019 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2020 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -13,18 +12,18 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 """
-Unit tests for OpenStack Cinder volume driver
+Unit tests for NexentaStor5 NFS Cinder volume driver
 """
+
 import hashlib
 import os
 import posixpath
+from unittest import mock
 
-import mock
 from oslo_utils import units
 
 from cinder import context
 from cinder import db
-from cinder import test
 from cinder.tests.unit.consistencygroup.fake_cgsnapshot import (
     fake_cgsnapshot_obj as fake_cgsnapshot)
 from cinder.tests.unit.consistencygroup.fake_consistencygroup import (
@@ -33,6 +32,7 @@ from cinder.tests.unit import fake_constants as fake
 from cinder.tests.unit.fake_snapshot import fake_snapshot_obj as fake_snapshot
 from cinder.tests.unit.fake_volume import fake_volume_obj as fake_volume
 from cinder.tests.unit.image import fake as fake_image
+from cinder.tests.unit import test
 from cinder.volume import configuration as conf
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 from cinder.volume.drivers.nexenta.ns5 import nfs

--- a/cinder/tests/unit/volume/drivers/nexenta/test_nexenta_edge.py
+++ b/cinder/tests/unit/volume/drivers/nexenta/test_nexenta_edge.py
@@ -1,6 +1,4 @@
-#
-# Copyright 2015 Nexenta Systems, Inc.
-# All Rights Reserved.
+# Copyright 2020 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -15,12 +13,12 @@
 #    under the License.
 
 import json
-import mock
-from mock import patch
+from unittest import mock
+from unittest.mock import patch
 
 from cinder import context
 from cinder import exception
-from cinder import test
+from cinder.tests.unit import test
 from cinder.volume import configuration as conf
 from cinder.volume.drivers.nexenta.nexentaedge import iscsi
 
@@ -113,11 +111,13 @@ class TestNexentaEdgeISCSIDriver(test.TestCase):
         ]
 
         def my_side_effect(*args, **kwargs):
-                return {'data': {
+            return {
+                'data': {
                     'X-ISCSI-TargetName': ISCSI_TARGET_NAME,
                     'X-ISCSI-TargetID': 1,
-                    'X-VIPS': json.dumps(vips)}
+                    'X-VIPS': json.dumps(vips)
                 }
+            }
 
         self.mock_api.side_effect = my_side_effect
         self.driver.do_setup(self.context)
@@ -131,11 +131,13 @@ class TestNexentaEdgeISCSIDriver(test.TestCase):
         ]
 
         def my_side_effect(*args, **kwargs):
-                return {'data': {
+            return {
+                'data': {
                     'X-ISCSI-TargetName': ISCSI_TARGET_NAME,
                     'X-ISCSI-TargetID': 1,
-                    'X-VIPS': json.dumps(vips)}
+                    'X-VIPS': json.dumps(vips)
                 }
+            }
 
         self.mock_api.side_effect = my_side_effect
         self.assertRaises(exception.NexentaException,

--- a/cinder/volume/drivers/nexenta/image.py
+++ b/cinder/volume/drivers/nexenta/image.py
@@ -1,0 +1,152 @@
+# Copyright 2020 Nexenta by DDN, Inc. All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import os
+
+from oslo_utils import units
+
+from cinder.image import image_utils
+from cinder.volume.drivers.nexenta import utils
+
+FILE_NAME = 'volume'
+FORMAT_RAW = 'raw'
+FORMAT_QCOW = 'qcow'
+FORMAT_QCOW2 = 'qcow2'
+FORMAT_PARALLELS = 'parallels'
+FORMAT_VDI = 'vdi'
+FORMAT_VHDX = 'vhdx'
+FORMAT_VMDK = 'vmdk'
+FORMAT_VPC = 'vpc'
+FORMAT_QED = 'qed'
+
+
+class VolumeImage(object):
+    def __init__(self, driver, volume, specs):
+        self.driver = driver
+        self.nohide = driver.nas_nohide
+        self.root = driver._execute_as_root
+        self.block_size = driver.configuration.volume_dd_blocksize
+        self.resizable_formats = [FORMAT_RAW, FORMAT_QCOW2]
+        self.file_size = volume['size'] * units.Gi
+        self.file_format = specs['format']
+        self.file_sparse = specs['sparse']
+        self.share = driver._get_volume_share(volume)
+        if self.nohide:
+            self.mntpoint = driver.nas_mntpoint
+            self.file_name = os.path.join(volume['name'], FILE_NAME)
+        else:
+            self.mntpoint = driver._mount_share(self.share)
+            self.file_name = FILE_NAME
+        self.file_path = os.path.join(self.mntpoint, self.file_name)
+
+    def __del__(self):
+        if not self.nohide:
+            self.driver._unmount_share(self.share, self.mntpoint)
+
+    @property
+    def info(self):
+        return image_utils.qemu_img_info(
+            self.file_path,
+            force_share=True,
+            run_as_root=self.root)
+
+    @property
+    def volume_size(self):
+        return utils.roundgb(self.file_size)
+
+    def execute(self, *cmd, **kwargs):
+        if 'run_as_root' not in kwargs:
+            kwargs['run_as_root'] = self.root
+        self.driver._execute(*cmd, **kwargs)
+
+    def create(self):
+        cmd = ['qemu-img', 'create', '-f']
+        cmd.append(self.file_format)
+        if self.file_format == FORMAT_QCOW2:
+            cmd.append('-o')
+            cmd.append('preallocation=metadata')
+        cmd.append(self.file_path)
+        cmd.append(self.file_size)
+        self.execute(*cmd)
+
+    def resize(self, file_size):
+        cmd = ['qemu-img', 'resize', '-f']
+        cmd.append(self.file_format)
+        if self.file_format == FORMAT_QCOW2:
+            cmd.append('--preallocation=metadata')
+        cmd.append(self.file_path)
+        cmd.append(file_size)
+        self.execute(*cmd)
+        self.file_size = file_size
+
+    def change(self, file_size=None, file_format=None):
+        if not file_size:
+            file_size = self.file_size
+        if not file_format:
+            file_format = self.file_format
+        while (self.file_format != file_format
+               or self.file_size != file_size):
+            if self.file_size == file_size:
+                self.convert(file_format)
+            elif self.file_format in self.resizable_formats:
+                self.resize(file_size)
+            elif file_format in self.resizable_formats:
+                self.convert(file_format)
+            else:
+                self.convert(FORMAT_RAW)
+
+    def upload(self, ctxt, image_service, image_meta):
+        image_utils.upload_volume(
+            ctxt, image_service,
+            image_meta, self.file_path,
+            volume_format=self.file_format,
+            run_as_root=self.root)
+
+    def fetch(self, ctxt, image_service, image_id):
+        image_utils.fetch_to_volume_format(
+            ctxt, image_service,
+            image_id, self.file_path,
+            self.file_format,
+            self.block_size,
+            run_as_root=self.root)
+        self.reload(file_size=True)
+
+    def download(self, ctxt, image_service, image_id):
+        file_size = self.file_size
+        file_format = self.file_format
+        if self.file_format not in self.resizable_formats:
+            self.file_format = FORMAT_RAW
+        self.fetch(ctxt, image_service, image_id)
+        self.change(file_size=file_size, file_format=file_format)
+
+    def convert(self, file_format):
+        file_path = '%(path)s.%(format)s' % {
+            'path': self.file_path,
+            'format': file_format
+        }
+        image_utils.convert_image(
+            self.file_path,
+            file_path,
+            file_format,
+            src_format=self.file_format,
+            run_as_root=self.root)
+        self.execute('mv', file_path, self.file_path)
+        self.file_format = file_format
+
+    def reload(self, file_size=False, file_format=False):
+        info = self.info
+        if file_size:
+            self.file_size = info.virtual_size
+        if file_format:
+            self.file_format = info.file_format

--- a/cinder/volume/drivers/nexenta/nexentaedge/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/nexentaedge/jsonrpc.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
+# Copyright 2020 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -13,9 +13,9 @@
 #    under the License.
 
 import json
-import requests
 
 from oslo_log import log as logging
+import requests
 
 from cinder import exception
 from cinder.i18n import _

--- a/cinder/volume/drivers/nexenta/nexentaedge/nbd.py
+++ b/cinder/volume/drivers/nexenta/nexentaedge/nbd.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Nexenta by DDN, Inc. All rights reserved.
+# Copyright 2020 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -14,12 +14,12 @@
 
 import json
 import os
-import six
 import socket
 
 from oslo_log import log as logging
 from oslo_utils import excutils
 from oslo_utils import units
+import six
 
 from cinder import exception
 from cinder.i18n import _

--- a/cinder/volume/drivers/nexenta/ns5/iscsi.py
+++ b/cinder/volume/drivers/nexenta/ns5/iscsi.py
@@ -22,7 +22,6 @@ from oslo_utils import strutils
 from oslo_utils import units
 import six
 
-from cinder import context
 from cinder import coordination
 from cinder.i18n import _
 from cinder.image import image_utils
@@ -31,7 +30,7 @@ from cinder import objects
 from cinder.volume import driver
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 from cinder.volume.drivers.nexenta import options
-from cinder.volume.drivers.nexenta import utils as nexenta_utils
+from cinder.volume.drivers.nexenta import utils
 from cinder.volume import volume_types
 from cinder.volume import volume_utils
 
@@ -95,9 +94,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
               - Added retry on driver initialization failure.
         1.5.1 - Support for location header.
         1.5.2 - Fixed list manageable volumes.
+        1.5.3 - Fixed concurrency issues.
     """
 
-    VERSION = '1.5.2'
+    VERSION = '1.5.3'
     CI_WIKI_NAME = "Nexenta_CI"
 
     vendor_name = 'Nexenta'
@@ -108,33 +108,35 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
     def __init__(self, *args, **kwargs):
         super(NexentaISCSIDriver, self).__init__(*args, **kwargs)
         if not self.configuration:
+            code = 'ENODATA'
             message = (_('%(product_name)s %(storage_protocol)s '
                          'backend configuration not found')
                        % {'product_name': self.product_name,
                           'storage_protocol': self.storage_protocol})
-            raise jsonrpc.NefException(code='ENODATA', message=message)
+            raise jsonrpc.NefException(code=code, message=message)
         self.configuration.append_config_values(
             options.NEXENTASTOR5_ISCSI_OPTS)
         self.nef = None
+        self.ctxt = None
+        self.san_host = None
+        self.san_port = None
         self.san_stat = None
+        self.san_portals = []
         self.backend_name = self._get_backend_name()
         self.san_driver = self.__class__.__name__
         self.image_cache = self.configuration.nexenta_image_cache
         self.target_prefix = self.configuration.nexenta_target_prefix
-        self.target_group_prefix = (
+        self.targetgroup_prefix = (
             self.configuration.nexenta_target_group_prefix)
         self.block_size = self.configuration.nexenta_blocksize
         self.host_group_prefix = self.configuration.nexenta_host_group_prefix
         self.luns_per_target = self.configuration.nexenta_luns_per_target
         self.lu_writebackcache_disabled = (
             self.configuration.nexenta_lu_writebackcache_disabled)
-        self.san_host = self.configuration.nexenta_host
-        self.san_port = self.configuration.nexenta_iscsi_target_portal_port
         self.san_path = posixpath.join(
             self.configuration.nexenta_volume,
             self.configuration.nexenta_volume_group)
         self.san_pool = self.configuration.nexenta_volume
-        self.portals = self.configuration.nexenta_iscsi_target_portals
         self.group_snapshot_template = (
             self.configuration.nexenta_group_snapshot_template)
         self.origin_snapshot_template = (
@@ -153,6 +155,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         return options.NEXENTASTOR5_ISCSI_OPTS
 
     def do_setup(self, ctxt):
+        self.ctxt = ctxt
         retries = 0
         while not self._do_setup():
             retries += 1
@@ -160,20 +163,68 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
 
     def _do_setup(self):
         try:
-            self.nef = jsonrpc.NefProxy(self.driver_volume_type,
-                                        self.san_pool,
-                                        self.san_path,
-                                        self.configuration)
+            self.nef = jsonrpc.NefProxy(
+                self.driver_volume_type,
+                self.san_pool,
+                self.san_path,
+                self.backend_name,
+                self.configuration)
         except jsonrpc.NefException as error:
             LOG.error('Failed to initialize RESTful API for backend '
                       '%(backend_name)s on host %(host)s: %(error)s',
                       {'backend_name': self.backend_name,
-                       'host': self.host,
-                       'error': error})
+                       'host': self.host, 'error': error})
             return False
         return True
 
     def check_for_setup_error(self):
+        host = self.configuration.nexenta_host
+        port = self.configuration.nexenta_iscsi_target_portal_port
+        if host:
+            if not port:
+                port = DEFAULT_ISCSI_PORT
+            portal = {'address': host, 'port': port}
+            self.san_portals.append(portal)
+            self.san_host = host
+            self.san_port = port
+        items = self.configuration.nexenta_iscsi_target_portals
+        for item in items:
+            if not item:
+                continue
+            hostport = item.split(':')
+            host = hostport[0]
+            port = DEFAULT_ISCSI_PORT
+            if len(hostport) == 2:
+                try:
+                    port = int(hostport[1])
+                except (TypeError, ValueError) as error:
+                    LOG.error('Invalid port of %(storage_protocol)s '
+                              'portal for backend %(backend_name)s '
+                              'on host %(host)s: %(error)s',
+                              {'storage_protocol': self.storage_protocol,
+                               'backend_name': self.backend_name,
+                               'host': self.host, 'error': error})
+                    raise
+            portal = {'address': host, 'port': port}
+            if portal not in self.san_portals:
+                self.san_portals.append(portal)
+            if not self.san_host:
+                self.san_host = host
+            if not self.san_port:
+                self.san_port = port
+        if not self.san_portals:
+            code = 'ENODATA'
+            message = (_('%(product_name)s %(storage_protocol)s '
+                         'host is not defined on host %(host)s, '
+                         'please check the Cinder configuration '
+                         'file for backend %(backend_name)s and '
+                         'nexenta_iscsi_target_portals and/or '
+                         'nexenta_host configuration options')
+                       % {'product_name': self.product_name,
+                          'storage_protocol': self.storage_protocol,
+                          'host': self.host,
+                          'backend_name': self.backend_name})
+            raise jsonrpc.NefException(code=code, message=message)
         retries = 0
         while not self._check_for_setup_error():
             retries += 1
@@ -188,9 +239,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             LOG.error('Failed to get stat of SAN pool %(san_pool)s: %(error)s',
                       {'san_pool': self.san_pool, 'error': error})
             return False
-        specs = self.nef.volumes.properties
-        names = [spec['api'] for spec in specs if 'api' in spec]
-        names.remove('sparseVolume')
+        items = self.nef.volumegroups.properties
+        names = [item['api'] for item in items if 'api' in item]
         fields = ','.join(names)
         payload = {'fields': fields}
         try:
@@ -203,6 +253,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             return False
         if not self.san_stat:
             return False
+        payload = {'fields': 'state'}
         try:
             service = self.nef.services.get('iscsit')
         except jsonrpc.NefException as error:
@@ -226,133 +277,74 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             LOG.error('Failed to create SAN path %(san_path)s: %(error)s',
                       {'san_path': self.san_path, 'error': error})
 
-    def _get_volume_reservation(self, volume):
-        """Calculates the correct reservation size for given volume size.
-
-        Its purpose is to reserve additional space for volume metadata
-        so volume don't unexpectedly run out of room. This function is
-        a copy of the volsize_to_reservation function in libzfs_dataset.c
-
-        :param volume: volume reference
-        :returns: reservation size
-        """
-        volume_path = self._get_volume_path(volume)
-        payload = {'fields': 'volumeBlockSize,volumeSize,dataCopies'}
-        volume_specs = self.nef.volumes.get(volume_path, payload)
-        block_size = volume_specs['volumeBlockSize']
-        volume_size = volume_specs['volumeSize']
-        data_copies = volume_specs['dataCopies']
-        reservation = volume_size
-        numdb = 7
-        dn_max_indblkshift = 17
-        spa_blkptrshift = 7
-        spa_dvas_per_bp = 3
-        dnodes_per_level_shift = dn_max_indblkshift - spa_blkptrshift
-        dnodes_per_level = 1 << dnodes_per_level_shift
-        nblocks = reservation // block_size
-        while nblocks > 1:
-            nblocks += dnodes_per_level - 1
-            nblocks //= dnodes_per_level
-            numdb += nblocks
-        numdb *= min(spa_dvas_per_bp, data_copies + 1)
-        reservation *= data_copies
-        numdb *= 1 << dn_max_indblkshift
-        reservation += numdb
-        volume_meta = reservation - volume_size
-        LOG.debug('Reservation size for raw volume %(volume)s: '
-                  '%(reservation)s, volume data size: %(volume_size)s '
-                  'and volume metadata size: %(volume_meta)s',
-                  {'volume': volume['name'], 'reservation': reservation,
-                   'volume_size': volume_size, 'volume_meta': volume_meta})
-        return reservation
-
-    def _set_volume_reservation(self, volume, reservation=None):
-        if reservation is None:
-            reservation = self._get_volume_reservation(volume)
-        volume_path = self._get_volume_path(volume)
-        payload = {'fields': 'referencedReservationSize,volumeSize'}
-        volume_specs = self.nef.volumes.get(volume_path, payload)
-        volume_reservation = volume_specs['referencedReservationSize']
-        volume_size = volume_specs['volumeSize']
-        if volume_reservation == reservation:
-            return
-        if not reservation:
-            payload = {'referencedReservationSize': reservation}
-            try:
-                self.nef.volumes.set(volume_path, payload)
-            except jsonrpc.NefException as error:
-                LOG.error('Failed to reset volume reservation size from '
-                          '%(volume_reservation)s to %(reservation)s '
-                          'for volume %(volume)s: %(error)s',
-                          {'volume_reservation': volume_reservation,
-                           'reservation': reservation,
-                           'volume': volume['name'],
-                           'error': error})
-                raise
-            return
-        # Workaround for NEX-21586
-        connectors = self._get_volume_connectors(volume)
-        if connectors:
-            code = 'EINVAL'
-            message = (_('Volume provisioning type cannot be changed '
-                         'for attached volume %(volume)s, volume '
-                         'connectors are: %(connectors)s')
-                       % {'volume': volume['name'],
-                          'connectors': connectors})
-            raise jsonrpc.NefException(code=code, message=message)
-        temporay_size = nexenta_utils.roundup(reservation, units.Gi)
-        payload = {'volumeSize': temporay_size}
-        try:
-            self.nef.volumes.set(volume_path, payload)
-        except jsonrpc.NefException as error:
-            LOG.error('Failed to temporarily change volume size from '
-                      '%(volume_size)s to %(temporay_size)s for volume '
-                      '%(volume)s: %(error)s',
-                      {'volume_size': volume_size,
-                       'temporay_size': temporay_size,
-                       'volume': volume['name'],
-                       'error': error})
-            raise
-        payload = {'referencedReservationSize': reservation}
-        try:
-            self.nef.volumes.set(volume_path, payload)
-        except jsonrpc.NefException as error:
-            LOG.error('Failed to change volume reservation size from '
-                      '%(volume_reservation)s to %(reservation)s '
-                      'for volume %(volume)s: %(error)s',
-                      {'volume_reservation': volume_reservation,
-                       'reservation': reservation,
-                       'volume': volume['name'],
-                       'error': error})
-            raise
-        payload = {'volumeSize': volume_size}
-        try:
-            self.nef.volumes.set(volume_path, payload)
-        except jsonrpc.NefException as error:
-            LOG.error('Failed to restore original volume size from '
-                      '%(temporay_size)s to %(volume_size)s for volume '
-                      '%(volume)s: %(error)s',
-                      {'temporay_size': temporay_size,
-                       'volume_size': volume_size,
-                       'volume': volume['name'],
-                       'error': error})
-            raise
-
-    def _update_volume_properties(self, volume):
+    def _update_volume_props(self, volume, volume_type=None):
         """Updates the existing volume properties.
 
         :param volume: volume reference
+        :param volume_type: new volume type
         """
-        if not volume['volume_type_id']:
-            return
-        ctxt = context.get_admin_context()
-        volume_type_id = volume['volume_type_id']
-        volume_type = volume_types.get_volume_type(ctxt, volume_type_id)
-        diff = {}
-        host = volume['host']
-        self.retype(ctxt, volume, volume_type, diff, host)
+        volume_path = self._get_volume_path(volume)
+        volume_size = volume['size'] * units.Gi
+        items = self.nef.volumes.properties
+        names = [item['api'] for item in items if 'api' in item]
+        # Workaround for NEX-21595
+        names += ['source', 'volumeSize', 'referencedReservationSize']
+        fields = ','.join(names)
+        payload = {'fields': fields, 'source': True}
+        props = self.nef.volumes.get(volume_path, payload)
+        src = props['source']
+        specs = self._get_volume_specs(volume, volume_type)
+        payload = {}
+        for item in items:
+            if 'api' not in item:
+                continue
+            api = item['api']
+            if api in specs:
+                value = specs[api]
+                if props[api] == value:
+                    continue
+                if 'change' in item:
+                    code = 'EINVAL'
+                    message = (_('Unable to change property %(name)s '
+                                 'for volume %(volume)s. %(reason)s')
+                               % {'name': item['name'],
+                                  'volume': volume['name'],
+                                  'reason': item['change']})
+                    raise jsonrpc.NefException(code=code, message=message)
+                payload[api] = value
+            elif src[api] in ['local', 'received']:
+                if props[api] == item['default']:
+                    continue
+                if 'inherit' in item:
+                    LOG.debug('Unable to inherit property %(name)s '
+                              'for volume %(volume)s. %(reason)s',
+                              {'name': item['name'],
+                               'volume': volume['name'],
+                               'reason': item['inherit']})
+                    continue
+                payload[api] = None
+        if props['volumeSize'] < volume_size:
+            payload['volumeSize'] = volume_size
+            if 0 < props['referencedReservationSize'] <= props['volumeSize']:
+                payload['referencedReservationSize'] = volume_size
+        if 'sparseVolume' in payload:
+            sparse_volume = payload.pop('sparseVolume')
+            if sparse_volume:
+                payload['referencedReservationSize'] = 0
+            else:
+                payload['referencedReservationSize'] = volume_size
+        if payload:
+            self.nef.volumes.set(volume_path, payload)
+        payload = {
+            'volume': volume_path,
+            'fields': 'guid'
+        }
+        logicalunits = self.nef.logicalunits.list(payload)
+        payload = self._get_lu_specs(volume)
+        for logicalunit in logicalunits:
+            guid = logicalunit['guid']
+            self.nef.logicalunits.set(guid, payload)
 
-    @coordination.synchronized('{self.nef.lock}')
     def create_volume(self, volume):
         """Create a zfs volume on appliance.
 
@@ -361,89 +353,88 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         """
         volume_path = self._get_volume_path(volume)
         volume_size = volume['size'] * units.Gi
-        properties = self.nef.volumes.properties
-        payload = self._get_vendor_properties(properties, volume)
-        payload.update({
-            'path': volume_path,
-            'volumeSize': volume_size
-        })
+        payload = self._get_volume_specs(volume)
+        payload['path'] = volume_path
+        payload['volumeSize'] = volume_size
         self.nef.volumes.create(payload)
 
-    def _verify_cache_image(self, ctxt, volume, image_meta, image_service):
-        properties = self.nef.volumes.properties
-        volume_type_specs = self._get_vendor_properties(properties, volume)
-        volume_blocksize = volume_type_specs['volumeBlockSize']
-        image_id = image_meta['id']
-        image_checksum = image_meta['checksum']
-        namespace = uuid.UUID(image_id, version=4)
-        name = '%s:%s' % (image_checksum, volume_blocksize)
-        name = nexenta_utils.native_string(name)
-        cache_uuid = uuid.uuid5(namespace, name)
-        cache_id = six.text_type(cache_uuid)
-        cache = {
-            'id': cache_id,
-            'name': self.cache_image_template % cache_id,
-            'volume_type_id': volume['volume_type_id']
-        }
-        cache_path = self._get_volume_path(cache)
-        payload = {'fields': 'volumeSize,readOnly'}
-        cache_exist = False
-        try:
-            cache_specs = self.nef.volumes.get(cache_path, payload)
-            image_size = cache_specs['volumeSize']
-            if not cache_specs['readOnly']:
-                self.delete_volume(cache)
-            else:
-                cache_exist = True
-        except jsonrpc.NefException as error:
-            if error.code != 'ENOENT':
-                raise
-        if not cache_exist:
-            with image_utils.TemporaryImages.fetch(image_service, ctxt,
-                                                   image_id) as image_file:
-                image_info = image_utils.qemu_img_info(image_file,
-                                                       force_share=True,
-                                                       run_as_root=True)
-                image_size = image_info.virtual_size
-        cache_size = nexenta_utils.roundup(image_size, units.Gi)
-        cache['size'] = cache_size // units.Gi
-        if cache['size'] > volume['size']:
-            code = 'ENOSPC'
-            message = (_('Unable to clone cache %(cache)s '
-                         'to volume %(volume)s: cache size '
-                         '%(cache_size)sGB is larger than '
-                         'volume size %(volume_size)sGB')
-                       % {'cache': cache['name'],
-                          'volume': volume['name'],
-                          'cache_size': cache['size'],
-                          'volume_size': volume['size']})
-            raise jsonrpc.NefException(code=code, message=message)
-        if not cache_exist:
-            self.create_volume(cache)
-            self.copy_image_to_volume(ctxt, cache, image_service, image_id)
-            payload = {'readOnly': True}
-            self.nef.volumes.set(cache_path, payload)
-        return cache
+    @coordination.synchronized('{self.nef.lock}-{cache_name}')
+    def _delete_cache(self, cache_name, cache_path, snapshot_path):
+        """Delete a image cache.
 
-    def _verify_cache_snapshot(self, cache):
-        snapshot = {
-            'id': cache['id'],
-            'name': self.cache_snapshot_template % cache['id'],
-            'volume_id': cache['id'],
-            'volume_name': cache['name'],
-            'volume_size': cache['size']
-        }
+        :param cache_name: cache volume name
+        :param cache_path: cache volume path
+        :param snapshot_path: cache snapshot path
+        """
+        payload = {'fields': 'clones'}
+        try:
+            props = self.nef.snapshots.get(snapshot_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to get clones of image cache '
+                      '%(name)s: %(error)s',
+                      {'name': cache_name, 'error': error})
+            return
+        if props['clones']:
+            clones = props['clones']
+            count = len(clones)
+            LOG.debug('Image cache %(name)s is still in use, '
+                      '%(count)s clone(s) was found: %(clones)s',
+                      {'name': cache_name, 'count': count,
+                       'clones': clones})
+            return
+        payload = {'snapshots': True}
+        try:
+            self.nef.volumes.delete(cache_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to delete image cache %(name)s: %(error)s',
+                      {'name': cache_name, 'error': error})
+
+    def _verify_cache(self, cache, snapshot):
+        cache_path = self._get_volume_path(cache)
+        payload = {'fields': 'volumeSize'}
+        try:
+            props = self.nef.volumes.get(cache_path, payload)
+        except jsonrpc.NefException as error:
+            if error.code == 'ENOENT':
+                return cache, snapshot
+            raise
+        cache_size = props['volumeSize']
+        cache['size'] = utils.roundgb(cache_size)
         snapshot_path = self._get_snapshot_path(snapshot)
         payload = {'fields': 'path'}
         try:
             self.nef.snapshots.get(snapshot_path, payload)
         except jsonrpc.NefException as error:
-            if error.code != 'ENOENT':
-                raise
-            self.create_snapshot(snapshot)
+            if error.code == 'ENOENT':
+                return cache, snapshot
+            raise
+        snapshot['volume_size'] = cache['size']
+        return cache, snapshot
+
+    @coordination.synchronized('{self.nef.lock}-{cache[name]}')
+    def _create_cache(self, ctxt, cache, image_id, image_service):
+        snapshot = {
+            'id': cache['id'],
+            'name': self.cache_snapshot_template % cache['id'],
+            'volume_id': cache['id'],
+            'volume_name': cache['name']
+        }
+        cache, snapshot = self._verify_cache(cache, snapshot)
+        if snapshot.get('volume_size', 0) > 0:
+            return snapshot
+        if 'size' in cache:
+            self.delete_volume(cache)
+        with image_utils.TemporaryImages.fetch(
+                image_service, ctxt, image_id) as image_file:
+            image_info = image_utils.qemu_img_info(image_file)
+            image_size = image_info.virtual_size
+            cache['size'] = utils.roundgb(image_size)
+            self.create_volume(cache)
+            self.copy_image_to_volume(ctxt, cache, image_service, image_id)
+        snapshot['volume_size'] = cache['size']
+        self.create_snapshot(snapshot)
         return snapshot
 
-    @coordination.synchronized('{self.nef.lock}-{image_meta[id]}')
     def clone_image(self, ctxt, volume, image_location, image_meta,
                     image_service):
         """Create a volume efficiently from an existing image.
@@ -466,22 +457,98 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         """
         if not self.image_cache:
             return None, False
+        specs = self._get_volume_specs(volume)
+        compound = '%(checksum)s:%(format)s' % {
+            'checksum': image_meta['checksum'],
+            'format': specs['volumeBlockSize']
+        }
+        image_id = image_meta['id']
+        namespace = uuid.UUID(image_id, version=4)
+        name = utils.native_string(compound)
+        cache_uuid = uuid.uuid5(namespace, name)
+        cache_id = six.text_type(cache_uuid)
+        cache_name = self.cache_image_template % cache_id
+        cache_type_id = volume['volume_type_id']
+        cache = {
+            'id': cache_id,
+            'name': cache_name,
+            'volume_type_id': cache_type_id
+        }
         try:
-            cache = self._verify_cache_image(ctxt, volume,
-                                             image_meta,
-                                             image_service)
-            snapshot = self._verify_cache_snapshot(cache)
-            self.create_volume_from_snapshot(volume, snapshot)
-        except jsonrpc.NefException as error:
-            LOG.error('Failed to clone image %(image)s '
-                      'to volume %(volume)s: %(error)s',
-                      {'image': image_meta['id'],
-                       'volume': volume['name'],
+            snapshot = self._create_cache(ctxt, cache,
+                                          image_id,
+                                          image_service)
+        except Exception as error:
+            LOG.error('Failed to create cache %(cache)s '
+                      'for image %(image)s: %(error)s',
+                      {'cache': cache_name,
+                       'image': image_id,
                        'error': error})
+            return None, False
+        if snapshot['volume_size'] > volume['size']:
+            code = 'ENOSPC'
+            message = (_('Unable to clone cache %(cache)s for '
+                         'image %(image)s to volume %(volume)s: '
+                         'cache size %(cache_size)sGB is larger '
+                         'than volume size %(volume_size)sGB')
+                       % {'cache': cache_name, 'image': image_id,
+                          'volume': volume['name'],
+                          'cache_size': snapshot['volume_size'],
+                          'volume_size': volume['size']})
+            raise jsonrpc.NefException(code=code, message=message)
+        try:
+            self.create_volume_from_snapshot(volume, snapshot)
+        except Exception as error:
+            LOG.error('Failed to clone cache %(cache)s for image '
+                      '%(image)s to volume %(volume)s: %(error)s',
+                      {'cache': cache['name'], 'image': image_id,
+                       'volume': volume['name'], 'error': error})
             return None, False
         return None, True
 
-    @coordination.synchronized('{self.nef.lock}')
+    def _demote_volume(self, volume, volume_origin):
+        """Demote a volume.
+
+        :param volume: volume reference
+        :param volume_origin: volume origin path
+        """
+        volume_path = self._get_volume_path(volume)
+        payload = {'parent': volume_path, 'fields': 'path'}
+        try:
+            snapshots = self.nef.snapshots.list(payload)
+        except jsonrpc.NefException as error:
+            if error.code == 'ENOENT':
+                return volume_origin
+            raise
+        origin_txg = 0
+        origin_path = None
+        clone_path = None
+        for snapshot in snapshots:
+            snapshot_path = snapshot['path']
+            payload = {'fields': 'clones,creationTxg'}
+            try:
+                props = self.nef.snapshots.get(snapshot_path, payload)
+            except jsonrpc.NefException as error:
+                if error.code == 'ENOENT':
+                    continue
+                raise
+            snapshot_clones = props['clones']
+            # Workaround for NEX-22763
+            snapshot_txg = int(props['creationTxg'])
+            if snapshot_clones and snapshot_txg > origin_txg:
+                clone_path = snapshot_clones[0]
+                origin_txg = snapshot_txg
+                origin_path = snapshot_path
+        if clone_path:
+            try:
+                self.nef.volumes.promote(clone_path)
+            except jsonrpc.NefException as error:
+                if error.code in ['ENOENT', 'EBADARG']:
+                    return volume_origin
+                raise
+            return origin_path
+        return volume_origin
+
     def delete_volume(self, volume):
         """Deletes a volume.
 
@@ -490,56 +557,35 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         volume_path = self._get_volume_path(volume)
         payload = {'fields': 'originalSnapshot'}
         try:
-            volume_spec = self.nef.volumes.get(volume_path, payload)
+            props = self.nef.volumes.get(volume_path, payload)
         except jsonrpc.NefException as error:
             if error.code == 'ENOENT':
                 return
             raise
-        volume_origin = volume_spec['originalSnapshot']
+        volume_exist = True
+        origin = props['originalSnapshot']
         payload = {'snapshots': True}
-        try:
-            self.nef.volumes.delete(volume_path, payload)
-        except jsonrpc.NefException as error:
-            if error.code != 'EEXIST':
+        while volume_exist:
+            try:
+                self.nef.volumes.delete(volume_path, payload)
+            except jsonrpc.NefException as error:
+                if error.code == 'EEXIST':
+                    origin = self._demote_volume(volume, origin)
+                    continue
                 raise
-            snapshot_tree = {}
-            payload = {'parent': volume_path, 'fields': 'path'}
-            snapshots = self.nef.snapshots.list(payload)
-            for snapshot in snapshots:
-                snapshot_path = snapshot['path']
-                payload = {'fields': 'clones,creationTxg'}
-                snapshot_spec = self.nef.snapshots.get(snapshot_path, payload)
-                if snapshot_spec['clones']:
-                    snapshot_txg = snapshot_spec['creationTxg']
-                    snapshot_clones = snapshot_spec['clones']
-                    first_clone = snapshot_clones[0]
-                    snapshot_tree[snapshot_txg] = first_clone
-            if snapshot_tree:
-                latest_txg = max(snapshot_tree)
-                clone_path = snapshot_tree[latest_txg]
-                self.nef.volumes.promote(clone_path)
-            payload = {'snapshots': True}
-            self.nef.volumes.delete(volume_path, payload)
-        if not volume_origin:
+            volume_exist = False
+        if not origin:
             return
-        origin_path, snapshot_name = volume_origin.split('@')
+        origin_path, snapshot_name = origin.split('@')
         origin_name = posixpath.basename(origin_path)
-        if nexenta_utils.match_template(self.origin_snapshot_template,
-                                        snapshot_name):
-            payload = {'defer': True}
-            try:
-                self.nef.snapshots.delete(volume_origin, payload)
-            except Exception:
-                pass
-        elif (nexenta_utils.match_template(self.cache_snapshot_template,
-                                           snapshot_name) and
-              nexenta_utils.match_template(self.cache_image_template,
-                                           origin_name)):
-            payload = {'snapshots': True}
-            try:
-                self.nef.volumes.delete(origin_path, payload)
-            except Exception:
-                pass
+        templates = {
+            self.cache_snapshot_template: snapshot_name,
+            self.cache_image_template: origin_name
+        }
+        for item, name in templates.items():
+            if not utils.match_template(item, name):
+                return
+        self._delete_cache(origin_name, origin_path, origin)
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -549,11 +595,13 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         """
         volume_path = self._get_volume_path(volume)
         volume_size = new_size * units.Gi
+        payload = {'fields': 'referencedReservationSize,volumeSize'}
+        props = self.nef.volumes.get(volume_path, payload)
         payload = {'volumeSize': volume_size}
+        if props['referencedReservationSize'] == props['volumeSize']:
+            payload['referencedReservationSize'] = volume_size
         self.nef.volumes.set(volume_path, payload)
-        self._set_volume_reservation(volume)
 
-    @coordination.synchronized('{self.nef.lock}')
     def create_snapshot(self, snapshot):
         """Creates a snapshot.
 
@@ -563,7 +611,6 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         payload = {'path': snapshot_path}
         self.nef.snapshots.create(payload)
 
-    @coordination.synchronized('{self.nef.lock}')
     def delete_snapshot(self, snapshot):
         """Deletes a snapshot.
 
@@ -581,28 +628,30 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         return False
 
     def revert_to_snapshot(self, ctxt, volume, snapshot):
-        """Revert volume to snapshot."""
-        volume_path = self._get_volume_path(volume)
-        payload = {'snapshot': snapshot['name']}
-        self.nef.volumes.rollback(volume_path, payload)
+        """Revert a volume to a snapshot.
 
-    @coordination.synchronized('{self.nef.lock}')
+        Note: the revert process should not change the volume's
+        current size, that means if the driver shrank
+        the volume during the process, it should extend the
+        volume internally.
+        """
+        volume_path = self._get_volume_path(volume)
+        snapshot_name = snapshot['name']
+        payload = {'snapshot': snapshot_name}
+        self.nef.volumes.rollback(volume_path, payload)
+        self._update_volume_props(volume)
+
     def create_volume_from_snapshot(self, volume, snapshot):
         """Create new volume from other's snapshot on appliance.
 
         :param volume: reference of volume to be created
         :param snapshot: reference of source snapshot
         """
-        LOG.debug('Create volume %(volume)s from snapshot %(snapshot)s',
-                  {'volume': volume['name'], 'snapshot': snapshot['name']})
         volume_path = self._get_volume_path(volume)
         snapshot_path = self._get_snapshot_path(snapshot)
         payload = {'targetPath': volume_path}
-        if volume['size'] > snapshot['volume_size']:
-            volume_size = volume['size'] * units.Gi
-            payload['volumeSize'] = volume_size
         self.nef.snapshots.clone(snapshot_path, payload)
-        self._update_volume_properties(volume)
+        self._update_volume_props(volume)
 
     def create_cloned_volume(self, volume, src_vref):
         """Creates a clone of the specified volume.
@@ -619,22 +668,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         self.create_snapshot(snapshot)
         try:
             self.create_volume_from_snapshot(volume, snapshot)
-        except jsonrpc.NefException as error:
-            LOG.error('Failed to create clone %(clone)s '
-                      'from volume %(volume)s: %(error)s',
-                      {'clone': volume['name'],
-                       'volume': src_vref['name'],
-                       'error': error})
-            raise
         finally:
-            try:
-                self.delete_snapshot(snapshot)
-            except jsonrpc.NefException as error:
-                LOG.error('Failed to delete temporary snapshot '
-                          '%(volume)s@%(snapshot)s: %(error)s',
-                          {'volume': src_vref['name'],
-                           'snapshot': snapshot['name'],
-                           'error': error})
+            self.delete_snapshot(snapshot)
 
     def create_export(self, ctxt, volume, connector):
         """Driver entry point to get the export info for a new volume."""
@@ -656,7 +691,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :returns: dictionary of connection information
         """
         info = {'driver_volume_type': self.driver_volume_type, 'data': {}}
-        host_iqn = None
+        initiator = None
         host_groups = []
         volume_path = self._get_volume_path(volume)
         if isinstance(connector, dict) and 'initiator' in connector:
@@ -670,15 +705,15 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                           'host_ip': connector.get('ip', 'unknown'),
                           'volume': volume['name']})
                 return True
-            host_iqn = connector['initiator']
+            initiator = connector['initiator']
             host_groups.append(DEFAULT_HOST_GROUP)
-            host_group = self._get_host_group(host_iqn)
+            host_group = self._get_hostgroup(initiator)
             if host_group is not None:
                 host_groups.append(host_group)
             LOG.debug('Terminate connection for volume %(volume)s '
                       'and initiator %(initiator)s',
                       {'volume': volume['name'],
-                       'initiator': host_iqn})
+                       'initiator': initiator})
         else:
             LOG.debug('Terminate all connections for volume %(volume)s',
                       {'volume': volume['name']})
@@ -693,12 +728,12 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             mapping_id = mapping.get('id')
             mapping_tg = mapping.get('targetGroup')
             mapping_hg = mapping.get('hostGroup')
-            if host_iqn is None or mapping_hg in host_groups:
+            if initiator is None or mapping_hg in host_groups:
                 LOG.debug('Delete LUN mapping %(id)s for volume %(volume)s, '
                           'target group %(tg)s and host group %(hg)s',
                           {'id': mapping_id, 'volume': volume['name'],
                            'tg': mapping_tg, 'hg': mapping_hg})
-                self._delete_lun_mapping(mapping_id)
+                self.nef.mappings.delete(mapping_id)
             else:
                 LOG.debug('Skip LUN mapping %(id)s for volume %(volume)s, '
                           'target group %(tg)s and host group %(hg)s',
@@ -718,12 +753,11 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor appliance."""
         provisioned_capacity_gb = total_volumes = total_snapshots = 0
-        ctxt = context.get_admin_context()
-        volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        volumes = objects.VolumeList.get_all_by_host(self.ctxt, self.host)
         for volume in volumes:
             provisioned_capacity_gb += volume['size']
             total_volumes += 1
-        snapshots = objects.SnapshotList.get_by_host(ctxt, self.host)
+        snapshots = objects.SnapshotList.get_by_host(self.ctxt, self.host)
         for snapshot in snapshots:
             provisioned_capacity_gb += snapshot['volume_size']
             total_snapshots += 1
@@ -832,126 +866,95 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         volume_name = snapshot['volume_name']
         snapshot_name = snapshot['name']
         volume_path = posixpath.join(self.san_path, volume_name)
-        snapshot_path = '%s@%s' % (volume_path, snapshot_name)
+        snapshot_path = '%(volume_path)s@%(snapshot_name)s' % {
+            'volume_path': volume_path,
+            'snapshot_name': snapshot_name
+        }
         return snapshot_path
 
-    def _get_target_group_name(self, target_name):
-        """Return Nexenta iSCSI target group name for volume."""
-        return target_name.replace(
-            self.configuration.nexenta_target_prefix,
-            self.configuration.nexenta_target_group_prefix
-        )
-
-    def _get_target_name(self, target_group_name):
-        """Return Nexenta iSCSI target name for volume."""
-        return target_group_name.replace(
-            self.configuration.nexenta_target_group_prefix,
-            self.configuration.nexenta_target_prefix
-        )
-
-    def _get_host_addresses(self):
+    def _get_addrs(self):
         """Returns NexentaStor IP addresses list."""
-        addresses = []
-        netaddrs = self.nef.netaddrs.list()
-        for netaddr in netaddrs:
-            cidr = six.text_type(netaddr['address'])
-            ip = cidr.split('/')[0]
-            instance = ipaddress.ip_address(ip)
-            if not instance.is_loopback:
-                addresses.append(instance.exploded)
-        LOG.debug('Configured IP addresses: %(addresses)s',
-                  {'addresses': addresses})
-        return addresses
-
-    def _get_host_portals(self):
-        """Return configured iSCSI portals list."""
-        host_portals = []
-        host_addresses = self._get_host_addresses()
-        if self.san_host:
-            if self.san_host in host_addresses:
-                if self.san_port:
-                    san_port = self.san_port
-                else:
-                    san_port = DEFAULT_ISCSI_PORT
-                host_portal = '%s:%s' % (self.san_host, san_port)
-                host_portals.append(host_portal)
-            else:
-                LOG.debug('Skip not a local IP address %(san_host)s',
-                          {'san_host': self.san_host})
-        else:
-            LOG.debug('Configuration parameter nexenta_host is not defined')
-        for portal in self.portals:
-            if not portal:
+        addrs = []
+        payload = {'fields': 'address,state'}
+        items = self.nef.netaddrs.list(payload)
+        for item in items:
+            if item['state'] != 'ok':
                 continue
-            host_port = portal.split(':')
-            portal_host = host_port[0]
-            if portal_host in host_addresses:
-                if len(host_port) == 2:
-                    portal_port = int(host_port[1])
-                else:
-                    portal_port = DEFAULT_ISCSI_PORT
-                host_portal = '%s:%s' % (portal_host, portal_port)
-                if host_portal not in host_portals:
-                    host_portals.append(host_portal)
-            else:
-                LOG.debug('Skip not a local portal IP address %(portal)s',
-                          {'portal': portal_host})
-        LOG.debug('Configured iSCSI portals: %(portals)s',
-                  {'portals': host_portals})
-        return host_portals
+            ip_mask = six.text_type(item['address'])
+            ip = ip_mask.split('/')[0]
+            addr = ipaddress.ip_address(ip)
+            if not addr.is_loopback:
+                addrs.append(addr.exploded)
+        LOG.debug('Configured IP addresses: %(addrs)s',
+                  {'addrs': addrs})
+        return addrs
 
-    def _target_group_props(self, group_name, host_portals):
-        """Check and update an existing targets/portals for given target group.
+    def _get_portals(self, addrs):
+        """Return configured iSCSI portals list."""
+        portals = []
+        items = self.san_portals
+        for item in items:
+            if item['address'] in addrs:
+                portals.append(item)
+        return portals
 
-        :param group_name: target group name
-        :param host_portals: configured host portals list
-        :returns: dictionary of portals per target
-        """
-        if not group_name.startswith(self.target_group_prefix):
-            LOG.debug('Skip not a cinder target group %(group)s',
-                      {'group': group_name})
-            return {}
-        group_props = {}
-        payload = {'name': group_name}
-        data = self.nef.targetgroups.list(payload)
-        if not data:
-            LOG.debug('Skip target group %(group)s: group not found',
-                      {'group': group_name})
-            return {}
-        target_names = data[0]['members']
-        if not target_names:
-            target_name = self._get_target_name(group_name)
-            self._create_target(target_name, host_portals)
-            self._update_target_group(group_name, [target_name])
-            group_props[target_name] = host_portals
-            return group_props
-        for target_name in target_names:
-            group_props[target_name] = []
-            payload = {'name': target_name}
-            data = self.nef.targets.list(payload)
-            if not data:
-                LOG.debug('Skip target group %(group)s: '
-                          'group member %(target)s not found',
-                          {'group': group_name, 'target': target_name})
-                return {}
-            target_portals = data[0]['portals']
-            if not target_portals:
-                LOG.debug('Skip target group %(group)s: '
-                          'group member %(target)s has no portals',
-                          {'group': group_name, 'target': target_name})
-                return {}
-            for item in target_portals:
-                target_portal = '%s:%s' % (item['address'], item['port'])
-                if target_portal not in host_portals:
-                    LOG.debug('Skip target group %(group)s: '
-                              'group member %(target)s bind to a '
-                              'non local portal address %(portal)s',
-                              {'group': group_name,
-                               'target': target_name,
-                               'portal': target_portal})
-                    return {}
-                group_props[target_name].append(target_portal)
-        return group_props
+    def _get_targets(self, hosts):
+        """Return configured iSCSI targets dictionary."""
+        targets = {}
+        payload = {'fields': 'name,state,portals'}
+        items = self.nef.targets.list(payload)
+        for item in items:
+            name = item['name']
+            state = item['state']
+            portals = item['portals']
+            if state != 'online':
+                LOG.debug('Skip iSCSI target %(name)s: %(state)s',
+                          {'name': name, 'state': state})
+                continue
+            if not name.startswith(self.target_prefix):
+                LOG.debug('Skip iSCSI target %(name)s: target name '
+                          'do not match configured prefix %(prefix)s',
+                          {'name': name, 'prefix': self.target_prefix})
+                continue
+            if not portals:
+                LOG.debug('Skip iSCSI target %(name)s: no target portals',
+                          {'name': name})
+                continue
+            if not all(portal in hosts for portal in portals):
+                LOG.debug('Skip iSCSI target %(name)s: target portals '
+                          '%(portals)s do not match host portals %(hosts)s',
+                          {'name': name, 'portals': portals, 'hosts': hosts})
+                continue
+            targets[name] = utils.prt2tpg(portals)
+        return targets
+
+    def _get_targetgroups(self, targets):
+        """Return configured target groups dictionary."""
+        dist = {}
+        payload = {'fields': 'name,members'}
+        items = self.nef.targetgroups.list(payload)
+        for item in items:
+            name = item['name']
+            members = item['members']
+            if not name.startswith(self.targetgroup_prefix):
+                LOG.debug('Skip targetgroup %(name)s: group name '
+                          'do not match configured prefix %(prefix)s',
+                          {'name': name, 'prefix': self.targetgroup_prefix})
+                continue
+            if not members:
+                LOG.debug('Skip targetgroup %(name)s: no members found',
+                          {'name': name})
+                continue
+            if not all(member in targets for member in members):
+                LOG.debug('Skip targetgroup %(name)s: group members '
+                          '%(members)s do not match host targets %(targets)s',
+                          {'name': name, 'members': members,
+                           'targets': targets})
+                continue
+            member = members[0]
+            portals = targets[member]
+            dist[name] = {'iqn': member, 'portals': portals}
+        return dist
 
     def initialize_connection(self, volume, connector):
         """Do all steps to get zfs volume exported at separate target.
@@ -960,127 +963,66 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         :param connector: connector reference
         :returns: dictionary of connection information
         """
+        initiator = connector.get('initiator', None)
+        multipath = connector.get('multipath', False)
+        LOG.debug('Initialize connection for volume %(volume)s and '
+                  'initiator %(initiator)s, multipath: %(multipath)s',
+                  {'volume': volume['name'], 'initiator': initiator,
+                   'multipath': multipath})
+        hostgroup = DEFAULT_HOST_GROUP
+        if initiator:
+            hostgroup = self._get_hostgroup(initiator)
+            if not hostgroup:
+                hostgroup = self._create_hostgroup(initiator)
+        addrs = self._get_addrs()
+        portals = self._get_portals(addrs)
+        targets = self._get_targets(portals)
+        dist = self._get_targetgroups(targets)
+        stat = {}
         volume_path = self._get_volume_path(volume)
-        host_iqn = connector.get('initiator')
-        LOG.debug('Initialize connection for volume: %(volume)s '
-                  'and initiator: %(initiator)s',
-                  {'volume': volume_path, 'initiator': host_iqn})
-
-        host_groups = [DEFAULT_HOST_GROUP]
-        host_group = self._get_host_group(host_iqn)
-        if host_group:
-            host_groups.append(host_group)
-
-        host_portals = self._get_host_portals()
-        props_portals = []
-        props_iqns = []
-        props_luns = []
-        payload = {'volume': volume_path}
+        payload = {
+            'fields': 'id,lun,hostGroup,targetGroup,volume'
+        }
         mappings = self.nef.mappings.list(payload)
         for mapping in mappings:
-            mapping_id = mapping['id']
-            mapping_lu = mapping['lun']
-            mapping_hg = mapping['hostGroup']
-            mapping_tg = mapping['targetGroup']
-            if mapping_tg == DEFAULT_TARGET_GROUP:
-                LOG.debug('Delete LUN mapping %(id)s for target group %(tg)s',
-                          {'id': mapping_id, 'tg': mapping_tg})
-                self._delete_lun_mapping(mapping_id)
+            uid = mapping['id']
+            lun = mapping['lun']
+            targetgroup = mapping['targetGroup']
+            if targetgroup == DEFAULT_TARGET_GROUP:
+                self.nef.mappings.delete(uid)
                 continue
-            if mapping_hg not in host_groups:
-                LOG.debug('Skip LUN mapping %(id)s for host group %(hg)s',
-                          {'id': mapping_id, 'hg': mapping_hg})
+            if targetgroup not in dist:
                 continue
-            group_props = self._target_group_props(mapping_tg, host_portals)
-            if not group_props:
-                LOG.debug('Skip LUN mapping %(id)s for target group %(tg)s',
-                          {'id': mapping_id, 'tg': mapping_tg})
+            if targetgroup not in stat:
+                stat[targetgroup] = 0
+            stat[targetgroup] += 1
+            if mapping['hostGroup'] != hostgroup:
                 continue
-            for target_iqn in group_props:
-                target_portals = group_props[target_iqn]
-                props_portals += target_portals
-                props_iqns += [target_iqn] * len(target_portals)
-                props_luns += [mapping_lu] * len(target_portals)
-
-        props = {}
-        props['discard'] = True
-        props['target_discovered'] = False
-        props['encrypted'] = False
-        props['qos_specs'] = None
-        props['volume_id'] = volume['id']
-        props['access_mode'] = 'rw'
-        multipath = connector.get('multipath', False)
-
-        if props_luns:
-            if multipath:
-                props['target_portals'] = props_portals
-                props['target_iqns'] = props_iqns
-                props['target_luns'] = props_luns
-            else:
-                index = random.randrange(len(props_luns))
-                props['target_portal'] = props_portals[index]
-                props['target_iqn'] = props_iqns[index]
-                props['target_lun'] = props_luns[index]
-            LOG.debug('Use existing LUN mapping(s) %(props)s',
-                      {'props': props})
-            return {'driver_volume_type': self.driver_volume_type,
-                    'data': props}
-
-        if host_group is None:
-            host_group = '%s-%s' % (self.host_group_prefix, uuid.uuid4().hex)
-            self._create_host_group(host_group, [host_iqn])
-
-        mappings_spread = {}
-        targets_spread = {}
-        data = self.nef.targetgroups.list()
-        for item in data:
-            target_group = item['name']
-            group_props = self._target_group_props(target_group, host_portals)
-            members = len(group_props)
-            if members == 0:
-                LOG.debug('Skip unsuitable target group %(tg)s',
-                          {'tg': target_group})
+            if mapping['volume'] != volume_path:
                 continue
-            payload = {'targetGroup': target_group}
-            data = self.nef.mappings.list(payload)
-            mappings = len(data)
-            if not mappings < self.luns_per_target:
-                LOG.debug('Skip target group %(tg)s: '
-                          'group members limit reached: %(limit)s',
-                          {'tg': target_group, 'limit': mappings})
-                continue
-            targets_spread[target_group] = group_props
-            mappings_spread[target_group] = mappings
-            LOG.debug('Found target group %(tg)s with %(members)s '
-                      'members and %(mappings)s LUNs',
-                      {'tg': target_group, 'members': members,
-                       'mappings': mappings})
-
-        if not mappings_spread:
-            target = '%s-%s' % (self.target_prefix, uuid.uuid4().hex)
-            target_group = self._get_target_group_name(target)
-            self._create_target(target, host_portals)
-            self._create_target_group(target_group, [target])
-            props_portals += host_portals
-            props_iqns += [target] * len(host_portals)
-        else:
-            target_group = min(mappings_spread, key=mappings_spread.get)
-            targets = targets_spread[target_group]
-            members = targets.keys()
-            mappings = mappings_spread[target_group]
-            LOG.debug('Using existing target group %(tg)s '
-                      'with members %(members)s and %(mappings)s LUNs',
-                      {'tg': target_group, 'members': members,
-                       'mappings': mappings})
-            for target in targets:
-                portals = targets[target]
-                props_portals += portals
-                props_iqns += [target] * len(portals)
-
+            target = dist[targetgroup]
+            return self._get_connection_info(volume, multipath, target, lun)
+        targetgroup = None
+        if stat:
+            key = min(stat, key=stat.get)
+            if stat[key] < self.luns_per_target:
+                targetgroup = key
+                target = dist[targetgroup]
+        if not targetgroup and dist:
+            targetgroup = random.choice(list(dist))
+            target = dist[targetgroup]
+        if not targetgroup:
+            suffix = uuid.uuid4().hex
+            iqn = self._create_target(suffix, portals)
+            targetgroup = self._create_targetgroup(suffix, iqn)
+            target = {
+                'iqn': iqn,
+                'portals': utils.prt2tpg(portals)
+            }
         payload = {
             'volume': volume_path,
-            'targetGroup': target_group,
-            'hostGroup': host_group
+            'targetGroup': targetgroup,
+            'hostGroup': hostgroup
         }
         uid = self.nef.mappings.create(payload)
         payload = {'fields': 'lun'}
@@ -1093,117 +1035,105 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 self.nef.delay(attempt)
             else:
                 lun = mapping['lun']
-        props_luns = [lun] * len(props_iqns)
-
-        if multipath:
-            props['target_portals'] = props_portals
-            props['target_iqns'] = props_iqns
-            props['target_luns'] = props_luns
-        else:
-            index = random.randrange(len(props_luns))
-            props['target_portal'] = props_portals[index]
-            props['target_iqn'] = props_iqns[index]
-            props['target_lun'] = props_luns[index]
-
-        payload = {
-            'volume': volume_path,
-            'fields': 'guid'
-        }
+                break
+        payload = {'volume': volume_path, 'fields': 'guid'}
         logicalunits = self.nef.logicalunits.list(payload)
-        guid = logicalunits[0]['guid']
-        properties = self.nef.logicalunits.properties
-        payload = self._get_vendor_properties(properties, volume)
+        if not logicalunits:
+            code = 'ENODATA'
+            message = (_('Unable to find logical unit for volume %(volume)s')
+                       % {'volume': volume['name']})
+            raise jsonrpc.NefException(code=code, message=message)
+        logicalunit = logicalunits[0]
+        guid = logicalunit['guid']
+        payload = self._get_lu_specs(volume)
         self.nef.logicalunits.set(guid, payload)
+        return self._get_connection_info(volume, multipath, target, lun)
 
-        LOG.debug('Created new LUN mapping: %(props)s',
-                  {'props': props})
-        return {'driver_volume_type': self.driver_volume_type,
-                'data': props}
+    def _get_connection_info(self, volume, multipath, target, lun):
+        data = {
+            'encrypted': False,
+            'discard': True,
+            'target_discovered': False,
+            'volume_id': volume['id']
+        }
+        portals = target['portals']
+        iqn = target['iqn']
+        count = len(portals)
+        index = random.randrange(count)
+        data.update({
+            'target_lun': lun,
+            'target_iqn': iqn,
+            'target_portal': portals[index]
+        })
+        if multipath:
+            data.update({
+                'target_luns': [lun] * count,
+                'target_iqns': [iqn] * count,
+                'target_portals': portals
+            })
+        return {
+            'driver_volume_type': self.driver_volume_type,
+            'data': data
+        }
 
-    def _create_target_group(self, name, members):
-        """Create a new target group with members.
-
-        :param name: group name
-        :param members: group members list
-        """
-        payload = {'name': name, 'members': members}
-        self.nef.targetgroups.create(payload)
-
-    def _update_target_group(self, name, members):
-        """Update a existing target group with new members.
-
-        :param name: group name
-        :param members: group members list
-        """
-        payload = {'members': members}
-        self.nef.targetgroups.set(name, payload)
-
-    def _delete_lun_mapping(self, name):
-        """Delete an existing LUN mapping.
-
-        :param name: LUN mapping ID
-        """
-        self.nef.mappings.delete(name)
-
-    def _create_target(self, name, portals):
+    def _create_target(self, suffix, portals):
         """Create a new target with portals.
 
-        :param name: target name
+        :param suffix: target name suffix
         :param portals: target portals list
         """
-        payload = {'name': name,
-                   'portals': self._s2d(portals)}
-        self.nef.targets.create(payload)
+        name = '%(prefix)s-%(suffix)s' % {
+            'prefix': self.target_prefix,
+            'suffix': suffix
+        }
+        payload = {'name': name, 'portals': portals}
+        return self.nef.targets.create(payload)
 
-    def _get_host_group(self, member):
-        """Find existing host group by group member.
+    def _create_targetgroup(self, suffix, target):
+        """Create a new target group with target.
 
-        :param member: host group member
-        :returns: host group name
+        :param suffix: group name siffix
+        :param target: group member
         """
-        host_groups = self.nef.hostgroups.list()
-        for host_group in host_groups:
-            members = host_group['members']
+        name = '%(prefix)s-%(suffix)s' % {
+            'prefix': self.targetgroup_prefix,
+            'suffix': suffix
+        }
+        members = [target]
+        payload = {'name': name, 'members': members}
+        return self.nef.targetgroups.create(payload)
+
+    def _get_hostgroup(self, member):
+        """Find existing hostgroup by group member.
+
+        :param member: hostgroup member
+        :returns: hostgroup name
+        """
+        payload = {'fields': 'members,name'}
+        hostgroups = self.nef.hostgroups.list(payload)
+        for hostgroup in hostgroups:
+            members = hostgroup['members']
             if member in members:
-                name = host_group['name']
-                LOG.debug('Found host group %(name)s for member %(member)s',
+                name = hostgroup['name']
+                LOG.debug('Found hostgroup %(name)s by member %(member)s',
                           {'name': name, 'member': member})
                 return name
         return None
 
-    def _create_host_group(self, name, members):
+    def _create_hostgroup(self, member):
         """Create a new host group.
 
-        :param name: host group name
-        :param members: host group members list
+        :param member: hostgroup member
+        :returns: hostgroup name
         """
+        name = '%(prefix)s-%(suffix)s' % {
+            'prefix': self.host_group_prefix,
+            'suffix': uuid.uuid4().hex
+        }
+        members = [member]
         payload = {'name': name, 'members': members}
         self.nef.hostgroups.create(payload)
-
-    @staticmethod
-    def _s2d(css):
-        """Parse list of colon-separated address and port to dictionary.
-
-        :param css: list of colon-separated address and port
-        :returns: dictionary
-        """
-        result = []
-        for key_val in css:
-            key, val = key_val.split(':')
-            result.append({'address': key, 'port': int(val)})
-        return result
-
-    @staticmethod
-    def _d2s(kvp):
-        """Parse dictionary to list of colon-separated address and port.
-
-        :param kvp: dictionary
-        :returns: list of colon-separated address and port
-        """
-        result = []
-        for key_val in kvp:
-            result.append('%s:%s' % (key_val['address'], key_val['port']))
-        return result
+        return name
 
     def create_consistencygroup(self, ctxt, group):
         """Creates a consistency group.
@@ -1396,12 +1326,13 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         }
         if not any(key in types for key in existing_ref):
             keys = ', '.join(types.keys())
+            code = 'EINVAL'
             message = (_('Manage existing volume failed '
                          'due to invalid backend reference. '
                          'Volume reference must contain '
                          'at least one valid key: %(keys)s')
                        % {'keys': keys})
-            raise jsonrpc.NefException(code='EINVAL', message=message)
+            raise jsonrpc.NefException(code=code, message=message)
         payload = {
             'parent': self.san_path,
             'fields': 'name,path,volumeSize'
@@ -1413,7 +1344,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         if len(existing_volumes) == 1:
             volume_path = existing_volumes[0]['path']
             volume_name = existing_volumes[0]['name']
-            volume_size = existing_volumes[0]['volumeSize'] // units.Gi
+            refsize = existing_volumes[0]['volumeSize']
+            volume_size = utils.roundgb(refsize)
             existing_volume = {
                 'name': volume_name,
                 'path': volume_path,
@@ -1421,9 +1353,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             }
             vid = volume_utils.extract_id_from_volume_name(volume_name)
             if volume_utils.check_already_managed_volume(vid):
+                code = 'EEXIST'
                 message = (_('Volume %(name)s already managed')
                            % {'name': volume_name})
-                raise jsonrpc.NefException(code='EBUSY', message=message)
+                raise jsonrpc.NefException(code=code, message=message)
             return existing_volume
         elif not existing_volumes:
             code = 'ENOENT'
@@ -1449,8 +1382,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             uuid.UUID(snapshot_id, version=4)
         except ValueError:
             return False
-        ctxt = context.get_admin_context()
-        return objects.Snapshot.exists(ctxt, snapshot_id)
+        return objects.Snapshot.exists(self.ctxt, snapshot_id)
 
     def _get_existing_snapshot(self, snapshot, existing_ref):
         types = {
@@ -1459,12 +1391,13 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         }
         if not any(key in types for key in existing_ref):
             keys = ', '.join(types.keys())
+            code = 'EINVAL'
             message = (_('Manage existing snapshot failed '
                          'due to invalid backend reference. '
                          'Snapshot reference must contain '
                          'at least one valid key: %(keys)s')
                        % {'keys': keys})
-            raise jsonrpc.NefException(code='EINVAL', message=message)
+            raise jsonrpc.NefException(code=code, message=message)
         volume_name = snapshot['volume_name']
         volume_size = snapshot['volume_size']
         volume = {'name': volume_name}
@@ -1489,9 +1422,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             }
             sid = volume_utils.extract_id_from_snapshot_name(name)
             if self._check_already_managed_snapshot(sid):
+                code = 'EEXIST'
                 message = (_('Snapshot %(name)s already managed')
                            % {'name': name})
-                raise jsonrpc.NefException(code='EBUSY', message=message)
+                raise jsonrpc.NefException(code=code, message=message)
             return existing_snapshot
         elif not existing_snapshots:
             code = 'ENOENT'
@@ -1504,7 +1438,6 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                    % {'reference': existing_ref, 'reason': reason})
         raise jsonrpc.NefException(code=code, message=message)
 
-    @coordination.synchronized('{self.nef.lock}')
     def manage_existing(self, volume, existing_ref):
         """Brings an existing backend storage object under Cinder management.
 
@@ -1542,16 +1475,17 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         payload = {'volume': existing_volume_path}
         mappings = self.nef.mappings.list(payload)
         if mappings:
-            message = (_('Failed to manage existing volume %(path)s '
+            code = 'EEXIST'
+            message = (_('Unable to manage existing volume %(name)s '
                          'due to existing LUN mappings: %(mappings)s')
-                       % {'path': existing_volume_path,
+                       % {'name': existing_volume['name'],
                           'mappings': mappings})
-            raise jsonrpc.NefException(code='EEXIST', message=message)
+            raise jsonrpc.NefException(code=code, message=message)
         if existing_volume['name'] != volume['name']:
             volume_path = self._get_volume_path(volume)
             payload = {'newPath': volume_path}
             self.nef.volumes.rename(existing_volume_path, payload)
-        self._update_volume_properties(volume)
+        self._update_volume_props(volume)
 
     def manage_existing_get_size(self, volume, existing_ref):
         """Return size of volume to be managed by manage_existing.
@@ -1613,11 +1547,10 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
             extra_info = None
             path = volume['path']
             guid = volume['guid']
-            size = volume['volumeSize'] // units.Gi
+            refsize = volume['volumeSize']
+            size = utils.roundgb(refsize)
             name = volume['name']
-            if nexenta_utils.match_template(self.cache_image_template, name):
-                LOG.debug('Skip image cache %(path)s',
-                          {'path': path})
+            if utils.match_template(self.cache_image_template, name):
                 continue
             if name in cinder_volume_names:
                 cinder_id = cinder_volume_names[name]
@@ -1655,9 +1588,9 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 'cinder_id': cinder_id,
                 'extra_info': extra_info
             })
-        return volume_utils.paginate_entries_list(manageable_volumes,
-                                                  marker, limit, offset,
-                                                  sort_keys, sort_dirs)
+        return volume_utils.paginate_entries_list(
+            manageable_volumes, marker, limit,
+            offset, sort_keys, sort_dirs)
 
     def unmanage(self, volume):
         """Removes the specified volume from Cinder management.
@@ -1673,7 +1606,6 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         """
         pass
 
-    @coordination.synchronized('{self.nef.lock}')
     def manage_existing_snapshot(self, snapshot, existing_ref):
         """Brings an existing backend storage object under Cinder management.
 
@@ -1752,11 +1684,20 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                           sort_keys (valid directions are 'asc' and 'desc')
 
         """
+        temporary_snapshots = {
+            self.cache_snapshot_template: 'image cache',
+            self.origin_snapshot_template: 'temporary origin',
+            self.group_snapshot_template: 'temporary group'
+        }
+        service_snapshots = {
+            'hprService': 'replication',
+            'snaplistId': 'snapping'
+        }
         manageable_snapshots = []
         cinder_volume_names = {}
         cinder_snapshot_names = {}
-        ctxt = context.get_admin_context()
-        cinder_volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        cinder_volumes = objects.VolumeList.get_all_by_host(
+            self.ctxt, self.host)
         for cinder_volume in cinder_volumes:
             key = self._get_volume_path(cinder_volume)
             value = {
@@ -1792,25 +1733,16 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                           'volume %(parent)s is unmanaged',
                           {'path': path, 'parent': parent})
                 continue
-            if nexenta_utils.match_template(self.cache_snapshot_template,
-                                            name):
-                LOG.debug('Skip image cache snapshot %(path)s',
-                          {'path': path})
-                continue
-            if nexenta_utils.match_template(self.origin_snapshot_template,
-                                            name):
-                LOG.debug('Skip temporary origin snapshot %(path)s',
-                          {'path': path})
-                continue
-            if nexenta_utils.match_template(self.group_snapshot_template,
-                                            name):
-                LOG.debug('Skip temporary group snapshot %(path)s',
-                          {'path': path})
-                continue
-            if snapshot['hprService'] or snapshot['snaplistId']:
-                LOG.debug('Skip Replication/Snapping snapshot %(path)s',
-                          {'path': path})
-                continue
+            for item, desc in temporary_snapshots.items():
+                if utils.match_template(item, name):
+                    LOG.debug('Skip %(desc)s snapshot %(path)s',
+                              {'desc': desc, 'path': path})
+                    continue
+            for item, desc in service_snapshots.items():
+                if snapshot[item]:
+                    LOG.debug('Skip %(desc)s snapshot %(path)s',
+                              {'desc': desc, 'path': path})
+                    continue
             if name in cinder_snapshot_names:
                 size = cinder_snapshot_names[name]['size']
                 cinder_id = cinder_snapshot_names[name]['id']
@@ -1847,9 +1779,9 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 'extra_info': extra_info,
                 'source_reference': source_reference
             })
-        return volume_utils.paginate_entries_list(manageable_snapshots,
-                                                  marker, limit, offset,
-                                                  sort_keys, sort_dirs)
+        return volume_utils.paginate_entries_list(
+            manageable_snapshots, marker, limit,
+            offset, sort_keys, sort_dirs)
 
     def unmanage_snapshot(self, snapshot):
         """Removes the specified snapshot from Cinder management.
@@ -1871,7 +1803,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
 
     def _migrate_volume(self, volume, scheme, hosts, port, path):
         """Storage assisted volume migration."""
-        src_hosts = self._get_host_addresses()
+        src_hosts = self._get_addrs()
         src_path = self._get_volume_path(volume)
         dst_path = posixpath.join(path, volume['name'])
         for dst_host in hosts:
@@ -2195,67 +2127,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                   'and volume type %(type)s with diff %(diff)s',
                   {'volume': volume['name'], 'host': host,
                    'type': new_type['name'], 'diff': diff})
-        volume_path = self._get_volume_path(volume)
-        vendor_specs = self.nef.volumes.properties
-        names = [_['api'] for _ in vendor_specs if 'api' in _]
-        names.append('source')
-        fields = ','.join(names)
-        payload = {'fields': fields, 'source': True}
-        volume_specs = self.nef.volumes.get(volume_path, payload)
-        volume_type_specs = self._get_vendor_properties(vendor_specs,
-                                                        volume,
-                                                        new_type)
-        sparse_volume = volume_type_specs['sparseVolume']
-        payload = {}
-        for vendor_spec in vendor_specs:
-            api = vendor_spec['api']
-            if api in volume_type_specs:
-                value = volume_type_specs[api]
-                if api in volume_specs:
-                    if volume_specs[api] == value:
-                        continue
-                if 'retype' in vendor_spec:
-                    code = 'EINVAL'
-                    message = (_('Failed to retype volume %(volume)s '
-                                 'to host %(host)s and volume type '
-                                 '%(type)s. %(reason)s')
-                               % {'volume': volume['name'],
-                                  'host': host,
-                                  'type': new_type['name'],
-                                  'reason': vendor_spec['retype']})
-                    raise jsonrpc.NefException(code=code, message=message)
-                payload[api] = value
-            elif (api in volume_specs and 'source' in volume_specs and
-                  api in volume_specs['source'] and
-                  volume_specs['source'][api] in ['local', 'received']):
-                if volume_specs[api] == vendor_spec['default']:
-                    continue
-                if 'inherit' in vendor_spec:
-                    LOG.debug('Unable to inherit property %(name)s '
-                              'from volume type %(type)s for volume '
-                              '%(volume)s. %(reason)s',
-                              {'name': api,
-                               'type': new_type['name'],
-                               'volume': volume['name'],
-                               'reason': vendor_spec['inherit']})
-                    continue
-                payload[api] = None
-        if 'sparseVolume' in payload:
-            sparse_volume = payload.pop('sparseVolume')
-        try:
-            self.nef.volumes.set(volume_path, payload)
-        except jsonrpc.NefException as error:
-            LOG.error('Failed to retype volume %(volume)s to '
-                      'host %(host)s and volume type %(type)s '
-                      'with payload %(payload)s: %(error)s',
-                      {'volume': volume['name'],
-                       'host': host,
-                       'type': new_type['name'],
-                       'payload': payload,
-                       'error': error})
-            raise
-        reservation = 0 if sparse_volume else None
-        self._set_volume_reservation(volume, reservation)
+        self._update_volume_props(volume, new_type)
         return True, None
 
     def _init_vendor_properties(self):
@@ -2287,67 +2159,92 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
         : return dictionary of vendor unique properties
         : return vendor name
         """
-        properties = {}
-        vendor_properties = []
+        vendor_properties = {}
         namespace = self.nef.volumes.namespace
+        items = self.nef.volumes.properties + self.nef.logicalunits.properties
         keys = ['enum', 'default', 'minimum', 'maximum']
-        vendor_properties += self.nef.volumes.properties
-        vendor_properties += self.nef.logicalunits.properties
-        for vendor_spec in vendor_properties:
-            property_spec = {}
+        for item in items:
+            spec = {}
             for key in keys:
-                if key in vendor_spec:
-                    value = vendor_spec[key]
-                    property_spec[key] = value
-            api = vendor_spec['api']
-            if 'cfg' in vendor_spec:
-                key = vendor_spec['cfg']
+                if key in item:
+                    spec[key] = item[key]
+            if 'cfg' in item:
+                key = item['cfg']
                 value = self.configuration.safe_get(key)
                 if value not in [None, '']:
-                    property_spec['default'] = value
-            elif api in self.san_stat:
-                value = self.san_stat[api]
-                property_spec['default'] = value
-            property_name = vendor_spec['name']
-            property_title = vendor_spec['title']
-            property_description = vendor_spec['description']
-            property_type = vendor_spec['type']
-            LOG.debug('Set %(product_name)s %(storage_protocol)s backend '
-                      '%(property_type)s property %(property_name)s: '
-                      '%(property_spec)s',
-                      {'product_name': self.product_name,
-                       'storage_protocol': self.storage_protocol,
-                       'property_type': property_type,
-                       'property_name': property_name,
-                       'property_spec': property_spec})
+                    spec['default'] = value
+            elif 'api' in item:
+                api = item['api']
+                if api in self.san_stat:
+                    value = self.san_stat[api]
+                    spec['default'] = value
+            LOG.debug('Initialize vendor capabilities for '
+                      '%(product)s %(protocol)s backend: '
+                      '%(type)s %(name)s property %(spec)s',
+                      {'product': self.product_name,
+                       'protocol': self.storage_protocol,
+                       'type': item['type'],
+                       'name': item['name'],
+                       'spec': spec})
             self._set_property(
-                properties,
-                property_name,
-                property_title,
-                property_description,
-                property_type,
-                **property_spec
+                vendor_properties,
+                item['name'],
+                item['title'],
+                item['description'],
+                item['type'],
+                **spec
             )
-        return properties, namespace
+        return vendor_properties, namespace
 
-    def _get_vendor_properties(self, vendor_specs, volume, volume_type=None):
-        properties = {}
-        extra_specs = {}
-        if volume_type:
-            volume_type_id = volume_type['id']
+    def _get_volume_type_specs(self, volume, volume_type=None):
+        if volume_type and 'id' in volume_type:
+            type_id = volume_type['id']
+        elif 'volume_type_id' in volume:
+            type_id = volume['volume_type_id']
         else:
-            volume_type_id = volume['volume_type_id']
-        if volume_type_id:
-            extra_specs = volume_types.get_volume_type_extra_specs(
-                volume_type_id)
-        for vendor_spec in vendor_specs:
-            api = vendor_spec['api']
-            name = vendor_spec['name']
-            if name in extra_specs:
-                extra_spec = extra_specs[name]
-                value = self._get_vendor_value(extra_spec, vendor_spec)
-            elif 'cfg' in vendor_spec:
-                key = vendor_spec['cfg']
+            type_id = None
+        if type_id:
+            return volume_types.get_volume_type_extra_specs(type_id)
+        return {}
+
+    def _get_lu_specs(self, volume, volume_type=None):
+        payload = {}
+        items = self.nef.logicalunits.properties
+        specs = self._get_volume_type_specs(volume, volume_type)
+        for item in items:
+            if 'api' not in item:
+                continue
+            api = item['api']
+            name = item['name']
+            if name in specs:
+                spec = specs[name]
+                value = self._check_volume_spec(spec, item)
+            elif 'cfg' in item:
+                key = item['cfg']
+                value = self.configuration.safe_get(key)
+                if value in [None, '']:
+                    continue
+            else:
+                continue
+            payload[api] = value
+        LOG.debug('LU properties for %(volume)s: %(payload)s',
+                  {'volume': volume['name'], 'payload': payload})
+        return payload
+
+    def _get_volume_specs(self, volume, volume_type=None):
+        payload = {}
+        items = self.nef.volumes.properties
+        specs = self._get_volume_type_specs(volume, volume_type)
+        for item in items:
+            if 'api' not in item:
+                continue
+            api = item['api']
+            name = item['name']
+            if name in specs:
+                spec = specs[name]
+                value = self._check_volume_spec(spec, item)
+            elif 'cfg' in item:
+                key = item['cfg']
                 value = self.configuration.safe_get(key)
                 if value in [None, '']:
                     continue
@@ -2355,30 +2252,24 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                 value = self.san_stat[api]
             else:
                 continue
-            properties[api] = value
-            LOG.debug('Get vendor property name %(name)s with '
-                      'API name %(api)s and %(type)s value '
-                      '%(value)s for volume %(volume)s',
-                      {'name': name,
-                       'api': api,
-                       'type': type(value).__name__,
-                       'value': value,
-                       'volume': volume['name']})
-        return properties
+            payload[api] = value
+        LOG.debug('Volume properties for %(volume)s: %(payload)s',
+                  {'volume': volume['name'], 'payload': payload})
+        return payload
 
-    def _get_vendor_value(self, value, vendor_spec):
-        name = vendor_spec['name']
+    def _check_volume_spec(self, value, prop):
+        name = prop['name']
         code = 'EINVAL'
-        if vendor_spec['type'] == 'integer':
+        if prop['type'] == 'integer':
             try:
                 value = int(value)
-            except ValueError:
+            except (TypeError, ValueError):
                 message = (_('Invalid non-integer value %(value)s for '
                              'vendor property name %(name)s')
                            % {'value': value, 'name': name})
                 raise jsonrpc.NefException(code=code, message=message)
-            if 'minimum' in vendor_spec:
-                minimum = vendor_spec['minimum']
+            if 'minimum' in prop:
+                minimum = prop['minimum']
                 if value < minimum:
                     message = (_('Integer value %(value)s is less than '
                                  'allowed minimum %(minimum)s for vendor '
@@ -2386,8 +2277,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                                % {'value': value, 'minimum': minimum,
                                   'name': name})
                     raise jsonrpc.NefException(code=code, message=message)
-            if 'maximum' in vendor_spec:
-                maximum = vendor_spec['maximum']
+            if 'maximum' in prop:
+                maximum = prop['maximum']
                 if value > maximum:
                     message = (_('Integer value %(value)s is greater than '
                                  'allowed maximum %(maximum)s for vendor '
@@ -2395,7 +2286,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                                % {'value': value, 'maximum': maximum,
                                   'name': name})
                     raise jsonrpc.NefException(code=code, message=message)
-        elif vendor_spec['type'] == 'string':
+        elif prop['type'] == 'string':
             try:
                 value = str(value)
             except UnicodeEncodeError:
@@ -2403,7 +2294,7 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                              'property name %(name)s')
                            % {'value': value, 'name': name})
                 raise jsonrpc.NefException(code=code, message=message)
-        elif vendor_spec['type'] == 'boolean':
+        elif prop['type'] == 'boolean':
             words = value.split()
             if len(words) == 2 and words[0] == '<is>':
                 value = words[1]
@@ -2414,8 +2305,8 @@ class NexentaISCSIDriver(driver.ISCSIDriver):
                              'property name %(name)s')
                            % {'value': value, 'name': name})
                 raise jsonrpc.NefException(code=code, message=message)
-        if 'enum' in vendor_spec:
-            enum = vendor_spec['enum']
+        if 'enum' in prop:
+            enum = prop['enum']
             if value not in enum:
                 message = (_('Value %(value)s is out of allowed enumeration '
                              '%(enum)s for vendor property name %(name)s')

--- a/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
@@ -18,6 +18,7 @@ import posixpath
 
 from eventlet import greenthread
 from oslo_log import log as logging
+from pkg_resources import parse_version
 import requests
 import six
 
@@ -26,6 +27,7 @@ from cinder.i18n import _
 
 LOG = logging.getLogger(__name__)
 
+ASYNC_WAIT = 0.25
 HTTPS_PORT = 8443
 HTTP_PORT = 8080
 HTTPS = 'https'
@@ -73,6 +75,7 @@ class NefRequest(object):
         self.error = None
         self.path = None
         self.time = 0
+        self.wait = 0
         self.data = []
         self.stat = {}
         self.hooks = {
@@ -84,21 +87,26 @@ class NefRequest(object):
         }
 
     def __call__(self, path, payload=None):
-        LOG.debug('Start NEF request: %(method)s %(path)s %(payload)s',
-                  {'method': self.method, 'path': path, 'payload': payload})
+        info = '%(method)s %(url)s %(payload)s' % {
+            'method': self.method,
+            'url': self.proxy.url(path),
+            'payload': payload
+        }
+        LOG.debug('Start request: %(info)s', {'info': info})
         self.path = path
         self.payload = payload
         for attempt in range(self.attempts):
             self.data = []
             if self.error:
-                self.proxy.delay(attempt)
+                self.delay(attempt)
                 if not self.find_host():
                     continue
-                LOG.debug('Retry NEF request: %(method)s %(path)s %(payload)s '
-                          '[%(attempt)s/%(attempts)s], reason: %(error)s',
-                          {'method': self.method, 'path': path,
-                           'payload': payload, 'attempt': attempt,
-                           'attempts': self.attempts, 'error': self.error})
+                LOG.debug('Retry request: %(info)s '
+                          '[%(attempt)s/%(attempts)s], '
+                          'reason: %(error)s',
+                          {'info': info, 'attempt': attempt,
+                           'attempts': self.attempts,
+                           'error': self.error})
             try:
                 response = self.request(self.method, self.path, self.payload)
             except Exception as error:
@@ -108,70 +116,73 @@ class NefRequest(object):
                     message = six.text_type(error)
                     self.error = NefException(message=message)
                 continue
-            LOG.debug('Finish NEF request: %(method)s %(path)s %(payload)s, '
+            count = sum(self.stat.values())
+            LOG.debug('Finish request: %(info)s, '
                       'total response time: %(time)s seconds, '
+                      'total wait time: %(wait)s seconds, '
                       'total requests count: %(count)s, '
                       'requests statistics: %(stat)s, '
                       'response content: %(content)s',
-                      {'method': self.method,
-                       'path': self.path,
-                       'payload': self.payload,
-                       'time': self.time,
-                       'count': sum(self.stat.values()),
+                      {'info': info, 'time': self.time,
+                       'wait': self.wait, 'count': count,
                        'stat': self.stat,
                        'content': response.content})
-            if response.ok and not response.content:
-                if 'location' in response.headers:
-                    location = response.headers['location']
-                    name = posixpath.basename(location)
-                    data = six.moves.urllib.parse.unquote_plus(name)
-                    return data
-                return None
-            content = json.loads(response.content)
+            content = None
+            if response.content:
+                content = json.loads(response.content)
             if not response.ok:
+                LOG.error('Failed request: %(info)s, '
+                          'response content: %(content)s',
+                          {'info': info, 'content': content})
                 raise NefException(content)
+            if (response.status_code == requests.codes.created and
+                    'location' in response.headers and not content):
+                location = response.headers['location']
+                name = posixpath.basename(location)
+                data = six.moves.urllib.parse.unquote_plus(name)
+                return data
             if isinstance(content, dict) and 'data' in content:
                 return self.data
             return content
-        LOG.error('Failed NEF request: %(method)s %(path)s '
-                  '%(payload)s, request reached maximum retry '
-                  'attempts: %(attempts)s, reason: %(error)s',
-                  {'method': self.method, 'path': path,
-                   'payload': payload, 'attempts': self.attempts,
+        LOG.error('Failed request: %(info)s, '
+                  'reached maximum retry attempts: '
+                  '%(attempts)s, reason: %(error)s',
+                  {'info': info, 'attempts': self.attempts,
                    'error': self.error})
         raise self.error
 
     def request(self, method, path, payload):
         if self.method not in ['get', 'delete', 'put', 'post']:
+            code = 'EINVAL'
             message = (_('Request method %(method)s not supported')
                        % {'method': self.method})
-            raise NefException(code='EINVAL', message=message)
+            raise NefException(code=code, message=message)
         if not path:
+            code = 'EINVAL'
             message = _('Request path is required')
-            raise NefException(code='EINVAL', message=message)
+            raise NefException(code=code, message=message)
         url = self.proxy.url(path)
         kwargs = dict(self.kwargs)
         if payload:
             if not isinstance(payload, dict):
+                code = 'EINVAL'
                 message = _('Request payload must be a dictionary')
-                raise NefException(code='EINVAL', message=message)
+                raise NefException(code=code, message=message)
             if method in ['get', 'delete']:
                 kwargs['params'] = payload
             elif method in ['put', 'post']:
                 kwargs['data'] = json.dumps(payload)
-        LOG.debug('Session request: %(method)s %(url)s %(data)s',
-                  {'method': method, 'url': url, 'data': kwargs})
         return self.proxy.session.request(method, url, **kwargs)
 
     def hook(self, response, **kwargs):
-        text = (_('session request %(method)s %(url)s %(body)s '
+        info = (_('session request %(method)s %(url)s %(body)s '
                   'and session response %(code)s %(content)s')
                 % {'method': response.request.method,
                    'url': response.request.url,
                    'body': response.request.body,
                    'code': response.status_code,
                    'content': response.content})
-        LOG.debug('Start request hook on %(text)s', {'text': text})
+        LOG.debug('Start request hook on %(info)s', {'info': info})
         if response.status_code not in self.stat:
             self.stat[response.status_code] = 0
         self.stat[response.status_code] += 1
@@ -183,21 +194,24 @@ class NefRequest(object):
         try:
             content = json.loads(response.content)
         except (TypeError, ValueError) as error:
-            message = (_('Failed request hook on %(text)s: '
+            code = 'EINVAL'
+            message = (_('Failed request hook on %(info)s: '
                          'JSON parser error: %(error)s')
-                       % {'text': text, 'error': error})
-            raise NefException(code='EINVAL', message=message)
+                       % {'info': info, 'error': error})
+            raise NefException(code=code, message=message)
         if response.ok and content is None:
             return response
         if not isinstance(content, dict):
-            message = (_('Failed request hook on %(text)s: '
+            code = 'EINVAL'
+            message = (_('Failed request hook on %(info)s: '
                          'no valid content found')
-                       % {'text': text})
-            raise NefException(code='EINVAL', message=message)
+                       % {'info': info})
+            raise NefException(code=code, message=message)
         if attempt > limit and not response.ok:
             return response
         method = 'get'
         if response.status_code == requests.codes.unauthorized:
+            # Workaround for NEX-22043
             if 'code' in content and content['code'] == 'ELICENSE':
                 raise NefException(content)
             if not self.auth():
@@ -216,28 +230,30 @@ class NefRequest(object):
         elif response.status_code == requests.codes.accepted:
             path, payload = self.parse(content, 'monitor')
             if not path:
-                message = (_('Failed request hook on %(text)s: '
+                code = 'ENODATA'
+                message = (_('Failed request hook on %(info)s: '
                              'monitor path not found')
-                           % {'text': text})
-                raise NefException(code='ENODATA', message=message)
-            self.proxy.delay(attempt)
+                           % {'info': info})
+                raise NefException(code=code, message=message)
+            self.delay(attempt, sync=False)
             return self.request(method, path, payload)
         elif response.status_code == requests.codes.ok:
             if 'data' not in content or not content['data']:
-                LOG.debug('Finish request hook on %(text)s: '
+                LOG.debug('Finish request hook on %(info)s: '
                           'non-paginated content',
-                          {'text': text})
+                          {'info': info})
                 return response
             data = content['data']
-            LOG.debug('Continue request hook on %(text)s: '
+            count = len(data)
+            LOG.debug('Continue request hook on %(info)s: '
                       'add %(count)s data items to response',
-                      {'text': text, 'count': len(data)})
+                      {'info': info, 'count': count})
             self.data += data
             path, payload = self.parse(content, 'next')
             if not path:
-                LOG.debug('Finish request hook on %(text)s: '
+                LOG.debug('Finish request hook on %(info)s: '
                           'no next page found',
-                          {'text': text})
+                          {'info': info})
                 return response
             if self.payload:
                 payload.update(self.payload)
@@ -246,8 +262,8 @@ class NefRequest(object):
                       {'method': method, 'path': path,
                        'payload': payload})
             return self.request(method, path, payload)
-        LOG.debug('Finish request hook on %(text)s',
-                  {'text': text})
+        LOG.debug('Finish request hook on %(info)s',
+                  {'info': info})
         return response
 
     def auth(self):
@@ -278,12 +294,7 @@ class NefRequest(object):
                   'host': self.proxy.host})
         try:
             response = self.request(method, self.proxy.root, payload)
-        except Exception as error:
-            LOG.error('Failed to find pool %(pool)s '
-                      'on host %(host)s: %(error)s',
-                      {'pool': self.proxy.pool,
-                       'host': self.proxy.host,
-                       'error': error})
+        except Exception:
             return False
         content = json.loads(response.content)
         if 'data' not in content or not content['data']:
@@ -300,8 +311,12 @@ class NefRequest(object):
         for host in self.proxy.hosts:
             self.proxy.update_host(host)
             if self.check_host():
+                self.proxy.update_lock()
                 return True
         return False
+
+    def delay(self, attempt, sync=True):
+        self.wait += self.proxy.delay(attempt, sync)
 
     @staticmethod
     def parse(content, name):
@@ -387,12 +402,36 @@ class NefSettings(NefCollections):
         return NotImplemented
 
 
+class NefSoftware(NefSettings, NefCollections):
+
+    def __init__(self, proxy):
+        super(NefSoftware, self).__init__(proxy)
+        self.root = '/software'
+        self.subj = 'software'
+
+    def get(self, name, payload=None):
+        return NotImplemented
+
+    def set(self, name, payload=None):
+        return NotImplemented
+
+    def list(self, payload=None):
+        return NotImplemented
+
+    def version(self):
+        name = 'current'
+        LOG.debug('Get %(name)s %(subj)s version',
+                  {'name': name, 'subj': self.subj})
+        path = self.path(name)
+        return self.proxy.get(path)
+
+
 class NefVsolutions(NefCollections):
 
     def __init__(self, proxy):
         super(NefVsolutions, self).__init__(proxy)
         self.root = '/vsolution/filesystems'
-        self.subj = 'vsolution'
+        self.subj = 'file'
         self.slot = 'files'
 
     def path(self, parent, name):
@@ -418,6 +457,13 @@ class NefVsolutions(NefCollections):
 
     def delete(self, name, payload=None):
         return NotImplemented
+
+    def resize(self, parent, name, payload=None):
+        LOG.debug('Resize %(subj)s: %(parent)s/%(name)s %(payload)s',
+                  {'subj': self.subj, 'parent': parent, 'name': name,
+                   'payload': payload})
+        path = self.path(parent, name)
+        self.proxy.put(path, payload)
 
 
 class NefDatasets(NefCollections):
@@ -452,37 +498,10 @@ class NefVolumeGroups(NefDatasets, NefCollections):
 
     def __init__(self, proxy):
         super(NefVolumeGroups, self).__init__(proxy)
+        self.prefix = 'volume'
         self.root = '/storage/volumeGroups'
         self.subj = 'volume group'
-
-    def rollback(self, name, payload=None):
-        LOG.debug('Rollback %(subj)s %(name)s: %(payload)s',
-                  {'subj': self.subj, 'name': name, 'payload': payload})
-        path = posixpath.join(self.path(name), 'rollback')
-        return self.proxy.post(path, payload)
-
-
-class NefVolumes(NefVolumeGroups, NefDatasets, NefCollections):
-
-    def __init__(self, proxy):
-        super(NefVolumes, self).__init__(proxy)
-        self.prefix = 'volume'
-        self.root = '/storage/volumes'
-        self.subj = 'volume'
         self.properties = [
-            {
-                'name': self.key('blocksize'),
-                'api': 'volumeBlockSize',
-                'cfg': 'nexenta_blocksize',
-                'title': 'Block size',
-                'retype': _('Volume block size cannot be changed after '
-                            'the volume has been created.'),
-                'description': _('Controls the block size of a volume.'),
-                'type': 'integer',
-                'enum': [512, 1024, 2048, 4096, 8192,
-                         16384, 32768, 65536, 131072],
-                'default': 32768
-            },
             {
                 'name': self.key('checksum'),
                 'api': 'checksumMode',
@@ -576,17 +595,6 @@ class NefVolumes(NefVolumeGroups, NefDatasets, NefCollections):
                 'default': 'all'
             },
             {
-                'name': self.key('thin_provisioning'),
-                'api': 'sparseVolume',
-                'cfg': 'nexenta_sparsed_volumes',
-                'title': 'Thin provisioning',
-                'inherit': _('Provisioning type cannot be inherit.'),
-                'description': _('Controls if a volume is created sparse '
-                                 '(with no space reservation).'),
-                'type': 'boolean',
-                'default': True
-            },
-            {
                 'name': self.key('sync'),
                 'api': 'syncMode',
                 'title': 'Sync mode',
@@ -618,6 +626,46 @@ class NefVolumes(NefVolumeGroups, NefDatasets, NefCollections):
             }
         ]
 
+    def rollback(self, name, payload=None):
+        LOG.debug('Rollback %(subj)s %(name)s: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = posixpath.join(self.path(name), 'rollback')
+        return self.proxy.post(path, payload)
+
+
+class NefVolumes(NefVolumeGroups, NefDatasets, NefCollections):
+
+    def __init__(self, proxy):
+        super(NefVolumes, self).__init__(proxy)
+        self.root = '/storage/volumes'
+        self.subj = 'volume'
+        self.properties += [
+            {
+                'name': self.key('blocksize'),
+                'api': 'volumeBlockSize',
+                'cfg': 'nexenta_blocksize',
+                'title': 'Block size',
+                'change': _('Volume block size cannot be changed after '
+                            'the volume has been created.'),
+                'description': _('Specifies the block size of the volume.'),
+                'type': 'integer',
+                'enum': [512, 1024, 2048, 4096, 8192, 16384, 32768, 65536,
+                         131072],
+                'default': 32768
+            },
+            {
+                'name': self.key('thin_provisioning'),
+                'api': 'sparseVolume',
+                'cfg': 'nexenta_sparsed_volumes',
+                'title': 'Thin provisioning',
+                'inherit': _('Provisioning type cannot be inherit.'),
+                'description': _('Controls if a volume is created sparse '
+                                 '(with no space reservation).'),
+                'type': 'boolean',
+                'default': True
+            }
+        ]
+
     def promote(self, name, payload=None):
         LOG.debug('Promote %(subj)s %(name)s: %(payload)s',
                   {'subj': self.subj, 'name': name, 'payload': payload})
@@ -625,78 +673,100 @@ class NefVolumes(NefVolumeGroups, NefDatasets, NefCollections):
         return self.proxy.post(path, payload)
 
 
-class NefFilesystems(NefVolumes, NefVolumeGroups, NefDatasets, NefCollections):
+class NefFilesystems(NefVolumeGroups, NefDatasets, NefCollections):
 
     def __init__(self, proxy):
         super(NefFilesystems, self).__init__(proxy)
         self.root = '/storage/filesystems'
         self.subj = 'filesystem'
-        for prop in self.properties:
-            if prop['name'] == self.key('blocksize'):
-                del prop['retype']
-                prop['api'] = 'recordSize'
-                prop['description'] = _('Specifies a suggested block size '
-                                        'for a volume.')
-                prop['enum'] = [512, 1024, 2048, 4096, 8192, 16384, 32768,
-                                65536, 131072, 262144, 524288, 1048576]
-        self.properties.append({
-            'name': self.key('rate_limit'),
-            'api': 'rateLimit',
-            'title': 'Transfer rate limit',
-            'description': _('Controls a transfer rate limit '
-                             '(bytes per second) for a volume.'),
-            'type': 'integer',
-            'default': 0
-        })
-        self.properties.append({
-            'name': self.key('nbmand'),
-            'api': 'nonBlockingMandatoryMode',
-            'title': 'Non-blocking mandatory locking',
-            'description': _('Allow or disallow non-blocking mandatory '
-                             'locking semantics for a volume.'),
-            'type': 'boolean',
-            'default': False
-        })
-        self.properties.append({
-            'name': self.key('smart_compression'),
-            'api': 'smartCompression',
-            'title': 'Smart compression',
-            'description': _('Allow or disallow dynamically tracks volume '
-                             'compression ratios to determine if a volume '
-                             'data is compressible or not.'),
-            'type': 'boolean',
-            'default': False
-        })
-        self.properties.append({
-            'name': self.key('snapdir'),
-            'api': 'snapshotDirectory',
-            'title': '.zfs directory visibility',
-            'description': _('Controls whether the .zfs directory '
-                             'is hidden or visible in the root of '
-                             'the volume file system.'),
-            'type': 'boolean',
-            'default': False
-        })
-        self.properties.append({
-            'name': self.key('format'),
-            'api': 'volumeFormat',
-            'cfg': 'nexenta_volume_format',
-            'title': 'Volume format',
-            'description': _('Controls volume format.'),
-            'enum': ['raw', 'qcow', 'qcow2', 'parallels',
-                     'vdi', 'vhdx', 'vmdk', 'vpc', 'qed'],
-            'type': 'string',
-            'default': 'raw'
-        })
-        self.properties.append({
-            'name': self.key('vsolution'),
-            'api': 'vSolution',
-            'cfg': 'nexenta_vsolution',
-            'title': 'vSolution API',
-            'description': _('Enables NexentaStor vSolution API.'),
-            'type': 'boolean',
-            'default': False
-        })
+        self.properties += [
+            {
+                'name': self.key('blocksize'),
+                'api': 'recordSize',
+                'cfg': 'nexenta_blocksize',
+                'title': 'Block size',
+                'description': _('Specifies the maximum size of a logical '
+                                 'block for a volume.'),
+                'type': 'integer',
+                'enum': [512, 1024, 2048, 4096, 8192, 16384, 32768, 65536,
+                         131072, 262144, 524288, 1048576],
+                'default': 32768
+            },
+            {
+                'name': self.key('nbmand'),
+                'api': 'nonBlockingMandatoryMode',
+                'title': 'Non-blocking mandatory locking',
+                'description': _('Allow or disallow non-blocking mandatory '
+                                 'locking semantics for a volume.'),
+                'type': 'boolean',
+                'default': False
+            },
+            {
+                'name': self.key('rate_limit'),
+                'api': 'rateLimit',
+                'title': 'Transfer rate limit',
+                'description': _('Controls a transfer rate limit '
+                                 '(bytes per second) for a volume.'),
+                'type': 'integer',
+                'default': 0
+            },
+            {
+                'name': self.key('smart_compression'),
+                'api': 'smartCompression',
+                'title': 'Smart compression',
+                'description': _('Allow or disallow dynamically tracks '
+                                 'volume compression ratios to determine '
+                                 'if a volume data is compressible or not.'),
+                'type': 'boolean',
+                'default': False
+            },
+            {
+                'name': self.key('snapdir'),
+                'api': 'snapshotDirectory',
+                'title': '.zfs directory visibility',
+                'description': _('Controls whether the .zfs directory is '
+                                 'hidden or visible in the root of the '
+                                 'volume file system.'),
+                'type': 'boolean',
+                'default': False
+            },
+            {
+                'name': self.key('format'),
+                'img': 'format',
+                'cfg': 'nexenta_volume_format',
+                'title': 'Volume format',
+                'description': _('Controls volume format.'),
+                'enum': ['raw', 'qcow', 'qcow2', 'parallels',
+                         'vdi', 'vhdx', 'vmdk', 'vpc', 'qed'],
+                'type': 'string',
+                'default': 'raw'
+            },
+            {
+                'name': self.key('thin_provisioning'),
+                'img': 'sparse',
+                'cfg': 'nexenta_sparsed_volumes',
+                'title': 'Thin provisioning',
+                'description': _('Controls if a volume is created sparse '
+                                 '(with no space reservation).'),
+                'type': 'boolean',
+                'default': True
+            },
+            {
+                'name': self.key('vsolution'),
+                'img': 'vsolution',
+                'cfg': 'nexenta_vsolution',
+                'title': 'vSolution API',
+                'description': _('Enables NexentaStor vSolution API.'),
+                'type': 'boolean',
+                'default': False
+            }
+        ]
+
+    def promote(self, name, payload=None):
+        LOG.debug('Promote %(subj)s %(name)s: %(payload)s',
+                  {'subj': self.subj, 'name': name, 'payload': payload})
+        path = posixpath.join(self.path(name), 'promote')
+        return self.proxy.post(path, payload)
 
     def mount(self, name, payload=None):
         LOG.debug('Mount %(subj)s %(name)s: %(payload)s',
@@ -724,11 +794,11 @@ class NefHpr(NefCollections):
         self.root = '/hpr/services'
         self.subj = 'HPR service'
 
-    def activate(self, payload=None):
-        LOG.debug('Activate %(payload)s',
-                  {'payload': payload})
-        root = posixpath.dirname(self.root)
-        path = posixpath.join(root, 'activate')
+    def activate(self, path):
+        LOG.debug('Activate dataset: %(path)s',
+                  {'path': path})
+        path = '/hpr/activate'
+        payload = {'datasetName': path}
         return self.proxy.post(path, payload)
 
     def start(self, name, payload=None):
@@ -829,12 +899,13 @@ class NefNetAddresses(NefCollections):
     def __init__(self, proxy):
         super(NefNetAddresses, self).__init__(proxy)
         self.root = '/network/addresses'
-        self.subj = 'network address'
+        self.subj = 'address'
 
 
 class NefProxy(object):
-    def __init__(self, proto, pool, path, conf):
+    def __init__(self, proto, pool, path, backend, conf):
         self.settings = NefSettings(self)
+        self.software = NefSoftware(self)
         self.vsolutions = NefVsolutions(self)
         self.filesystems = NefFilesystems(self)
         self.volumegroups = NefVolumeGroups(self)
@@ -850,6 +921,7 @@ class NefProxy(object):
         self.mappings = NefLunMappings(self)
         self.logicalunits = NefLogicalUnits(self)
         self.netaddrs = NefNetAddresses(self)
+        self.version = None
         self.lock = None
         self.auto = False
         self.tokens = {}
@@ -876,26 +948,29 @@ class NefProxy(object):
                 self.port = HTTP_PORT
         self.username = conf.nexenta_user
         self.password = conf.nexenta_password
+        self.backend = backend
         self.hosts = []
         if conf.nexenta_rest_address:
-            for host in conf.nexenta_rest_address.split(','):
-                self.hosts.append(host.strip())
+            for host in conf.nexenta_rest_address:
+                if host:
+                    self.hosts.append(host)
         elif proto == ISCSI and conf.nexenta_host:
             self.hosts.append(conf.nexenta_host)
         elif proto == NFS and conf.nas_host:
             self.hosts.append(conf.nas_host)
         else:
+            code = 'EINVAL'
             message = (_('NexentaStor Rest API address is not defined, '
                          'please check the Cinder configuration file for '
                          'NexentaStor backend and nexenta_rest_address, '
                          'nexenta_host or nas_host configuration options'))
-            raise NefException(code='EINVAL', message=message)
+            raise NefException(code=code, message=message)
         self.host = self.hosts[0]
         self.pool = pool
         self.path = path
         self.root = self.filesystems.root
         self.retries = conf.nexenta_rest_retry_count
-        self.backoff_factor = conf.nexenta_rest_backoff_factor
+        self.backoff = conf.nexenta_rest_backoff_factor
         self.timeout = (conf.nexenta_rest_connect_timeout,
                         conf.nexenta_rest_read_timeout)
         self.session = requests.Session()
@@ -928,60 +1003,85 @@ class NefProxy(object):
             token = self.tokens[host]
             self.update_bearer(token)
 
+    def version_less(self, version):
+        if not self.version:
+            return True
+        return parse_version(self.version) < parse_version(version)
+
     def update_lock(self):
+        software = {}
         settings = {}
+        compound = []
+        clusters = []
+        guids = []
         guid = None
         try:
+            software = self.software.version()
+        except Exception:
+            pass
+        if software and 'version' in software:
+            version = software['version']
+            if version:
+                compound.append(version)
+        if software and 'build' in software:
+            build = software['build']
+            if build:
+                compound.append(build)
+        if compound:
+            self.version = '.'.join(map(str, compound))
+            LOG.info('Software version for group %(backend)s: %(version)s',
+                     {'backend': self.backend, 'version': self.version})
+        else:
+            self.version = None
+        try:
             settings = self.settings.get('system.guid')
-        except NefException as error:
-            LOG.error('Unable to get host settings: %(error)s',
-                      {'error': error})
+        except Exception:
+            pass
         if settings and 'value' in settings:
             guid = settings['value']
-            LOG.debug('Host guid: %(guid)s', {'guid': guid})
-        else:
-            LOG.error('Unable to get host guid: %(settings)s',
-                      {'settings': settings})
-        guids = []
-        clusters = []
         payload = {'fields': 'nodes'}
         try:
             clusters = self.rsf.list(payload)
-        except NefException as error:
-            LOG.error('Unable to get HA cluster guid: %(error)s',
-                      {'error': error})
+        except Exception:
+            pass
         for cluster in clusters:
             if 'nodes' not in cluster:
                 continue
             nodes = cluster['nodes']
             for node in nodes:
                 if 'machineId' in node:
-                    guids.append(node['machineId'])
-        if guid in guids:
-            guid = ':'.join(sorted(guids))
-            LOG.debug('HA cluster guid: %(guid)s',
-                      {'guid': guid})
+                    hostid = node['machineId']
+                    if hostid and hostid != '-':
+                        guids.append(hostid)
+        if guid and guids and guid in guids:
+            guid = ':'.join(map(str, sorted(guids)))
         if not guid:
-            guid = ':'.join(sorted(self.hosts))
+            guid = ':'.join(map(str, sorted(self.hosts)))
         lock = '%s:%s' % (guid, self.path)
         if isinstance(lock, six.text_type):
             lock = lock.encode('utf-8')
         self.lock = hashlib.md5(lock).hexdigest()
-        LOG.debug('NEF coordination lock: %(lock)s',
-                  {'lock': self.lock})
+        LOG.info('Coordination lock for group %(backend)s: %(lock)s',
+                 {'backend': self.backend, 'lock': self.lock})
 
-    def url(self, path=''):
+    def url(self, path=None):
+        if not path:
+            path = ''
         netloc = '%s:%d' % (self.host, self.port)
         components = (self.scheme, netloc, path, None, None)
         url = six.moves.urllib.parse.urlunsplit(components)
         return url
 
-    def delay(self, attempt):
+    def delay(self, attempt, sync=True):
+        backoff = self.backoff
+        if not sync:
+            backoff = ASYNC_WAIT
         if self.retries > 0:
             attempt %= self.retries
             if attempt == 0:
                 attempt = self.retries
-        interval = float(self.backoff_factor * (2 ** (attempt - 1)))
+        interval = float(backoff * (2 ** (attempt - 1)))
         LOG.debug('Waiting for %(interval)s seconds',
                   {'interval': interval})
         greenthread.sleep(interval)
+        return interval

--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -12,7 +12,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import errno
 import ipaddress
 import os
 import posixpath
@@ -26,7 +25,6 @@ from oslo_utils import strutils
 from oslo_utils import units
 import six
 
-from cinder import context
 from cinder import coordination
 from cinder.i18n import _
 from cinder.image import image_utils
@@ -34,25 +32,15 @@ from cinder import interface
 from cinder import objects
 from cinder.privsep import fs
 from cinder import utils as cinder_utils
+from cinder.volume.drivers.nexenta import image
 from cinder.volume.drivers.nexenta.ns5 import jsonrpc
 from cinder.volume.drivers.nexenta import options
-from cinder.volume.drivers.nexenta import utils as nexenta_utils
+from cinder.volume.drivers.nexenta import utils
 from cinder.volume.drivers import nfs
 from cinder.volume import volume_types
 from cinder.volume import volume_utils
 
 LOG = logging.getLogger(__name__)
-
-VOLUME_FILE_NAME = 'volume'
-VOLUME_FORMAT_RAW = 'raw'
-VOLUME_FORMAT_QCOW = 'qcow'
-VOLUME_FORMAT_QCOW2 = 'qcow2'
-VOLUME_FORMAT_PARALLELS = 'parallels'
-VOLUME_FORMAT_VDI = 'vdi'
-VOLUME_FORMAT_VHDX = 'vhdx'
-VOLUME_FORMAT_VMDK = 'vmdk'
-VOLUME_FORMAT_VPC = 'vpc'
-VOLUME_FORMAT_QED = 'qed'
 
 
 @interface.volumedriver
@@ -119,9 +107,11 @@ class NexentaNfsDriver(nfs.NfsDriver):
               - Added QoS support in terms of I/O throttling rate.
         1.9.2 - Added support for NexentaStor5 vSolution API.
         1.9.3 - Added support for NAS secure operations.
+        1.9.4 - Added support for nohide NFS option.
+              - Fixed concurrency issues.
     """
 
-    VERSION = '1.9.3'
+    VERSION = '1.9.4'
     CI_WIKI_NAME = "Nexenta_CI"
 
     vendor_name = 'Nexenta'
@@ -133,11 +123,12 @@ class NexentaNfsDriver(nfs.NfsDriver):
         self._remotefsclient = None
         super(NexentaNfsDriver, self).__init__(*args, **kwargs)
         if not self.configuration:
+            code = 'ENODATA'
             message = (_('%(product_name)s %(storage_protocol)s '
                          'backend configuration not found')
                        % {'product_name': self.product_name,
                           'storage_protocol': self.storage_protocol})
-            raise jsonrpc.NefException(code='ENODATA', message=message)
+            raise jsonrpc.NefException(code=code, message=message)
         self.configuration.append_config_values(options.NEXENTASTOR5_NFS_OPTS)
         root_helper = cinder_utils.get_root_helper()
         mount_point_base = self.configuration.nexenta_mount_point_base
@@ -162,7 +153,11 @@ class NexentaNfsDriver(nfs.NfsDriver):
             nfs_mount_point_base=self.mount_point_base,
             nfs_mount_options=self.mount_options)
         self.nef = None
+        self.ctxt = None
         self.nas_stat = None
+        self.nas_share = None
+        self.nas_nohide = False
+        self.nas_mntpoint = None
         self.backend_name = self._get_backend_name()
         self.nas_driver = self.__class__.__name__
         self.nas_host = self.configuration.nas_host
@@ -194,6 +189,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         return options.NEXENTASTOR5_NFS_OPTS
 
     def do_setup(self, ctxt):
+        self.ctxt = ctxt
         retries = 0
         while not self._do_setup():
             retries += 1
@@ -202,7 +198,9 @@ class NexentaNfsDriver(nfs.NfsDriver):
     def _do_setup(self):
         try:
             self.nef = jsonrpc.NefProxy(self.driver_volume_type,
-                                        self.nas_pool, self.nas_path,
+                                        self.nas_pool,
+                                        self.nas_path,
+                                        self.backend_name,
                                         self.configuration)
         except jsonrpc.NefException as error:
             LOG.error('Failed to initialize RESTful API for backend '
@@ -220,13 +218,14 @@ class NexentaNfsDriver(nfs.NfsDriver):
         }
         for option_name, option_value in secure_options.items():
             if option_value not in ['auto', 'true', 'false']:
+                code = 'EINVAL'
                 message = (_('Invalid value %(option_value)s for '
                              'configuration option %(option_name)s '
                              'defined for backend %(backend_name)s')
                            % {'option_value': option_value,
                               'option_name': option_name,
                               'backend_name': self.backend_name})
-                raise jsonrpc.NefException(code='EINVAL', message=message)
+                raise jsonrpc.NefException(code=code, message=message)
         self.set_nas_security_options(self._is_voldb_empty_at_startup)
         retries = 0
         while not self._check_for_setup_error():
@@ -242,13 +241,9 @@ class NexentaNfsDriver(nfs.NfsDriver):
             LOG.error('Failed to get stat of NAS pool %(nas_pool)s: %(error)s',
                       {'nas_pool': self.nas_pool, 'error': error})
             return False
-        specs = self.nef.filesystems.properties
-        names = [spec['api'] for spec in specs if 'api' in spec]
-        names.remove('sparseVolume')
-        names.remove('volumeFormat')
-        names.remove('vSolution')
-        names.append('mountPoint')
-        names.append('isMounted')
+        items = self.nef.filesystems.properties
+        names = [item['api'] for item in items if 'api' in item]
+        names += ['mountPoint', 'isMounted']
         fields = ','.join(names)
         payload = {'fields': fields}
         try:
@@ -265,8 +260,9 @@ class NexentaNfsDriver(nfs.NfsDriver):
             LOG.error('NAS path %(nas_path)s is not mounted',
                       {'nas_path': self.nas_path})
             return False
+        payload = {'fields': 'state'}
         try:
-            service = self.nef.services.get('nfs')
+            service = self.nef.services.get('nfs', payload)
         except jsonrpc.NefException as error:
             LOG.error('Failed to get state of NFS service: %(error)s',
                       {'error': error})
@@ -275,8 +271,9 @@ class NexentaNfsDriver(nfs.NfsDriver):
             LOG.error('NFS service is not online: %(state)s',
                       {'state': service['state']})
             return False
+        payload = {'fields': 'nohide,shareState'}
         try:
-            share = self.nef.nfs.get(self.nas_path)
+            share = self.nef.nfs.get(self.nas_path, payload)
         except jsonrpc.NefException as error:
             LOG.error('Failed to get state of NFS share %(share)s: %(error)s',
                       {'share': self.nas_path, 'error': error})
@@ -286,6 +283,18 @@ class NexentaNfsDriver(nfs.NfsDriver):
                       {'share': self.nas_path,
                        'state': share['shareState']})
             return False
+        self.nas_nohide = share['nohide']
+        self.nas_share = '%(host)s:%(path)s' % {
+            'host': self.nas_host,
+            'path': self.nas_stat['mountPoint']
+        }
+        if self.nas_nohide:
+            try:
+                self.nas_mntpoint = self._mount_share(self.nas_share)
+            except Exception as error:
+                LOG.error('Failed to enable nohide feature: %(error)s',
+                          {'error': error})
+                self.nas_nohide = False
         payload = {}
         if self.nas_stat['nonBlockingMandatoryMode'] != self.nbmand:
             payload['nonBlockingMandatoryMode'] = self.nbmand
@@ -341,21 +350,59 @@ class NexentaNfsDriver(nfs.NfsDriver):
         """
         return self.nas_secure_file_operations
 
-    def _update_volume_properties(self, volume):
+    def _update_volume_props(self, volume, volume_type=None):
         """Updates the existing volume properties.
 
         :param volume: volume reference
+        :param volume_type: new volume type
         """
-        if not volume['volume_type_id']:
-            return
-        ctxt = context.get_admin_context()
-        volume_type_id = volume['volume_type_id']
-        volume_type = volume_types.get_volume_type(ctxt, volume_type_id)
-        diff = {}
-        host = volume['host']
-        self.retype(ctxt, volume, volume_type, diff, host)
+        volume_path = self._get_volume_path(volume)
+        items = self.nef.filesystems.properties
+        names = [item['api'] for item in items if 'api' in item]
+        # Workaround for NEX-21595
+        names += ['referencedReservationSize', 'source']
+        fields = ','.join(names)
+        payload = {'fields': fields, 'source': True}
+        props = self.nef.filesystems.get(volume_path, payload)
+        src = props['source']
+        reservation = props['referencedReservationSize']
+        specs = self._get_volume_specs(volume, volume_type)
+        payload = {}
+        for item in items:
+            if 'api' not in item:
+                continue
+            api = item['api']
+            if api in specs:
+                value = specs[api]
+                if props[api] == value:
+                    continue
+                payload[api] = value
+            elif src[api] in ['local', 'received']:
+                if props[api] == item['default']:
+                    continue
+                if 'inherit' in item:
+                    LOG.debug('Unable to inherit property %(name)s '
+                              'for volume %(volume)s. %(reason)s',
+                              {'name': item['name'],
+                               'volume': volume['name'],
+                               'reason': item['inherit']})
+                    continue
+                payload[api] = None
+        if payload:
+            self.nef.filesystems.set(volume_path, payload)
+        specs = self._get_image_specs(volume, volume_type)
+        file_size = volume['size'] * units.Gi
+        file_format = specs['format']
+        file_sparse = specs['sparse']
+        volume_image = image.VolumeImage(self, volume, specs)
+        volume_image.reload(file_size=True, file_format=True)
+        volume_image.change(file_size=file_size, file_format=file_format)
+        if file_sparse:
+            file_size = 0
+        if reservation != file_size:
+            self._set_volume_reservation(volume, file_size, file_format)
 
-    def _get_volume_reservation(self, volume, volume_size, volume_format):
+    def _get_volume_reservation(self, volume, file_size, file_format):
         """Calculates the correct reservation size for given volume size.
 
         Its purpose is to reserve additional space for volume metadata
@@ -364,298 +411,233 @@ class NexentaNfsDriver(nfs.NfsDriver):
         and qcow2_calc_prealloc_size function in qcow2.c
 
         :param volume: volume reference
-        :param volume_size: volume size in bytes
-        :param volume_format: volume backend file format
+        :param file_size: volume file size in bytes
+        :param file_format: volume file format
         :returns: reservation size
         """
         volume_path = self._get_volume_path(volume)
         payload = {'fields': 'recordSize,dataCopies'}
-        filesystem = self.nef.filesystems.get(volume_path, payload)
-        block_size = filesystem['recordSize']
-        data_copies = filesystem['dataCopies']
-        reservation = volume_size
+        props = self.nef.filesystems.get(volume_path, payload)
+        blocksize = props['recordSize']
+        ncopies = props['dataCopies']
+        reservation = file_size
         numdb = 7
         dn_max_indblkshift = 17
         spa_blkptrshift = 7
         spa_dvas_per_bp = 3
         dnodes_per_level_shift = dn_max_indblkshift - spa_blkptrshift
         dnodes_per_level = 1 << dnodes_per_level_shift
-        nblocks = reservation // block_size
+        nblocks = file_size // blocksize
         while nblocks > 1:
             nblocks += dnodes_per_level - 1
             nblocks //= dnodes_per_level
             numdb += nblocks
-        numdb *= min(spa_dvas_per_bp, data_copies + 1)
-        reservation *= data_copies
+        numdb *= min(spa_dvas_per_bp, ncopies + 1)
+        reservation *= ncopies
         numdb *= 1 << dn_max_indblkshift
         reservation += numdb
-        if volume_format == VOLUME_FORMAT_RAW:
-            meta_size = 0
-        elif volume_format == VOLUME_FORMAT_QCOW:
-            meta_size = 48 + 4 * volume_size // units.Mi
-        elif volume_format == VOLUME_FORMAT_QCOW2:
+        if file_format == image.FORMAT_RAW:
+            file_meta = 0
+        elif file_format == image.FORMAT_QCOW:
+            file_meta = 48 + 4 * file_size // units.Mi
+        elif file_format == image.FORMAT_QCOW2:
             cluster_size = 64 * units.Ki
             refcount_size = 4
             int_size = (sys.maxsize.bit_length() + 1) // 8
-            meta_size = 0
-            aligned_volume_size = nexenta_utils.roundup(volume_size,
-                                                        cluster_size)
-            meta_size += cluster_size
+            file_meta = 0
+            aligned_file_size = utils.roundup(file_size, cluster_size)
+            file_meta += cluster_size
             blocks_per_table = cluster_size // int_size
-            clusters = aligned_volume_size // cluster_size
-            nl2e = nexenta_utils.roundup(clusters, blocks_per_table)
-            meta_size += nl2e * int_size
+            clusters = aligned_file_size // cluster_size
+            nl2e = utils.roundup(clusters, blocks_per_table)
+            file_meta += nl2e * int_size
             clusters = nl2e * int_size // cluster_size
-            nl1e = nexenta_utils.roundup(clusters, blocks_per_table)
-            meta_size += nl1e * int_size
-            clusters = (aligned_volume_size + meta_size) // cluster_size
+            nl1e = utils.roundup(clusters, blocks_per_table)
+            file_meta += nl1e * int_size
+            clusters = (aligned_file_size + file_meta) // cluster_size
             refcounts_per_block = 8 * cluster_size // (1 << refcount_size)
             table = blocks = first = 0
             last = 1
             while first != last:
                 last = first
                 first = clusters + blocks + table
-                blocks = nexenta_utils.divup(first, refcounts_per_block)
-                table = nexenta_utils.divup(blocks, blocks_per_table)
+                blocks = utils.divup(first, refcounts_per_block)
+                table = utils.divup(blocks, blocks_per_table)
                 first = clusters + blocks + table
-            meta_size += (blocks + table) * cluster_size
-        elif volume_format == VOLUME_FORMAT_PARALLELS:
-            meta_size = (1 + volume_size // units.Gi // 256) * units.Mi
-        elif volume_format == VOLUME_FORMAT_VDI:
-            meta_size = 512 + 4 * volume_size // units.Mi
-        elif volume_format == VOLUME_FORMAT_VHDX:
-            meta_size = 8 * units.Mi
-        elif volume_format == VOLUME_FORMAT_VMDK:
-            meta_size = 192 * (units.Ki + volume_size // units.Mi)
-        elif volume_format == VOLUME_FORMAT_VPC:
-            meta_size = 512 + 2 * (units.Ki + volume_size // units.Mi)
-        elif volume_format == VOLUME_FORMAT_QED:
-            meta_size = 320 * units.Ki
+            file_meta += (blocks + table) * cluster_size
+        elif file_format == image.FORMAT_PARALLELS:
+            file_meta = (1 + file_size // units.Gi // 256) * units.Mi
+        elif file_format == image.FORMAT_VDI:
+            file_meta = 512 + 4 * file_size // units.Mi
+        elif file_format == image.FORMAT_VHDX:
+            file_meta = 8 * units.Mi
+        elif file_format == image.FORMAT_VMDK:
+            file_meta = 192 * (units.Ki + file_size // units.Mi)
+        elif file_format == image.FORMAT_VPC:
+            file_meta = 512 + 2 * (units.Ki + file_size // units.Mi)
+        elif file_format == image.FORMAT_QED:
+            file_meta = 320 * units.Ki
         else:
-            message = (_('Volume format %(volume_format)s is not supported')
-                       % {'volume_format': volume_format})
-            raise jsonrpc.NefException(code='EINVAL', message=message)
-        reservation += meta_size
-        volume_meta = reservation - volume_size
-        LOG.debug('Reservation size for %(format)s volume %(volume)s: '
-                  '%(reservation)s, volume data size: %(volume_size)s, '
-                  'volume metadata size: %(volume_meta)s and volume '
-                  'file metadata size: %(meta_size)s',
-                  {'format': volume_format, 'volume': volume['name'],
-                   'reservation': reservation, 'volume_size': volume_size,
-                   'volume_meta': volume_meta, 'meta_size': meta_size})
+            code = 'EINVAL'
+            message = (_('Volume format %(format)s is not supported')
+                       % {'format': file_format})
+            raise jsonrpc.NefException(code=code, message=message)
+        zfs_meta = reservation - file_size
+        reservation += file_meta
+        LOG.debug('Reservation for %(format)s volume %(volume)s: '
+                  '%(reservation)s, volume file size: %(file_size)s, '
+                  'volume metadata size: %(zfs_meta)s and '
+                  'volume file metadata size: %(file_meta)s',
+                  {'format': file_format, 'volume': volume['name'],
+                   'reservation': reservation, 'file_size': file_size,
+                   'zfs_meta': zfs_meta, 'file_meta': file_meta})
         return reservation
 
-    def _set_volume_reservation(self, volume, volume_size, volume_format):
-        volume_reservation = 0
-        if volume_size:
-            volume_reservation = self._get_volume_reservation(volume,
-                                                              volume_size,
-                                                              volume_format)
+    def _set_volume_reservation(self, volume, file_size, file_format):
+        reservation = 0
+        if file_size:
+            reservation = self._get_volume_reservation(
+                volume, file_size, file_format)
         volume_path = self._get_volume_path(volume)
-        payload = {'referencedReservationSize': volume_reservation}
+        payload = {'referencedReservationSize': reservation}
         try:
             self.nef.filesystems.set(volume_path, payload)
         except jsonrpc.NefException as error:
             LOG.error('Failed to set %(format)s volume %(volume)s '
-                      'reservation size to %(reservation)s: %(error)s',
-                      {'format': volume_format,
+                      'reservation to %(reservation)s: %(error)s',
+                      {'format': file_format,
                        'volume': volume['name'],
-                       'reservation': volume_reservation,
+                       'reservation': reservation,
                        'error': error})
             raise
 
-    def _change_volume_format(self, volume, volume_file, src_format,
-                              dst_format):
-        backup_file = '%(path)s.%(format)s' % {
-            'path': volume_file,
-            'format': src_format
-        }
-        try:
-            self._execute('mv', volume_file, backup_file,
-                          run_as_root=self._execute_as_root)
-        except OSError as error:
-            code = errno.errorcode[error.errno]
-            message = (_('Failed to rename backend file %(volume_file)s '
-                         'to %(backup_file)s before converting volume '
-                         '%(volume)s: %(error)s')
-                       % {'volume_file': volume_file,
-                          'backup_file': backup_file,
-                          'volume': volume['name'],
-                          'error': error.strerror})
-            raise jsonrpc.NefException(code=code, message=message)
-        try:
-            self._execute('qemu-img', 'convert',
-                          '-f', src_format,
-                          '-O', dst_format,
-                          backup_file,
-                          volume_file,
-                          run_as_root=self._execute_as_root)
-        except OSError as error:
-            code = errno.errorcode[error.errno]
-            message = (_('Failed to convert %(src_format)s file '
-                         '%(backup_file)s to %(dst_format)s file '
-                         '%(volume_file)s for volume %(volume)s: %(error)s')
-                       % {'src_format': src_format,
-                          'backup_file': backup_file,
-                          'dst_format': dst_format,
-                          'volume_file': volume_file,
-                          'volume': volume['name'],
-                          'error': error.strerror})
-            raise jsonrpc.NefException(code=code, message=message)
-        try:
-            self._execute('rm', '-f', backup_file,
-                          run_as_root=self._execute_as_root)
-        except OSError as error:
-            code = errno.errorcode[error.errno]
-            message = (_('Failed to delete %(src_format)s backup '
-                         'file %(backup_file)s after converting '
-                         'volume %(volume)s: %(error)s')
-                       % {'src_format': src_format,
-                          'backup_file': backup_file,
-                          'volume': volume['name'],
-                          'error': error.strerror})
-            raise jsonrpc.NefException(code=code, message=message)
-        LOG.debug('Successfully converted volume %(volume)s from '
-                  '%(src_format)s to %(dst_format)s format',
-                  {'volume': volume['name'],
-                   'src_format': src_format,
-                   'dst_format': dst_format})
+    def _create_volume(self, volume):
+        volume_path = self._get_volume_path(volume)
+        payload = self._get_volume_specs(volume)
+        payload['path'] = volume_path
+        self.nef.filesystems.create(payload)
+        self._set_volume_acl(volume)
+        return volume_path
 
-    @coordination.synchronized('{self.nef.lock}')
     def create_volume(self, volume):
         """Creates a volume.
 
         :param volume: volume reference
         """
-        volume_path = self._get_volume_path(volume)
-        volume_size = volume['size'] * units.Gi
-        properties = self.nef.filesystems.properties
-        payload = self._get_vendor_properties(properties, volume)
-        sparse_volume = payload.pop('sparseVolume')
-        volume_format = payload.pop('volumeFormat')
-        volume_vsolution = payload.pop('vSolution')
-        payload['path'] = volume_path
-        self.nef.filesystems.create(payload)
-        if not sparse_volume:
-            self._set_volume_reservation(volume, volume_size, volume_format)
-        self._set_volume_acl(volume)
-        payload = {'size': volume_size}
-        if volume_vsolution and volume_format == VOLUME_FORMAT_RAW:
+        volume_path = self._create_volume(volume)
+        specs = self._get_image_specs(volume)
+        file_size = volume['size'] * units.Gi
+        file_format = specs['format']
+        file_sparse = specs['sparse']
+        file_vsolution = specs['vsolution']
+        if not file_sparse:
+            self._set_volume_reservation(volume, file_size, file_format)
+        payload = {'size': file_size}
+        if file_vsolution and file_format == image.FORMAT_RAW:
             if self.nas_secure_file_permissions:
                 payload['mode'] = '660'
-            self.nef.vsolutions.create(volume_path, VOLUME_FILE_NAME, payload)
+            self.nef.vsolutions.create(volume_path, image.FILE_NAME, payload)
         else:
-            nfs_share, mount_point, volume_file = self._mount_volume(volume)
-            if volume_format == VOLUME_FORMAT_QCOW2:
-                payload['preallocation'] = 'metadata'
-            volume_options = ','.join(['%s=%s' % _ for _ in payload.items()])
-            self._execute('qemu-img', 'create',
-                          '-f', volume_format,
-                          '-o', volume_options,
-                          volume_file,
-                          run_as_root=self._execute_as_root)
-            self._unmount_volume(volume, nfs_share, mount_point)
+            volume_image = image.VolumeImage(self, volume, specs)
+            volume_image.create()
 
     @coordination.synchronized('{self.nef.lock}-{volume[id]}')
     def copy_image_to_volume(self, ctxt, volume, image_service, image_id):
-        nfs_share, mount_point, volume_file = self._mount_volume(volume)
-        volume_info = self._get_image_info(volume_file)
-        volume_format = volume_info.file_format
-        volume_blocksize = self.configuration.volume_dd_blocksize
+        specs = self._get_image_specs(volume)
         LOG.debug('Copy image %(image)s to %(format)s volume %(volume)s',
-                  {'image': image_id,
-                   'format': volume_format,
+                  {'image': image_id, 'format': specs['format'],
                    'volume': volume['name']})
-        if volume_format not in [VOLUME_FORMAT_RAW, VOLUME_FORMAT_QCOW2]:
-            volume_format = VOLUME_FORMAT_RAW
-        image_utils.fetch_to_volume_format(ctxt, image_service, image_id,
-                                           volume_file, volume_format,
-                                           volume_blocksize,
-                                           run_as_root=self._execute_as_root)
-        image_utils.resize_image(volume_file, volume['size'],
-                                 run_as_root=self._execute_as_root)
-        if volume_format not in [VOLUME_FORMAT_RAW, VOLUME_FORMAT_QCOW2]:
-            volume_new_format = volume_info.file_format
-            self._change_volume_format(volume, volume_file, volume_format,
-                                       volume_new_format)
-        self._unmount_volume(volume, nfs_share, mount_point)
+        volume_image = image.VolumeImage(self, volume, specs)
+        volume_image.download(ctxt, image_service, image_id)
 
-    def _verify_cache_image(self, ctxt, volume, image_meta, image_service):
-        properties = self.nef.filesystems.properties
-        volume_type_specs = self._get_vendor_properties(properties, volume)
-        volume_format = volume_type_specs['volumeFormat']
-        image_id = image_meta['id']
-        image_checksum = image_meta['checksum']
-        namespace = uuid.UUID(image_id, version=4)
-        name = '%s:%s' % (image_checksum, volume_format)
-        name = nexenta_utils.native_string(name)
-        cache_uuid = uuid.uuid5(namespace, name)
-        cache_id = six.text_type(cache_uuid)
-        cache = {
-            'id': cache_id,
-            'name': self.cache_image_template % cache_id,
-            'volume_type_id': volume['volume_type_id']
-        }
-        cache_path = self._get_volume_path(cache)
-        payload = {'fields': 'readOnly'}
-        cache_exist = False
+    @coordination.synchronized('{self.nef.lock}-{image_meta[id]}')
+    def copy_volume_to_image(self, ctxt, volume, image_service, image_meta):
+        specs = self._get_image_specs(volume)
+        LOG.debug('Copy %(format)s volume %(volume)s to image %(image)s',
+                  {'format': specs['format'], 'volume': volume['name'],
+                   'image': image_meta['id']})
+        volume_image = image.VolumeImage(self, volume, specs)
+        volume_image.reload(file_format=True)
+        volume_image.upload(ctxt, image_service, image_meta)
+
+    @coordination.synchronized('{self.nef.lock}-{cache_name}')
+    def _delete_cache(self, cache_name, cache_path, snapshot_path):
+        """Delete a image cache.
+
+        :param cache_name: cache volume name
+        :param cache_path: cache volume path
+        :param snapshot_path: cache snapshot path
+        """
+        payload = {'fields': 'clones'}
         try:
-            cache_specs = self.nef.filesystems.get(cache_path, payload)
-            if not cache_specs['readOnly']:
-                self.delete_volume(cache)
-            else:
-                cache_exist = True
+            props = self.nef.snapshots.get(snapshot_path, payload)
         except jsonrpc.NefException as error:
-            if error.code != 'ENOENT':
-                raise
-        if not cache_exist:
-            with image_utils.TemporaryImages.fetch(image_service, ctxt,
-                                                   image_id) as image_file:
-                image_info = self._get_image_info(image_file)
-        else:
-            nfs_share, mount_point, cache_file = self._mount_volume(cache)
-            image_info = self._get_image_info(cache_file)
-            self._unmount_volume(cache, nfs_share, mount_point)
-        image_size = nexenta_utils.roundup(image_info.virtual_size, units.Gi)
-        cache['size'] = image_size // units.Gi
-        if cache['size'] > volume['size']:
-            code = 'ENOSPC'
-            message = (_('Unable to clone cache %(cache)s '
-                         'to volume %(volume)s: cache size '
-                         '%(cache_size)sGB is larger than '
-                         'volume size %(volume_size)sGB')
-                       % {'cache': cache['name'],
-                          'volume': volume['name'],
-                          'cache_size': cache['size'],
-                          'volume_size': volume['size']})
-            raise jsonrpc.NefException(code=code, message=message)
-        if not cache_exist:
-            self.create_volume(cache)
-            self.copy_image_to_volume(ctxt, cache, image_service, image_id)
-            payload = {'readOnly': True}
-            self.nef.filesystems.set(cache_path, payload)
-        return cache
+            LOG.error('Failed to get clones of image cache '
+                      '%(name)s: %(error)s',
+                      {'name': cache_name, 'error': error})
+            return
+        if props['clones']:
+            clones = props['clones']
+            count = len(clones)
+            LOG.debug('Image cache %(name)s is still in use, '
+                      '%(count)s clone(s) was found: %(clones)s',
+                      {'name': cache_name, 'count': count,
+                       'clones': clones})
+            return
+        payload = {'snapshots': True, 'force': True}
+        try:
+            self.nef.filesystems.delete(cache_path, payload)
+        except jsonrpc.NefException as error:
+            LOG.error('Failed to delete image cache %(name)s: %(error)s',
+                      {'name': cache_name, 'error': error})
 
-    def _verify_cache_snapshot(self, cache):
-        snapshot = {
-            'id': cache['id'],
-            'name': self.cache_snapshot_template % cache['id'],
-            'volume_id': cache['id'],
-            'volume_name': cache['name'],
-            'volume_size': cache['size']
-        }
+    def _verify_cache(self, cache, snapshot):
+        cache_path = self._get_volume_path(cache)
+        payload = {'fields': 'referencedReservationSize'}
+        try:
+            props = self.nef.filesystems.get(cache_path, payload)
+        except jsonrpc.NefException as error:
+            if error.code == 'ENOENT':
+                return cache, snapshot
+            raise
+        cache_size = props['referencedReservationSize']
+        cache['size'] = utils.roundgb(cache_size)
         snapshot_path = self._get_snapshot_path(snapshot)
         payload = {'fields': 'path'}
         try:
             self.nef.snapshots.get(snapshot_path, payload)
         except jsonrpc.NefException as error:
-            if error.code != 'ENOENT':
-                raise
-            self.create_snapshot(snapshot)
+            if error.code == 'ENOENT':
+                return cache, snapshot
+            raise
+        snapshot['volume_size'] = cache['size']
+        return cache, snapshot
+
+    @coordination.synchronized('{self.nef.lock}-{cache[name]}')
+    def _create_cache(self, ctxt, cache, image_id, image_service):
+        snapshot = {
+            'id': cache['id'],
+            'name': self.cache_snapshot_template % cache['id'],
+            'volume_id': cache['id'],
+            'volume_name': cache['name']
+        }
+        cache, snapshot = self._verify_cache(cache, snapshot)
+        if snapshot.get('volume_size', 0) > 0:
+            return snapshot
+        if 'size' in cache:
+            self.delete_volume(cache)
+        cache['size'] = 0
+        cache_path = self._create_volume(cache)
+        specs = self._get_image_specs(cache)
+        volume_image = image.VolumeImage(self, cache, specs)
+        volume_image.fetch(ctxt, image_service, image_id)
+        payload = {'referencedReservationSize': volume_image.file_size}
+        self.nef.filesystems.set(cache_path, payload)
+        cache['size'] = volume_image.volume_size
+        snapshot['volume_size'] = cache['size']
+        self.create_snapshot(snapshot)
         return snapshot
 
-    @coordination.synchronized('{self.nef.lock}-{image_meta[id]}')
     def clone_image(self, ctxt, volume, image_location, image_meta,
                     image_service):
         """Create a volume efficiently from an existing image.
@@ -678,132 +660,124 @@ class NexentaNfsDriver(nfs.NfsDriver):
         """
         if not self.image_cache:
             return None, False
+        specs = self._get_image_specs(volume)
+        compound = '%(checksum)s:%(format)s' % {
+            'checksum': image_meta['checksum'],
+            'format': specs['format']
+        }
+        image_id = image_meta['id']
+        namespace = uuid.UUID(image_id, version=4)
+        name = utils.native_string(compound)
+        cache_uuid = uuid.uuid5(namespace, name)
+        cache_id = six.text_type(cache_uuid)
+        cache_name = self.cache_image_template % cache_id
+        cache_type_id = volume['volume_type_id']
+        cache = {
+            'id': cache_id,
+            'name': cache_name,
+            'volume_type_id': cache_type_id
+        }
+
         try:
-            cache = self._verify_cache_image(ctxt, volume,
-                                             image_meta,
-                                             image_service)
-            snapshot = self._verify_cache_snapshot(cache)
-            self.create_volume_from_snapshot(volume, snapshot)
-        except jsonrpc.NefException as error:
-            LOG.error('Failed to clone image %(image)s '
-                      'to volume %(volume)s: %(error)s',
-                      {'image': image_meta['id'],
-                       'volume': volume['name'],
+            snapshot = self._create_cache(ctxt, cache,
+                                          image_id,
+                                          image_service)
+        except Exception as error:
+            LOG.error('Failed to create cache %(cache)s '
+                      'for image %(image)s: %(error)s',
+                      {'cache': cache_name,
+                       'image': image_id,
                        'error': error})
+            return None, False
+
+        if snapshot['volume_size'] > volume['size']:
+            code = 'ENOSPC'
+            message = (_('Unable to clone cache %(cache)s for '
+                         'image %(image)s to volume %(volume)s: '
+                         'cache size %(cache_size)sGB is larger '
+                         'than volume size %(volume_size)sGB')
+                       % {'cache': cache_name, 'image': image_id,
+                          'volume': volume['name'],
+                          'cache_size': snapshot['volume_size'],
+                          'volume_size': volume['size']})
+            raise jsonrpc.NefException(code=code, message=message)
+
+        try:
+            self.create_volume_from_snapshot(volume, snapshot)
+        except Exception as error:
+            LOG.error('Failed to clone cache %(cache)s for image '
+                      '%(image)s to volume %(volume)s: %(error)s',
+                      {'cache': cache['name'], 'image': image_id,
+                       'volume': volume['name'], 'error': error})
             return None, False
         return None, True
 
-    @coordination.synchronized('{self.nef.lock}-{image_meta[id]}')
-    def copy_volume_to_image(self, ctxt, volume, image_service, image_meta):
-        nfs_share, mount_point, volume_file = self._mount_volume(volume)
-        volume_info = self._get_image_info(volume_file)
-        volume_format = volume_info.file_format
-        LOG.debug('Copy %(format)s volume %(volume)s to image %(image)s',
-                  {'format': volume_format,
-                   'volume': volume['name'],
-                   'image': image_meta['id']})
-        image_utils.upload_volume(
-            ctxt, image_service,
-            image_meta, volume_file,
-            volume_format=volume_format,
-            run_as_root=self._execute_as_root)
-        self._unmount_volume(volume, nfs_share, mount_point)
+    def _mount_share(self, share):
+        """Ensure that share is mounted on the host.
 
-    def _mount_volume(self, volume):
-        """Ensure that volume is mounted on the host.
-
-        :param volume: volume reference
-        :returns: NFS share, mount point and local volume file path
+        :param share: nfs share
+        :returns: mount point
         """
-        nfs_share = self._get_volume_share(volume)
         attempts = max(1, self.configuration.nfs_mount_attempts)
         for attempt in range(1, attempts + 1):
             try:
-                self._remotefsclient.mount(nfs_share)
-            except OSError as error:
+                self._remotefsclient.mount(share)
+            except Exception as error:
                 if attempt == attempts:
-                    LOG.error('Failed to mount NFS share %(nfs_share)s '
+                    LOG.error('Failed to mount NFS share %(share)s '
                               'after %(attempts)s attempts: %(error)s',
-                              {'nfs_share': nfs_share,
-                               'attempts': attempts,
+                              {'share': share, 'attempts': attempts,
                                'error': error})
                     raise
                 LOG.debug('Mount attempt %(attempt)s failed: %(error)s, '
-                          'retrying mount NFS share %(nfs_share)s',
-                          {'attempt': attempt,
-                           'error': error,
-                           'nfs_share': nfs_share})
+                          'retrying mount NFS share %(share)s',
+                          {'attempt': attempt, 'error': error,
+                           'share': share})
                 self.nef.delay(attempt)
             else:
-                LOG.debug('NFS share %(nfs_share)s has '
-                          'been successfully mounted',
-                          {'nfs_share': nfs_share})
+                LOG.debug('NFS share %(share)s has been mounted',
+                          {'share': share})
                 break
-        mount_point = self._get_mount_point_for_share(nfs_share)
-        volume_file = os.path.join(mount_point, VOLUME_FILE_NAME)
-        return nfs_share, mount_point, volume_file
+        mntpoint = self._get_mount_point_for_share(share)
+        return mntpoint
 
-    def _remount_volume(self, volume):
-        """Workaround for NEX-16457."""
-        volume_path = self._get_volume_path(volume)
-        self.nef.filesystems.unmount(volume_path)
-        self.nef.filesystems.mount(volume_path)
-
-    def _unmount_volume(self, volume, nfs_share=None, mount_point=None):
+    def _unmount_share(self, share, mntpoint=None):
         """Ensure that NFS share is unmounted on the host.
 
-        :param volume: volume reference
-        :param nfs_share: NFS share
-        :param mount_point: mount point
+        :param share: nfs share
+        :param mntpoint: mount point
         """
-        if nfs_share is None:
-            try:
-                nfs_share = self._get_volume_share(volume)
-            except jsonrpc.NefException:
-                nas_path = posixpath.join(
-                    self.nas_stat['mountPoint'],
-                    volume['name'])
-                nfs_share = '%(host)s:%(path)s' % {
-                    'host': self.nas_host,
-                    'path': nas_path
-                }
-        if mount_point is None:
-            mount_point = self._get_mount_point_for_share(nfs_share)
-        if mount_point not in self._remotefsclient._read_mounts():
-            LOG.debug('NFS share %(nfs_share)s is not mounted '
-                      'at mount point %(mount_point)s',
-                      {'nfs_share': nfs_share,
-                       'mount_point': mount_point})
+        if not mntpoint:
+            mntpoint = self._get_mount_point_for_share(share)
+        if mntpoint not in self._remotefsclient._read_mounts():
+            LOG.debug('NFS share %(share)s is not mounted to '
+                      'mount point %(mntpoint)s',
+                      {'share': share, 'mntpoint': mntpoint})
             return
         attempts = max(1, self.configuration.nfs_mount_attempts)
         for attempt in range(1, attempts + 1):
             try:
-                fs.umount(mount_point)
+                fs.umount(mntpoint)
             except OSError as error:
                 if attempt == attempts:
-                    LOG.error('Failed to unmount NFS share %(nfs_share)s '
-                              'from mount point %(mount_point)s after '
+                    LOG.error('Failed to unmount NFS share %(share)s '
+                              'from mount point %(mntpoint)s after '
                               '%(attempts)s attempts: %(error)s',
-                              {'nfs_share': nfs_share,
-                               'mount_point': mount_point,
-                               'attempts': attempts,
-                               'error': error})
+                              {'share': share, 'mntpoint': mntpoint,
+                               'attempts': attempts, 'error': error})
                     raise
                 LOG.debug('Unmount attempt %(attempt)s failed: %(error)s, '
-                          'retrying unmount NFS share %(nfs_share)s from '
-                          'mount point %(mount_point)s',
-                          {'attempt': attempt,
-                           'error': error,
-                           'nfs_share': nfs_share,
-                           'mount_point': mount_point})
+                          'retrying unmount NFS share %(share)s from '
+                          'mount point %(mntpoint)s',
+                          {'attempt': attempt, 'error': error,
+                           'share': share, 'mntpoint': mntpoint})
                 self.nef.delay(attempt)
             else:
-                LOG.debug('NFS share %(nfs_share)s has been successfully '
-                          'unmounted from mount point %(mount_point)s',
-                          {'nfs_share': nfs_share,
-                           'mount_point': mount_point})
+                LOG.debug('NFS share %(share)s has been successfully '
+                          'unmounted from mount point %(mntpoint)s',
+                          {'share': share, 'mntpoint': mntpoint})
                 break
-        self._delete(mount_point)
+        self._delete(mntpoint)
 
     def _migrate_volume(self, volume, scheme, hosts, port, path):
         """Storage assisted volume migration."""
@@ -1071,9 +1045,9 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param connector: a connector object
         :returns: dictionary of connection information
         """
-        LOG.debug('Terminate volume connection for %(volume)s',
-                  {'volume': volume['name']})
-        self._unmount_volume(volume)
+        if not self.nas_nohide:
+            share = os.path.join(self.nas_share, volume['name'])
+            self._unmount_share(share)
 
     def initialize_connection(self, volume, connector):
         """Terminate a connection to a volume.
@@ -1086,31 +1060,13 @@ class NexentaNfsDriver(nfs.NfsDriver):
                   'and connector %(connector)s',
                   {'volume': volume['name'],
                    'connector': connector})
-        volume_path = self._get_volume_path(volume)
-        payload = {
-            'fields': 'nonBlockingMandatoryMode,source',
-            'source': True
-        }
-        volume_specs = self.nef.filesystems.get(volume_path, payload)
-        if volume_specs['nonBlockingMandatoryMode'] != self.nbmand:
-            payload = {'nonBlockingMandatoryMode': self.nbmand}
-            if 'source' in volume_specs:
-                source = volume_specs['source']
-                value = source['nonBlockingMandatoryMode']
-                if value == 'inherited':
-                    self.nef.filesystems.set(self.nas_path, payload)
-                elif value in ['local', 'received']:
-                    self.nef.filesystems.set(volume_path, payload)
-            else:
-                self.nef.filesystems.set(volume_path, payload)
-            self._remount_volume(volume)
-        nfs_share, mount_point, volume_file = self._mount_volume(volume)
-        volume_info = self._get_image_info(volume_file)
-        self._unmount_volume(volume, nfs_share, mount_point)
+        specs = self._get_image_specs(volume)
+        volume_image = image.VolumeImage(self, volume, specs)
+        volume_image.reload(file_format=True)
         data = {
-            'export': nfs_share,
-            'format': volume_info.file_format,
-            'name': VOLUME_FILE_NAME
+            'export': volume_image.share,
+            'format': volume_image.file_format,
+            'name': volume_image.file_name
         }
         if self.mount_options:
             data['options'] = '-o %s' % self.mount_options
@@ -1121,76 +1077,97 @@ class NexentaNfsDriver(nfs.NfsDriver):
         }
         return connection_info
 
-    @coordination.synchronized('{self.nef.lock}')
+    def _demote_volume(self, volume, volume_origin):
+        """Demote a volume.
+
+        :param volume: volume reference
+        :param volume_origin: volume origin path
+        """
+        volume_path = self._get_volume_path(volume)
+        payload = {'parent': volume_path, 'fields': 'path'}
+        try:
+            snapshots = self.nef.snapshots.list(payload)
+        except jsonrpc.NefException as error:
+            if error.code == 'ENOENT':
+                return volume_origin
+            raise
+        origin_txg = 0
+        origin_path = None
+        clone_path = None
+        for snapshot in snapshots:
+            snapshot_path = snapshot['path']
+            payload = {'fields': 'clones,creationTxg'}
+            try:
+                props = self.nef.snapshots.get(snapshot_path, payload)
+            except jsonrpc.NefException as error:
+                if error.code == 'ENOENT':
+                    continue
+                raise
+            snapshot_clones = props['clones']
+            # Workaround for NEX-22763
+            snapshot_txg = int(props['creationTxg'])
+            if snapshot_clones and snapshot_txg > origin_txg:
+                clone_path = snapshot_clones[0]
+                origin_txg = snapshot_txg
+                origin_path = snapshot_path
+        if clone_path:
+            try:
+                self.nef.filesystems.promote(clone_path)
+            except jsonrpc.NefException as error:
+                if error.code in ['ENOENT', 'EBADARG']:
+                    return volume_origin
+                raise
+            return origin_path
+        return volume_origin
+
     def delete_volume(self, volume):
         """Deletes a volume.
 
         :param volume: volume reference
         """
-        self._unmount_volume(volume)
         volume_path = self._get_volume_path(volume)
         payload = {'fields': 'originalSnapshot'}
         try:
-            volume_spec = self.nef.filesystems.get(volume_path, payload)
+            props = self.nef.filesystems.get(volume_path, payload)
         except jsonrpc.NefException as error:
             if error.code == 'ENOENT':
                 return
             raise
-        volume_origin = volume_spec['originalSnapshot']
-        payload = {'force': True, 'snapshots': True}
-        try:
-            self.nef.filesystems.delete(volume_path, payload)
-        except jsonrpc.NefException as error:
-            if error.code != 'EEXIST':
+        volume_exist = True
+        origin = props['originalSnapshot']
+        payload = {'snapshots': True, 'force': True}
+        while volume_exist:
+            try:
+                self.nef.filesystems.delete(volume_path, payload)
+            except jsonrpc.NefException as error:
+                if error.code == 'EEXIST':
+                    origin = self._demote_volume(volume, origin)
+                    continue
                 raise
-            snapshot_tree = {}
-            payload = {'parent': volume_path, 'fields': 'path'}
-            snapshots = self.nef.snapshots.list(payload)
-            for snapshot in snapshots:
-                snapshot_path = snapshot['path']
-                payload = {'fields': 'clones,creationTxg'}
-                snapshot_spec = self.nef.snapshots.get(snapshot_path, payload)
-                if snapshot_spec['clones']:
-                    snapshot_txg = snapshot_spec['creationTxg']
-                    snapshot_clones = snapshot_spec['clones']
-                    first_clone = snapshot_clones[0]
-                    snapshot_tree[snapshot_txg] = first_clone
-            if snapshot_tree:
-                latest_txg = max(snapshot_tree)
-                clone_path = snapshot_tree[latest_txg]
-                self.nef.filesystems.promote(clone_path)
-            payload = {'force': True, 'snapshots': True}
-            self.nef.filesystems.delete(volume_path, payload)
-        if not volume_origin:
+            volume_exist = False
+        if not origin:
             return
-        origin_path, snapshot_name = volume_origin.split('@')
+        origin_path, snapshot_name = origin.split('@')
         origin_name = posixpath.basename(origin_path)
-        if nexenta_utils.match_template(self.origin_snapshot_template,
-                                        snapshot_name):
-            payload = {'defer': True}
-            try:
-                self.nef.snapshots.delete(volume_origin, payload)
-            except Exception:
-                pass
-        elif (nexenta_utils.match_template(self.cache_snapshot_template,
-                                           snapshot_name) and
-              nexenta_utils.match_template(self.cache_image_template,
-                                           origin_name)):
-            payload = {'force': True, 'snapshots': True}
-            try:
-                self.nef.filesystems.delete(origin_path, payload)
-            except Exception:
-                pass
+        templates = {
+            self.cache_snapshot_template: snapshot_name,
+            self.cache_image_template: origin_name
+        }
+        for item, name in templates.items():
+            if not utils.match_template(item, name):
+                return
+        self._delete_cache(origin_name, origin_path, origin)
 
-    def _delete(self, path):
-        """Override parent method for safe remove mountpoint."""
+    def _delete(self, mntpoint):
+        """Override parent method for safe remove mount point."""
         try:
-            self._execute('rm', '-d', path, run_as_root=self._execute_as_root)
-            LOG.debug('The mountpoint %(path)s has been successfully removed',
-                      {'path': path})
+            self._execute('rm', '-d', mntpoint,
+                          run_as_root=self._execute_as_root)
+            LOG.debug('The mount point %(mntpoint)s has been removed',
+                      {'mntpoint': mntpoint})
         except OSError as error:
-            LOG.error('Failed to remove mountpoint %(path)s: %(error)s',
-                      {'path': path, 'error': error.strerror})
+            LOG.error('Failed to remove mount point %(mntpoint)s: %(error)s',
+                      {'mntpoint': mntpoint, 'error': error.strerror})
 
     def extend_volume(self, volume, new_size):
         """Extend an existing volume.
@@ -1198,22 +1175,22 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param volume: volume reference
         :param new_size: volume new size in GB
         """
-        LOG.info('Extend volume %(volume)s, new size: %(size)sGB',
-                 {'volume': volume['name'], 'size': new_size})
-        properties = self.nef.filesystems.properties
-        payload = self._get_vendor_properties(properties, volume)
-        sparse_volume = payload.pop('sparseVolume')
-        nfs_share, mount_point, volume_file = self._mount_volume(volume)
-        if not sparse_volume:
-            volume_info = self._get_image_info(volume_file)
-            volume_size = new_size * units.Gi
-            volume_format = volume_info.file_format
-            self._set_volume_reservation(volume, volume_size, volume_format)
-        image_utils.resize_image(volume_file, new_size,
-                                 run_as_root=self._execute_as_root)
-        self._unmount_volume(volume, nfs_share, mount_point)
+        specs = self._get_image_specs(volume)
+        file_sparse = specs['sparse']
+        file_vsolution = specs['vsolution']
+        volume_image = image.VolumeImage(self, volume, specs)
+        volume_image.reload(file_size=True, file_format=True)
+        file_size = new_size * units.Gi
+        file_format = volume_image.file_format
+        if not file_sparse:
+            self._set_volume_reservation(volume, file_size, file_format)
+        if file_vsolution and file_format == image.FORMAT_RAW:
+            volume_path = self._get_volume_path(volume)
+            payload = {'size': file_size}
+            self.nef.vsolutions.resize(volume_path, image.FILE_NAME, payload)
+        else:
+            volume_image.change(file_size=file_size)
 
-    @coordination.synchronized('{self.nef.lock}')
     def create_snapshot(self, snapshot):
         """Creates a snapshot.
 
@@ -1223,7 +1200,6 @@ class NexentaNfsDriver(nfs.NfsDriver):
         payload = {'path': snapshot_path}
         self.nef.snapshots.create(payload)
 
-    @coordination.synchronized('{self.nef.lock}')
     def delete_snapshot(self, snapshot):
         """Deletes a snapshot.
 
@@ -1241,29 +1217,34 @@ class NexentaNfsDriver(nfs.NfsDriver):
         return False
 
     def revert_to_snapshot(self, ctxt, volume, snapshot):
-        """Revert volume to snapshot."""
-        volume_path = self._get_volume_path(volume)
-        payload = {'snapshot': snapshot['name']}
-        self.nef.filesystems.rollback(volume_path, payload)
+        """Revert a volume to a snapshot.
 
-    @coordination.synchronized('{self.nef.lock}')
+        Note: the revert process should not change the volume's
+        current size, that means if the driver shrank
+        the volume during the process, it should extend the
+        volume internally.
+        """
+        volume_path = self._get_volume_path(volume)
+        snapshot_name = snapshot['name']
+        payload = {'snapshot': snapshot_name}
+        self.nef.filesystems.rollback(volume_path, payload)
+        self._update_volume_props(volume)
+
     def create_volume_from_snapshot(self, volume, snapshot):
         """Create new volume from other's snapshot on appliance.
 
         :param volume: reference of volume to be created
         :param snapshot: reference of source snapshot
         """
-        LOG.debug('Create volume %(volume)s from snapshot %(snapshot)s',
-                  {'volume': volume['name'], 'snapshot': snapshot['name']})
         volume_path = self._get_volume_path(volume)
         snapshot_path = self._get_snapshot_path(snapshot)
         payload = {'targetPath': volume_path}
         self.nef.snapshots.clone(snapshot_path, payload)
-        self._remount_volume(volume)
-        self._set_volume_acl(volume)
-        if volume['size'] > snapshot['volume_size']:
-            self.extend_volume(volume, volume['size'])
-        self._update_volume_properties(volume)
+        # Workaround for NEX-16457
+        if self.nef.version_less('5.2.0.17'):
+            self.nef.filesystems.unmount(volume_path)
+            self.nef.filesystems.mount(volume_path)
+        self._update_volume_props(volume)
 
     def create_cloned_volume(self, volume, src_vref):
         """Creates a clone of the specified volume.
@@ -1280,22 +1261,8 @@ class NexentaNfsDriver(nfs.NfsDriver):
         self.create_snapshot(snapshot)
         try:
             self.create_volume_from_snapshot(volume, snapshot)
-        except jsonrpc.NefException as error:
-            LOG.error('Failed to create clone %(clone)s '
-                      'from volume %(volume)s: %(error)s',
-                      {'clone': volume['name'],
-                       'volume': src_vref['name'],
-                       'error': error})
-            raise
         finally:
-            try:
-                self.delete_snapshot(snapshot)
-            except jsonrpc.NefException as error:
-                LOG.error('Failed to delete temporary snapshot '
-                          '%(volume)s@%(snapshot)s: %(error)s',
-                          {'volume': src_vref['name'],
-                           'snapshot': snapshot['name'],
-                           'error': error})
+            self.delete_snapshot(snapshot)
 
     def create_consistencygroup(self, ctxt, group):
         """Creates a consistency group.
@@ -1477,19 +1444,9 @@ class NexentaNfsDriver(nfs.NfsDriver):
         :param source_vols: a list of volume objects in the source_group.
         :returns: model_update, volumes_model_update
         """
-        return self.create_consistencygroup_from_src(ctxt, group, volumes,
-                                                     group_snapshot, snapshots,
-                                                     source_group, source_vols)
-
-    def local_path(self, volume):
-        """Get volume path (mounted locally fs path) for given volume.
-
-        :param volume: volume reference
-        """
-        nfs_share = self._get_volume_share(volume)
-        mount_point = self._get_mount_point_for_share(nfs_share)
-        volume_file = os.path.join(mount_point, VOLUME_FILE_NAME)
-        return volume_file
+        return self.create_consistencygroup_from_src(
+            ctxt, group, volumes, group_snapshot,
+            snapshots, source_group, source_vols)
 
     def _set_volume_acl(self, volume):
         """Sets access permissions for given volume.
@@ -1510,26 +1467,32 @@ class NexentaNfsDriver(nfs.NfsDriver):
         }
         self.nef.filesystems.acl(volume_path, payload)
 
-    def _get_image_info(self, image_path):
-        """Return an object from qemu-img info."""
-        info = image_utils.qemu_img_info(
-            image_path, force_share=True,
-            run_as_root=self._execute_as_root)
-        return info
-
     def _get_volume_share(self, volume):
         """Return NFS share path for the volume."""
+        specs = self._get_volume_specs(volume)
         volume_path = self._get_volume_path(volume)
-        get_payload = {'fields': 'mountPoint,isMounted'}
-        filesystem = self.nef.filesystems.get(volume_path, get_payload)
-        if filesystem['mountPoint'] == 'none':
-            activate_payload = {'datasetName': volume_path}
-            self.nef.hpr.activate(activate_payload)
-            filesystem = self.nef.filesystems.get(volume_path, get_payload)
-        if not filesystem['isMounted']:
+        payload = {'fields': 'isMounted,mountPoint,nonBlockingMandatoryMode'}
+        props = self.nef.filesystems.get(volume_path, payload)
+        nbmand = specs.get('nonBlockingMandatoryMode', self.nbmand)
+        if props['nonBlockingMandatoryMode'] != nbmand:
+            payload = {'nonBlockingMandatoryMode': nbmand}
+            self.nef.filesystems.set(volume_path, payload)
+            if props['isMounted']:
+                self.nef.filesystems.unmount(volume_path)
+                props['isMounted'] = False
+        if props['mountPoint'] == 'none':
+            self.nef.hpr.activate(volume_path)
+            props = self.nef.filesystems.get(volume_path, payload)
+        if not props['isMounted']:
             self.nef.filesystems.mount(volume_path)
-        nfs_share = '%s:%s' % (self.nas_host, filesystem['mountPoint'])
-        return nfs_share
+        if self.nas_nohide:
+            share = self.nas_share
+        else:
+            share = '%(host)s:%(mntpoint)s' % {
+                'host': self.nas_host,
+                'mntpoint': props['mountPoint']
+            }
+        return share
 
     def _get_volume_path(self, volume):
         """Return ZFS dataset path for the volume."""
@@ -1542,7 +1505,10 @@ class NexentaNfsDriver(nfs.NfsDriver):
         volume_name = snapshot['volume_name']
         snapshot_name = snapshot['name']
         volume_path = posixpath.join(self.nas_path, volume_name)
-        snapshot_path = '%s@%s' % (volume_path, snapshot_name)
+        snapshot_path = '%(volume_path)s@%(snapshot_name)s' % {
+            'volume_path': volume_path,
+            'snapshot_name': snapshot_name
+        }
         return snapshot_path
 
     def get_volume_stats(self, refresh=False):
@@ -1557,12 +1523,11 @@ class NexentaNfsDriver(nfs.NfsDriver):
     def _update_volume_stats(self):
         """Retrieve stats info for NexentaStor Appliance."""
         provisioned_capacity_gb = total_volumes = total_snapshots = 0
-        ctxt = context.get_admin_context()
-        volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        volumes = objects.VolumeList.get_all_by_host(self.ctxt, self.host)
         for volume in volumes:
             provisioned_capacity_gb += volume['size']
             total_volumes += 1
-        snapshots = objects.SnapshotList.get_by_host(ctxt, self.host)
+        snapshots = objects.SnapshotList.get_by_host(self.ctxt, self.host)
         for snapshot in snapshots:
             provisioned_capacity_gb += snapshot['volume_size']
             total_snapshots += 1
@@ -1649,39 +1614,44 @@ class NexentaNfsDriver(nfs.NfsDriver):
             'source-guid': 'guid'
         }
         if not any(key in types for key in existing_ref):
+            code = 'EINVAL'
             keys = ', '.join(types.keys())
             message = (_('Manage existing volume failed '
                          'due to invalid backend reference. '
                          'Volume reference must contain '
                          'at least one valid key: %(keys)s')
                        % {'keys': keys})
-            raise jsonrpc.NefException(code='EINVAL', message=message)
+            raise jsonrpc.NefException(code=code, message=message)
         payload = {
             'parent': self.nas_path,
-            'fields': 'path',
+            'fields': 'path,bytesReferenced',
             'recursive': False
         }
         for key, value in types.items():
             if key in existing_ref:
-                if value == 'path':
-                    path = posixpath.join(self.nas_path,
-                                          existing_ref[key])
-                else:
-                    path = existing_ref[key]
-                payload[value] = path
+                payload[value] = existing_ref[key]
+        # Workaround for NEX-22773
+        if 'path' in payload:
+            name = payload['path']
+            path = posixpath.join(self.nas_path, name)
+            payload['path'] = path
         existing_volumes = self.nef.filesystems.list(payload)
         if len(existing_volumes) == 1:
+            refsize = existing_volumes[0]['bytesReferenced']
             volume_path = existing_volumes[0]['path']
             volume_name = posixpath.basename(volume_path)
+            volume_size = utils.roundgb(refsize)
             existing_volume = {
                 'name': volume_name,
-                'path': volume_path
+                'path': volume_path,
+                'size': volume_size
             }
             vid = volume_utils.extract_id_from_volume_name(volume_name)
             if volume_utils.check_already_managed_volume(vid):
+                code = 'EEXIST'
                 message = (_('Volume %(name)s already managed')
                            % {'name': volume_name})
-                raise jsonrpc.NefException(code='EBUSY', message=message)
+                raise jsonrpc.NefException(code=code, message=message)
             return existing_volume
         elif not existing_volumes:
             code = 'ENOENT'
@@ -1707,8 +1677,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
             uuid.UUID(snapshot_id, version=4)
         except ValueError:
             return False
-        ctxt = context.get_admin_context()
-        return objects.Snapshot.exists(ctxt, snapshot_id)
+        return objects.Snapshot.exists(self.ctxt, snapshot_id)
 
     def _get_existing_snapshot(self, snapshot, existing_ref):
         types = {
@@ -1717,12 +1686,13 @@ class NexentaNfsDriver(nfs.NfsDriver):
         }
         if not any(key in types for key in existing_ref):
             keys = ', '.join(types.keys())
+            code = 'EINVAL'
             message = (_('Manage existing snapshot failed '
                          'due to invalid backend reference. '
                          'Snapshot reference must contain '
                          'at least one valid key: %(keys)s')
                        % {'keys': keys})
-            raise jsonrpc.NefException(code='EINVAL', message=message)
+            raise jsonrpc.NefException(code=code, message=message)
         volume_name = snapshot['volume_name']
         volume_size = snapshot['volume_size']
         volume = {'name': volume_name}
@@ -1747,9 +1717,10 @@ class NexentaNfsDriver(nfs.NfsDriver):
             }
             sid = volume_utils.extract_id_from_snapshot_name(name)
             if self._check_already_managed_snapshot(sid):
+                code = 'EEXIST'
                 message = (_('Snapshot %(name)s already managed')
                            % {'name': name})
-                raise jsonrpc.NefException(code='EBUSY', message=message)
+                raise jsonrpc.NefException(code=code, message=message)
             return existing_snapshot
         elif not existing_snapshots:
             code = 'ENOENT'
@@ -1762,7 +1733,6 @@ class NexentaNfsDriver(nfs.NfsDriver):
                    % {'reference': existing_ref, 'reason': reason})
         raise jsonrpc.NefException(code=code, message=message)
 
-    @coordination.synchronized('{self.nef.lock}')
     def manage_existing(self, volume, existing_ref):
         """Brings an existing backend storage object under Cinder management.
 
@@ -1801,7 +1771,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
             volume_path = self._get_volume_path(volume)
             payload = {'newPath': volume_path}
             self.nef.filesystems.rename(existing_volume_path, payload)
-        self._update_volume_properties(volume)
+        self._update_volume_props(volume)
 
     def manage_existing_get_size(self, volume, existing_ref):
         """Return size of volume to be managed by manage_existing.
@@ -1815,26 +1785,10 @@ class NexentaNfsDriver(nfs.NfsDriver):
         """
         existing_volume = self._get_existing_volume(existing_ref)
         self._set_volume_acl(existing_volume)
-        nfs_share, mount_point, existing_volume_file = (
-            self._mount_volume(existing_volume))
-        try:
-            existing_volume_info = self._get_image_info(existing_volume_file)
-        except OSError as error:
-            code = errno.errorcode[error.errno]
-            message = (_('Manage existing volume %(volume)s failed, '
-                         'unable to get size of volume backend file '
-                         '%(volume_file)s: %(error)s')
-                       % {'volume': existing_volume['name'],
-                          'volume_file': existing_volume_file,
-                          'error': error.strerror})
-            raise jsonrpc.NefException(code=code, message=message)
-        finally:
-            self._unmount_volume(existing_volume, nfs_share, mount_point)
-        existing_volume_size = existing_volume_info.virtual_size // units.Gi
-        LOG.debug('Manage existing volume: %(volume)s size is %(size)sG',
-                  {'volume': existing_volume['name'],
-                   'size': existing_volume_size})
-        return existing_volume_size
+        specs = self._get_image_specs(existing_volume)
+        volume_image = image.VolumeImage(self, existing_volume, specs)
+        volume_image.reload(file_size=True)
+        return volume_image.volume_size
 
     def get_manageable_volumes(self, cinder_volumes, marker, limit, offset,
                                sort_keys, sort_dirs):
@@ -1873,7 +1827,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
             cinder_volume_names[key] = value
         payload = {
             'parent': self.nas_path,
-            'fields': 'guid,parent,path,bytesUsed',
+            'fields': 'name,guid,parent,path,bytesReferenced',
             'recursive': False
         }
         volumes = self.nef.filesystems.list(payload)
@@ -1885,15 +1839,14 @@ class NexentaNfsDriver(nfs.NfsDriver):
             path = volume['path']
             guid = volume['guid']
             parent = volume['parent']
-            size = volume['bytesUsed'] // units.Gi
-            name = posixpath.basename(path)
+            refsize = volume['bytesReferenced']
+            size = utils.roundgb(refsize)
+            name = volume['name']
             if path == self.nas_path:
                 continue
             if parent != self.nas_path:
                 continue
-            if nexenta_utils.match_template(self.cache_image_template, name):
-                LOG.debug('Skip image cache %(path)s',
-                          {'path': path})
+            if utils.match_template(self.cache_image_template, name):
                 continue
             if name in cinder_volume_names:
                 cinder_id = cinder_volume_names[name]
@@ -1911,9 +1864,9 @@ class NexentaNfsDriver(nfs.NfsDriver):
                 'cinder_id': cinder_id,
                 'extra_info': extra_info
             })
-        return volume_utils.paginate_entries_list(manageable_volumes,
-                                                  marker, limit, offset,
-                                                  sort_keys, sort_dirs)
+        return volume_utils.paginate_entries_list(
+            manageable_volumes, marker, limit,
+            offset, sort_keys, sort_dirs)
 
     def unmanage(self, volume):
         """Removes the specified volume from Cinder management.
@@ -1929,7 +1882,6 @@ class NexentaNfsDriver(nfs.NfsDriver):
         """
         pass
 
-    @coordination.synchronized('{self.nef.lock}')
     def manage_existing_snapshot(self, snapshot, existing_ref):
         """Brings an existing backend storage object under Cinder management.
 
@@ -2008,11 +1960,20 @@ class NexentaNfsDriver(nfs.NfsDriver):
                           sort_keys (valid directions are 'asc' and 'desc')
 
         """
+        temporary_snapshots = {
+            self.cache_snapshot_template: 'image cache',
+            self.origin_snapshot_template: 'temporary origin',
+            self.group_snapshot_template: 'temporary group'
+        }
+        service_snapshots = {
+            'hprService': 'replication',
+            'snaplistId': 'snapping'
+        }
         manageable_snapshots = []
         cinder_volume_names = {}
         cinder_snapshot_names = {}
-        ctxt = context.get_admin_context()
-        cinder_volumes = objects.VolumeList.get_all_by_host(ctxt, self.host)
+        cinder_volumes = objects.VolumeList.get_all_by_host(
+            self.ctxt, self.host)
         for cinder_volume in cinder_volumes:
             key = self._get_volume_path(cinder_volume)
             value = {
@@ -2048,25 +2009,16 @@ class NexentaNfsDriver(nfs.NfsDriver):
                           'volume %(parent)s is unmanaged',
                           {'path': path, 'parent': parent})
                 continue
-            if nexenta_utils.match_template(self.cache_snapshot_template,
-                                            name):
-                LOG.debug('Skip image cache snapshot %(path)s',
-                          {'path': path})
-                continue
-            if nexenta_utils.match_template(self.origin_snapshot_template,
-                                            name):
-                LOG.debug('Skip temporary origin snapshot %(path)s',
-                          {'path': path})
-                continue
-            if nexenta_utils.match_template(self.group_snapshot_template,
-                                            name):
-                LOG.debug('Skip temporary group snapshot %(path)s',
-                          {'path': path})
-                continue
-            if snapshot['hprService'] or snapshot['snaplistId']:
-                LOG.debug('Skip Replication/Snapping snapshot %(path)s',
-                          {'path': path})
-                continue
+            for item, desc in temporary_snapshots.items():
+                if utils.match_template(item, name):
+                    LOG.debug('Skip %(desc)s snapshot %(path)s',
+                              {'desc': desc, 'path': path})
+                    continue
+            for item, desc in service_snapshots.items():
+                if snapshot[item]:
+                    LOG.debug('Skip %(desc)s snapshot %(path)s',
+                              {'desc': desc, 'path': path})
+                    continue
             if name in cinder_snapshot_names:
                 size = cinder_snapshot_names[name]['size']
                 cinder_id = cinder_snapshot_names[name]['id']
@@ -2103,9 +2055,9 @@ class NexentaNfsDriver(nfs.NfsDriver):
                 'extra_info': extra_info,
                 'source_reference': source_reference
             })
-        return volume_utils.paginate_entries_list(manageable_snapshots,
-                                                  marker, limit, offset,
-                                                  sort_keys, sort_dirs)
+        return volume_utils.paginate_entries_list(
+            manageable_snapshots, marker, limit,
+            offset, sort_keys, sort_dirs)
 
     def unmanage_snapshot(self, snapshot):
         """Removes the specified snapshot from Cinder management.
@@ -2192,106 +2144,27 @@ class NexentaNfsDriver(nfs.NfsDriver):
         migration
         """
         connector_properties = cinder_utils.brick_get_connector_properties()
-        attach_info, dst_volume = self._attach_volume(ctxt, dst_volume,
-                                                      connector_properties,
-                                                      remote=True)
-        dst_volume_file = attach_info['device']['path']
-        dst_volume_info = self._get_image_info(dst_volume_file)
+        attach_info, dst_volume = self._attach_volume(
+            ctxt, dst_volume, connector_properties, remote=True)
+        dst_file_path = attach_info['device']['path']
+        dst_image = image_utils.qemu_img_info(
+            dst_file_path, force_share=True,
+            run_as_root=self._execute_as_root)
         self._detach_volume(ctxt, attach_info, dst_volume,
                             connector_properties, force=True)
-        src_nfs_share, src_mount_point, src_volume_file = (
-            self._mount_volume(src_volume))
-        src_volume_info = self._get_image_info(src_volume_file)
-        if src_volume_info.file_format != dst_volume_info.file_format:
-            self._change_volume_format(src_volume, src_volume_file,
-                                       src_volume_info.file_format,
-                                       dst_volume_info.file_format)
-        self._unmount_volume(src_volume, src_nfs_share, src_mount_point)
+        src_specs = self._get_image_specs(src_volume)
+        src_image = image.VolumeImage(self, src_volume, src_specs)
+        src_image.reload(file_format=True)
+        if src_image.file_format != dst_image.file_format:
+            src_image.change(file_format=dst_image.file_format)
 
     def retype(self, ctxt, volume, new_type, diff, host):
         """Retype from one volume type to another."""
-        LOG.debug('Retype volume %(volume)s to host %(host)s '
+        LOG.debug('Retype volume %(volume)s on host %(host)s '
                   'and volume type %(type)s with diff %(diff)s',
                   {'volume': volume['name'], 'host': host,
                    'type': new_type['name'], 'diff': diff})
-        volume_path = self._get_volume_path(volume)
-        vendor_specs = self.nef.filesystems.properties
-        names = [_['api'] for _ in vendor_specs if 'api' in _]
-        names.remove('sparseVolume')
-        names.remove('volumeFormat')
-        names.remove('vSolution')
-        names.append('source')
-        fields = ','.join(names)
-        payload = {'fields': fields, 'source': True}
-        volume_specs = self.nef.filesystems.get(volume_path, payload)
-        volume_type_specs = self._get_vendor_properties(vendor_specs,
-                                                        volume,
-                                                        new_type)
-        sparse_volume = volume_type_specs['sparseVolume']
-        volume_new_format = volume_type_specs['volumeFormat']
-        payload = {}
-        for vendor_spec in vendor_specs:
-            api = vendor_spec['api']
-            if api in volume_type_specs:
-                value = volume_type_specs[api]
-                if api in volume_specs:
-                    if volume_specs[api] == value:
-                        continue
-                if 'retype' in vendor_spec:
-                    code = 'EINVAL'
-                    message = (_('Failed to retype volume %(volume)s '
-                                 'to host %(host)s and volume type '
-                                 '%(type)s. %(reason)s')
-                               % {'volume': volume['name'],
-                                  'host': host,
-                                  'type': new_type['name'],
-                                  'reason': vendor_spec['retype']})
-                    raise jsonrpc.NefException(code=code, message=message)
-                payload[api] = value
-            elif (api in volume_specs and 'source' in volume_specs and
-                  api in volume_specs['source'] and
-                  volume_specs['source'][api] in ['local', 'received']):
-                if volume_specs[api] == vendor_spec['default']:
-                    continue
-                if 'inherit' in vendor_spec:
-                    LOG.debug('Unable to inherit property %(name)s '
-                              'from volume type %(type)s for volume '
-                              '%(volume)s. %(reason)s',
-                              {'name': api,
-                               'type': new_type['name'],
-                               'volume': volume['name'],
-                               'reason': vendor_spec['inherit']})
-                    continue
-                payload[api] = None
-        if 'sparseVolume' in payload:
-            sparse_volume = payload.pop('sparseVolume')
-        if 'volumeFormat' in payload:
-            volume_new_format = payload.pop('volumeFormat')
-        if 'vSolution' in payload:
-            del payload['vSolution']
-        try:
-            self.nef.filesystems.set(volume_path, payload)
-        except jsonrpc.NefException as error:
-            LOG.error('Failed to retype volume %(volume)s to '
-                      'host %(host)s and volume type %(type)s '
-                      'with payload %(payload)s: %(error)s',
-                      {'volume': volume['name'],
-                       'host': host,
-                       'type': new_type['name'],
-                       'payload': payload,
-                       'error': error})
-            raise
-        nfs_share, mount_point, volume_file = self._mount_volume(volume)
-        volume_info = self._get_image_info(volume_file)
-        volume_size = volume_info.virtual_size
-        volume_format = volume_info.file_format
-        if volume_format != volume_new_format:
-            self._change_volume_format(volume, volume_file, volume_format,
-                                       volume_new_format)
-        self._unmount_volume(volume, nfs_share, mount_point)
-        if sparse_volume:
-            volume_size = 0
-        self._set_volume_reservation(volume, volume_size, volume_new_format)
+        self._update_volume_props(volume, new_type)
         return True, None
 
     def _init_vendor_properties(self):
@@ -2323,65 +2196,92 @@ class NexentaNfsDriver(nfs.NfsDriver):
         : return dictionary of vendor unique properties
         : return vendor name
         """
-        properties = {}
+        vendor_properties = {}
         namespace = self.nef.filesystems.namespace
-        vendor_properties = self.nef.filesystems.properties
+        items = self.nef.filesystems.properties
         keys = ['enum', 'default', 'minimum', 'maximum']
-        for vendor_spec in vendor_properties:
-            property_spec = {}
+        for item in items:
+            spec = {}
             for key in keys:
-                if key in vendor_spec:
-                    value = vendor_spec[key]
-                    property_spec[key] = value
-            api = vendor_spec['api']
-            if 'cfg' in vendor_spec:
-                key = vendor_spec['cfg']
+                if key in item:
+                    spec[key] = item[key]
+            if 'cfg' in item:
+                key = item['cfg']
                 value = self.configuration.safe_get(key)
                 if value not in [None, '']:
-                    property_spec['default'] = value
-            elif api in self.nas_stat:
-                value = self.nas_stat[api]
-                property_spec['default'] = value
-            property_name = vendor_spec['name']
-            property_title = vendor_spec['title']
-            property_description = vendor_spec['description']
-            property_type = vendor_spec['type']
-            LOG.debug('Set %(product_name)s %(storage_protocol)s backend '
-                      '%(property_type)s property %(property_name)s: '
-                      '%(property_spec)s',
-                      {'product_name': self.product_name,
-                       'storage_protocol': self.storage_protocol,
-                       'property_type': property_type,
-                       'property_name': property_name,
-                       'property_spec': property_spec})
+                    spec['default'] = value
+            elif 'api' in item:
+                api = item['api']
+                if api in self.nas_stat:
+                    value = self.nas_stat[api]
+                    spec['default'] = value
+            LOG.debug('Initialize vendor capabilities for '
+                      '%(product)s %(protocol)s backend: '
+                      '%(type)s %(name)s property %(spec)s',
+                      {'product': self.product_name,
+                       'protocol': self.storage_protocol,
+                       'type': item['type'],
+                       'name': item['name'],
+                       'spec': spec})
             self._set_property(
-                properties,
-                property_name,
-                property_title,
-                property_description,
-                property_type,
-                **property_spec
+                vendor_properties,
+                item['name'],
+                item['title'],
+                item['description'],
+                item['type'],
+                **spec
             )
-        return properties, namespace
+        return vendor_properties, namespace
 
-    def _get_vendor_properties(self, vendor_specs, volume, volume_type=None):
-        properties = {}
-        extra_specs = {}
-        if volume_type:
-            volume_type_id = volume_type['id']
+    def _get_volume_type_specs(self, volume, volume_type=None):
+        if volume_type and 'id' in volume_type:
+            type_id = volume_type['id']
+        elif 'volume_type_id' in volume:
+            type_id = volume['volume_type_id']
         else:
-            volume_type_id = volume['volume_type_id']
-        if volume_type_id:
-            extra_specs = volume_types.get_volume_type_extra_specs(
-                volume_type_id)
-        for vendor_spec in vendor_specs:
-            api = vendor_spec['api']
-            name = vendor_spec['name']
-            if name in extra_specs:
-                extra_spec = extra_specs[name]
-                value = self._get_vendor_value(extra_spec, vendor_spec)
-            elif 'cfg' in vendor_spec:
-                key = vendor_spec['cfg']
+            type_id = None
+        if type_id:
+            return volume_types.get_volume_type_extra_specs(type_id)
+        return {}
+
+    def _get_image_specs(self, volume, volume_type=None):
+        payload = {}
+        items = self.nef.filesystems.properties
+        specs = self._get_volume_type_specs(volume, volume_type)
+        for item in items:
+            if 'img' not in item:
+                continue
+            img = item['img']
+            name = item['name']
+            if name in specs:
+                spec = specs[name]
+                value = self._check_volume_spec(spec, item)
+            elif 'cfg' in item:
+                key = item['cfg']
+                value = self.configuration.safe_get(key)
+                if value in [None, '']:
+                    continue
+            else:
+                continue
+            payload[img] = value
+        LOG.debug('Image properties for %(volume)s: %(payload)s',
+                  {'volume': volume['name'], 'payload': payload})
+        return payload
+
+    def _get_volume_specs(self, volume, volume_type=None):
+        payload = {}
+        items = self.nef.filesystems.properties
+        specs = self._get_volume_type_specs(volume, volume_type)
+        for item in items:
+            if 'api' not in item:
+                continue
+            api = item['api']
+            name = item['name']
+            if name in specs:
+                spec = specs[name]
+                value = self._check_volume_spec(spec, item)
+            elif 'cfg' in item:
+                key = item['cfg']
                 value = self.configuration.safe_get(key)
                 if value in [None, '']:
                     continue
@@ -2389,21 +2289,15 @@ class NexentaNfsDriver(nfs.NfsDriver):
                 value = self.nas_stat[api]
             else:
                 continue
-            properties[api] = value
-            LOG.debug('Get vendor property name %(name)s with '
-                      'API name %(api)s and %(type)s value '
-                      '%(value)s for volume %(volume)s',
-                      {'name': name,
-                       'api': api,
-                       'type': type(value).__name__,
-                       'value': value,
-                       'volume': volume['name']})
-        return properties
+            payload[api] = value
+        LOG.debug('Volume properties for %(volume)s: %(payload)s',
+                  {'volume': volume['name'], 'payload': payload})
+        return payload
 
-    def _get_vendor_value(self, value, vendor_spec):
-        name = vendor_spec['name']
+    def _check_volume_spec(self, value, prop):
+        name = prop['name']
         code = 'EINVAL'
-        if vendor_spec['type'] == 'integer':
+        if prop['type'] == 'integer':
             try:
                 value = int(value)
             except ValueError:
@@ -2411,8 +2305,8 @@ class NexentaNfsDriver(nfs.NfsDriver):
                              'vendor property name %(name)s')
                            % {'value': value, 'name': name})
                 raise jsonrpc.NefException(code=code, message=message)
-            if 'minimum' in vendor_spec:
-                minimum = vendor_spec['minimum']
+            if 'minimum' in prop:
+                minimum = prop['minimum']
                 if value < minimum:
                     message = (_('Integer value %(value)s is less than '
                                  'allowed minimum %(minimum)s for vendor '
@@ -2420,8 +2314,8 @@ class NexentaNfsDriver(nfs.NfsDriver):
                                % {'value': value, 'minimum': minimum,
                                   'name': name})
                     raise jsonrpc.NefException(code=code, message=message)
-            if 'maximum' in vendor_spec:
-                maximum = vendor_spec['maximum']
+            if 'maximum' in prop:
+                maximum = prop['maximum']
                 if value > maximum:
                     message = (_('Integer value %(value)s is greater than '
                                  'allowed maximum %(maximum)s for vendor '
@@ -2429,7 +2323,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
                                % {'value': value, 'maximum': maximum,
                                   'name': name})
                     raise jsonrpc.NefException(code=code, message=message)
-        elif vendor_spec['type'] == 'string':
+        elif prop['type'] == 'string':
             try:
                 value = str(value)
             except UnicodeEncodeError:
@@ -2437,7 +2331,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
                              'property name %(name)s')
                            % {'value': value, 'name': name})
                 raise jsonrpc.NefException(code=code, message=message)
-        elif vendor_spec['type'] == 'boolean':
+        elif prop['type'] == 'boolean':
             words = value.split()
             if len(words) == 2 and words[0] == '<is>':
                 value = words[1]
@@ -2448,8 +2342,8 @@ class NexentaNfsDriver(nfs.NfsDriver):
                              'property name %(name)s')
                            % {'value': value, 'name': name})
                 raise jsonrpc.NefException(code=code, message=message)
-        if 'enum' in vendor_spec:
-            enum = vendor_spec['enum']
+        if 'enum' in prop:
+            enum = prop['enum']
             if value not in enum:
                 message = (_('Value %(value)s is out of allowed enumeration '
                              '%(enum)s for vendor property name %(name)s')

--- a/cinder/volume/drivers/nexenta/options.py
+++ b/cinder/volume/drivers/nexenta/options.py
@@ -23,43 +23,30 @@ NEXENTASTOR_CONNECTION_OPTS = [
                                   'protocol should now be set using the '
                                   'common parameter nexenta_rest_protocol.',
                 help='Use HTTP secure protocol for NexentaStor '
-                     'management REST API connections.'),
+                     'management RESTful API connections.'),
     cfg.StrOpt('nexenta_rest_protocol',
                default='auto',
                choices=['http', 'https', 'auto'],
                help='NexentaStor RESTful API interface protocol.'),
     cfg.IntOpt('nexenta_rest_port',
-               deprecated_for_removal=True,
-               deprecated_reason='Rest address should now be set using '
-                                 'the common param san_api_port.',
                default=0,
                help='NexentaStor RESTful API interface port. If it is '
                     'equal zero, 8443 for HTTPS and 8080 for HTTP will '
                     'be used for NexentaStor5 and 8457 for NexentaStor4.'),
     cfg.StrOpt('nexenta_user',
-               deprecated_for_removal=True,
-               deprecated_reason='Common user parameters should be used '
-                                 'depending on the driver type: '
-                                 'san_login or nas_login',
+               required=True,
                default='admin',
                help='User name to connect to NexentaStor RESTful API '
                     'interface.'),
     cfg.StrOpt('nexenta_password',
-               deprecated_for_removal=True,
-               deprecated_reason='Common password parameters should be '
-                                 'used depending on the driver type: '
-                                 'san_password or nas_password.',
-               default='nexenta',
+               required=True,
+               secret=True,
                help='User password to connect to NexentaStor RESTful API '
-                    'interface.',
-               secret=True),
-    cfg.StrOpt('nexenta_rest_address',
-               deprecated_for_removal=True,
-               deprecated_reason='Rest address should now be set using '
-                                 'the common param depending on driver '
-                                 'type, san_ip or nas_host.',
-               default='',
-               help='IP address of NexentaStor RESTful API interface.'),
+                    'interface.'),
+    cfg.ListOpt('nexenta_rest_address',
+                default=[],
+                help='One or more comma delimited IP addresses for management '
+                     'communication with NexentaStor RESTful API interface.'),
     cfg.FloatOpt('nexenta_rest_connect_timeout',
                  default=30,
                  help='Specifies the time limit (in seconds), within '
@@ -180,7 +167,7 @@ NEXENTASTOR5_ISCSI_OPTS = [
                default='iscsi',
                help='NexentaStor volume group name that holds all volumes.'),
     cfg.ListOpt('nexenta_iscsi_target_portals',
-                default='',
+                default=[],
                 help='Comma separated list of portals for NexentaStor, in '
                      'format of IP:port,IP:port. Port number is optional, '
                      'default value is 3260.'),

--- a/cinder/volume/drivers/nexenta/utils.py
+++ b/cinder/volume/drivers/nexenta/utils.py
@@ -77,6 +77,10 @@ def roundup(numerator, denominator):
     return divup(numerator, denominator) * denominator
 
 
+def roundgb(numerator):
+    return roundup(numerator, units.Gi) // units.Gi
+
+
 def match_template(template, name):
     if not (name and isinstance(name, six.string_types) and
             template and isinstance(template, six.string_types)):
@@ -96,3 +100,19 @@ def match_template(template, name):
     except ValueError:
         return False
     return True
+
+
+def prt2tpg(portals):
+    """Convert list of dicts to list.
+
+    :param portals: list of portals dicts
+    :returns flat list of portals
+    """
+    tpg = []
+    for portal in portals:
+        hostport = '%(host)s:%(port)s' % {
+            'host': portal['address'],
+            'port': portal['port']
+        }
+        tpg.append(hostport)
+    return tpg


### PR DESCRIPTION
**Changes:**
* Support for NEF vSolution API for volume creation and extend
* Support for lockless parallel volume management operations
* Support for NFS *nohide* mount option
* Optimal flows for combined convert-extend-retype operations
* Fixes for revert/extend
* Fixes for Python 3.x
* Workarounds for NEF API known issues
* Code style cleanup (Pep8/Python3)

**JIRA tickets:**
* NEX-22630 Slow Cinder volume manipulation times
* NEX-22697 Concurrent creation/deleting volumes may fail with Stderr: qemu-img: Could not open volume: No such file or directory
* NEX-22725 The revert process should not change the volume's current type and size
* NEX-22764 Cinder volume destroy TypeError: '>' not supported between instances of 'str' and 'int'
* NEX-22776 Failed to extend non-raw volume: Image format driver does not support resize
* NEX-22777 Workaround for NEX-22773 Storage API cannot find datasets by name if parent is nested
* NEX-22778 Workarounds for known issues should only be applied if necessary
* NEX-22779 Support nohide NFS option

**Pep8**
```
pep8 run-test: commands[0] | flake8 .
pep8 run-test: commands[1] | doc8
Scanning...
Validating...
========
Total files scanned = 208
Total files ignored = 1246
Total accumulated errors = 0
Detailed error counts:
    - CheckCarriageReturn = 0
    - CheckIndentationNoTab = 0
    - CheckMaxLineLength = 0
    - CheckNewlineEndOfFile = 0
    - CheckTrailingWhitespace = 0
    - CheckValidity = 0
pep8 finish: run-test  after 96.47 seconds
pep8 start: run-test-post 
pep8 finish: run-test-post  after 0.00 seconds
______________________________________________________________________________________ summary _______________________________________________________________________________________
  pep8: commands succeeded
  congratulations :)
```

**Tempest with default options**
```
======
Totals
======
Ran: 268 tests in 1382.6102 sec.
 - Passed: 264
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3385.9833 sec.
```

**Tempest with enabled vSolution API**
```
======
Totals
======
Ran: 268 tests in 1225.9988 sec.
 - Passed: 264
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3423.9689 sec.
```

**Tempest with enabled NFS nohide**
```
======
Totals
======
Ran: 268 tests in 1305.2061 sec.
 - Passed: 264
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3489.4737 sec.
```

**Tempest with enabled NFS nohide and vSolution API**
```
======
Totals
======
Ran: 268 tests in 1326.0535 sec.
 - Passed: 264
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3609.7322 sec.
```

**Tempest for iSCSI**
```
======
Totals
======
Ran: 268 tests in 4799.3716 sec.
 - Passed: 265
 - Skipped: 3
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 3553.4667 sec.
```