### PR TITLE
NEX-23003 OpenStack Cinder CI failed: AttributeError: module 'cinder.utils' has no attribute 'brick_get_connector_properties'

### DIFF
--- a/cinder/volume/drivers/nexenta/ns5/nfs.py
+++ b/cinder/volume/drivers/nexenta/ns5/nfs.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Nexenta by DDN, Inc. All rights reserved.
+# Copyright 2021 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -2158,7 +2158,7 @@ class NexentaNfsDriver(nfs.NfsDriver):
         This method will be called before _copy_volume_data during volume
         migration
         """
-        connector_properties = cinder_utils.brick_get_connector_properties()
+        connector_properties = volume_utils.brick_get_connector_properties()
         attach_info, dst_volume = self._attach_volume(
             ctxt, dst_volume, connector_properties, remote=True)
         dst_file_path = attach_info['device']['path']


### PR DESCRIPTION
Sync with upstream:
```
commit e7b4670516d9db4606efdeae36052c8da6470072
Author: Eric Harney <eharney@redhat.com>
Date:   Mon Jan 18 21:43:32 2021 +0000

    Move brick calls from cinder.utils to volume_utils

    Move code that calls out to os-brick for connectors,
    encryptors, etc., into volume_utils.

    This leaves cinder/utils.py more general-purpose
    cinder-wide code, which reduces unnecessary binding
    between things like "cinder-manage db" and calls
    that load much more of cinder's code (and external
    libraries like os-brick).

    This also means that some drivers only need to
    import volume_utils and not cinder.utils.

    Partial-Bug: #1912278
    Change-Id: Ib2e2960ca354a47d303e0633c7d84e6da4b55b82
```