### PR TITLE
Cumulative set of fixes for os-brick NFS connector and Python 3.x

### DIFF
--- a/cinder/volume/drivers/nexenta/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/jsonrpc.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Nexenta by DDN, Inc. All rights reserved.
+# Copyright 2021 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -159,7 +159,7 @@ class NmsRequest(object):
                 continue
 
             try:
-                content = json.loads(response.content)
+                content = response.json()
             except (TypeError, ValueError) as error:
                 text = response.content
                 try:

--- a/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
+++ b/cinder/volume/drivers/nexenta/ns5/jsonrpc.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Nexenta by DDN, Inc. All rights reserved.
+# Copyright 2021 Nexenta by DDN, Inc. All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -132,8 +132,10 @@ class NefRequest(object):
                        'content': response.content})
             content = None
             if response.content:
-                content = json.loads(response.content)
+                content = response.json()
             if not response.ok:
+                if not content:
+                    content = 'Unknown error'
                 LOG.error('Failed request %(info)s, '
                           'response content: %(content)s',
                           {'info': info, 'content': content})
@@ -195,7 +197,7 @@ class NefRequest(object):
         if response.ok and not response.content:
             return response
         try:
-            content = json.loads(response.content)
+            content = response.json()
         except (TypeError, ValueError) as error:
             code = 'EINVAL'
             message = (_('Failed request hook on %(info)s: '
@@ -278,7 +280,7 @@ class NefRequest(object):
         }
         self.proxy.delete_bearer()
         response = self.request(method, path, payload)
-        content = json.loads(response.content)
+        content = response.json()
         if 'token' in content:
             token = content['token']
             if token:
@@ -299,7 +301,7 @@ class NefRequest(object):
             response = self.request(method, self.proxy.root, payload)
         except Exception:
             return False
-        content = json.loads(response.content)
+        content = response.json()
         if 'data' not in content or not content['data']:
             LOG.error('Pool %(pool)s not found on host %(host)s',
                       {'pool': self.proxy.pool,


### PR DESCRIPTION
**Description**: Cumulative set of fixes for os-brick NFS connector and Python 3.x

* 147390 After deleting the cinder volume still it shows as mounted on controller
* ES-497 After deleting the cinder volume still it shows as mounted on controller
* NEX-23056 After deleting the cinder volume still it shows as mounted on controller
* NEX-23057 Race condition on mount/unmount Cinder NFS volumes
* NEX-23058 NFS 4.1 mont attempts fails
* NEX-23060 JSON parser error: the JSON object must be str, not 'bytes'

Signed-off-by: Alex Deiter <alex.deiter@gmail.com>

**References**

* Cinder BUG: https://bugs.launchpad.net/cinder/+bug/1559342
* OS-Brick BUG: https://bugs.launchpad.net/os-brick/+bug/1543528
* Python changelog: https://docs.python.org/3/whatsnew/3.6.html#json 

**Pep8 test results**
```
$ tox -e pep8
pep8 develop-inst-noop: /opt/stack/cinder
pep8 run-test-pre: PYTHONHASHSEED='0'
pep8 run-test: commands[0] | flake8 .
pep8 run-test: commands[1] | /opt/stack/cinder/tools/config/check_uptodate.sh
pep8 run-test: commands[2] | /opt/stack/cinder/tools/check_exec.py /opt/stack/cinder/cinder
___________________________________ summary ____________________________________
  pep8: commands succeeded
  congratulations :)
```

**Tempest test for NexentaStor5 NFS backend with Python 2.7**
```
$ tox -e ci -- volume
======
Totals
======
Ran: 253 tests in 9354.0000 sec.
 - Passed: 247
 - Skipped: 6
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 7020.9298 sec.
________________________________________________________________________________ summary ________________________________________________________________________________
  ci: commands succeeded
  congratulations :)

```

**Tempest test for NexentaStor5 NFS backend with Python 3.5**
```
$ tox -e ci -- volume
======
Totals
======
Ran: 253 tests in 9592.7604 sec.
 - Passed: 247
 - Skipped: 6
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 7202.3199 sec.
________________________________________________________________________________ summary ________________________________________________________________________________
  ci: commands succeeded
  congratulations :)
```

**Tempest test for NexentaStor4 NFS backend with Python 2.7**
```
$ tox -e ci -- volume
======
Totals
======
Ran: 250 tests in 8932.0000 sec.
 - Passed: 241
 - Skipped: 9
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 6619.7647 sec.
________________________________________________________________________________ summary ________________________________________________________________________________
  ci: commands succeeded
  congratulations :)

```

**Tempest test for NexentaStor4 NFS backend with Python 3.5**
```
$ tox -e ci -- volume
======
Totals
======
Ran: 250 tests in 8992.7097 sec.
 - Passed: 241
 - Skipped: 9
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 6631.7591 sec.
________________________________________________________________________________ summary ________________________________________________________________________________
  ci: commands succeeded
  congratulations :)
```